### PR TITLE
New calculation of CFL frequency

### DIFF
--- a/maxima/g0/advection/advectionFuncs-vol-C.mac
+++ b/maxima/g0/advection/advectionFuncs-vol-C.mac
@@ -5,10 +5,10 @@ load("out-scripts");
 load(stringproc)$
 fpprec : 24$
 
-dx2   : [dx2, dy2, dz2]$
 cidx(cdim) := makelist(i,i,0,cdim-1)$
 
-calcAdvectionVolUpdater(fh, funcNm, cdim, basisFun, polyOrder) := block([bP,cid,vid,wDdx,dvDdx,dir,volTerm,clst,strOut],
+calcAdvectionVolUpdater(fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [bP,NC,cflPt,cid,dir,rdx2,u_e,f_e,volTerm,amid],
 
   kill(varsC, basisC),
 
@@ -30,10 +30,12 @@ calcAdvectionVolUpdater(fh, funcNm, cdim, basisFun, polyOrder) := block([bP,cid,
   printf(fh, "  // out:       Incremented output.~%"),
   cid : cidx(cdim),
   for dir : 1 thru cdim do (
-      printf(fh, "  const double d~a2 = 2.0/dxv[~a]; ~%", varsC[dir], cid[dir])
+      printf(fh, "  const double rd~a2 = 2.0/dxv[~a]; ~%", varsC[dir], cid[dir])
   ),
-  /* alpha_mid is our approximation of sum_i max(abs(alpha_i))/dx_i */
-  printf(fh, "  double alpha_mid = 0.0; ~%"),
+  rdx2 : [rdx2, rdy2, rdz2],
+
+  /* cflFreq_mid is our approximation of sum_i max(abs(alpha_i))/(dx_i/(2p+1)) */
+  printf(fh, "  double cflFreq_mid = 0.0; ~%"),
 
   /* Advection velocity in each direction of configuration space. */
   u_e : doExpand1(u, bC),
@@ -45,17 +47,18 @@ calcAdvectionVolUpdater(fh, funcNm, cdim, basisFun, polyOrder) := block([bP,cid,
   /* Inner product of grad(psi) . u f, where psi is a basis function. */
   volTerm : 0,
   for dir : 1 thru cdim do (
-    /* evaluate alpha_vdim at cflPt to approximate max(abs(alpha_vdim))/dv_i */
-    amid : gcfac(float(expand(subst(cflPt,0.5*subst(a0=NC*(dir-1),u_e))))),
-    printf(fh, "  alpha_mid += fabs(~a); ~%", amid),
+    /* evaluate alpha_vdim at cflPt to approximate
+    ** max(abs(alpha_vdim))/(dx_i/(2p+1)). */
+    amid : gcfac(float(expand(subst(cflPt,(2*polyOrder+1)*0.5*subst(a0=NC*(dir-1),u_e))))),
+    printf(fh, "  cflFreq_mid += fabs(~a); ~%", rdx2[dir]*amid),
 
-    volTerm : volTerm + subst(a0=NC*(dir-1),calcInnerProdList(varsC, dx2[dir]*u_e, diff(bC,varsC[dir]), f_e))
+    volTerm : volTerm + subst(a0=NC*(dir-1),calcInnerProdList(varsC, rdx2[dir]*u_e, diff(bC,varsC[dir]), f_e))
   ),
   printf(fh, "~%"),
 
   writeCExprsCollect1c(volTerm),
   printf(fh, "~%"),
 
-  printf(fh, "  return alpha_mid; ~%"),
+  printf(fh, "  return cflFreq_mid; ~%"),
   printf(fh, "} ~%")
 )$

--- a/maxima/g0/dg_diffusion/diff-vol-C.mac
+++ b/maxima/g0/dg_diffusion/diff-vol-C.mac
@@ -31,8 +31,10 @@ for polyOrder : minPolyOrder thru maxPolyOrder do (
     printf(fh, "  // D: Diffusion tensor~%"),
     printf(fh, "  // q: Input field~%"),
     printf(fh, "  // out: Incremented output~%~%"),
-    printf(fh, "  const double J[~a] = {4/dx[0]/dx[0]", ndim),
-    for d : 2 thru ndim do printf(fh, ", 4/dx[~a]/dx[~a]", d-1, d-1),
+
+    polyFact : (polyOrder+1)^2,
+    printf(fh, "  const double J[~a] = {~a/dx[0]/dx[0]", ndim, float(4*polyFact)),
+    for d : 2 thru ndim do printf(fh, ", ~a/dx[~a]/dx[~a]", float(4*polyFact), d-1, d-1),
     printf(fh, "};~%~%"),
     
     printf(fh, "~%  return D[0]*J[0]"),

--- a/maxima/g0/gyrokinetic/gkUtil.mac
+++ b/maxima/g0/gyrokinetic/gkUtil.mac
@@ -532,9 +532,9 @@ calcAndWrite_upwindIncr_wLFfluxes(fH,basisType,polyOrder,bP,surfDir,alphaSurf_e)
 )$
 
 calcAndWrite_quadCFLfreq_wPhaseAlpha(basisType,polyOrder,bP,surfDir,alpha_e) := block(
-  [i,varsP,numP,cdim,vdim,pDim,surfVar,surfIntVars,surf_cvars,surf_vvars,surfNodes,numNodes,
-   bSurf,numSurf,surfBasis,ignoreVars,alphaSurfL_c,alphaSurfL_e,alphaSurfL_n,alphaSurfR_c,
-   alphaSurfR_e,alphaSurfR_n],
+  [i,varsP,numP,cdim,vdim,pDim,surfVar,surfIntVars,pOrderCFL,surf_cvars,surf_vvars,
+   surfNodes,numNodes,bSurf,numSurf,surfBasis,ignoreVars,alphaSurfL_c,alphaSurfL_e,
+   alphaSurfL_n,alphaSurfR_c,alphaSurfR_e,alphaSurfR_n],
   /* Compute the CFL frequency from quadrature node contributions on the
      surfaces in the dir dimension, given a phase-space volume expansion
      of the speed (i.e. coming from doExpand(alpha,bP)). */
@@ -548,6 +548,11 @@ calcAndWrite_quadCFLfreq_wPhaseAlpha(basisType,polyOrder,bP,surfDir,alpha_e) := 
   if isInList(vpar,varsP) then vdim : vdim+1,
   if isInList(mu,varsP) then vdim : vdim+1,
   cdim : pDim-vdim,
+
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean gkhybrid basis. */
+  pOrderCFL : polyOrder,
+  if polyOrder=1 and surfDir=cdim+1 then ( pOrderCFL : 2 ),
 
   surf_cvars : delete(surfVar, makelist(varsP[i],i,1,cdim)),
   surf_vvars : delete(surfVar, makelist(varsP[cdim+i],i,1,vdim)),
@@ -589,7 +594,7 @@ calcAndWrite_quadCFLfreq_wPhaseAlpha(basisType,polyOrder,bP,surfDir,alpha_e) := 
   printf(fh, "  // Evaluate alpha at left surface quadrature points.~%"),
   for i : 1 thru numNodes do (
     printf(fh, "  alphaL = ~a; ~%", gcfac(float(alphaSurfL_n[i]))),
-    printf(fh, "  cflFreq += -0.5*(alphaL-fabs(alphaL)); ~%")
+    printf(fh, "  cflFreq += -~a*(alphaL-fabs(alphaL)); ~%",float(0.5*(2*pOrderCFL+1)))
   ),
 
   /*
@@ -601,6 +606,6 @@ calcAndWrite_quadCFLfreq_wPhaseAlpha(basisType,polyOrder,bP,surfDir,alpha_e) := 
   printf(fh, "  // Evaluate alpha at right surface quadrature points.~%"),
   for i : 1 thru numNodes do (
     printf(fh, "  alphaR = ~a; ~%", gcfac(float(alphaSurfR_n[i]))),
-    printf(fh, "  cflFreq += 0.5*(alphaR+fabs(alphaR)); ~%")
+    printf(fh, "  cflFreq += ~a*(alphaR+fabs(alphaR)); ~%",float(0.5*(2*pOrderCFL+1)))
   )
 )$

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-vol.mac
@@ -5,24 +5,29 @@ load(stringproc)$
 
 fpprec : 24$
 
-/* This script generates the kernels for the volume term
-   diffusion contribution from Lenard Bernstein operator to the
-   gyrokinetic equation. */
+/* This script generates the kernels for the diffusion volume
+   kernel of the Lenard Bernstein operator for the
+   gyrokinetic equation. It only computes the CFL frequency. */
 
 varsVAll : [vpar, mu]$
 
 vIndex1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 
 calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [varsC,bC,varsP,bP,NP,NC,vidx1,dir,f_e,nuSum_e,nuUSum_e,nuVtSqSum_e,zr,
-   facDiff_c,facDiff_NoZero,facDiff_NoZero_e,i,BmagInv_e,facDiffMu_NoZero,
-   expr,polyFact,facDiff_mid],
+  [varsC,bC,varsP,bP,NP,NC,pOrderVpar,vidx1,dir,f_e,nuSum_e,nuUSum_e,
+   nuVtSqSum_e,zr,facDiff_c,facDiff_NoZero,facDiff_NoZero_e,i,BmagInv_e,
+   facDiffMu_NoZero,expr,polyFact,facDiff_mid],
 
   printf(fh, "#include <gkyl_lbo_gyrokinetic_kernels.h> ~%"),
 
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
   NC : length(bC),  NP : length(bP),
+
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean hybrid basis. */
+  pOrderVpar : polyOrder,
+  if polyOrder=1 then ( pOrderVpar : 2 ),
 
   vidx1 : vIndex1(cdim,vdim),
 
@@ -59,12 +64,15 @@ calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   /* ..................... vpar contribution ...................... */
 
+  /* Polynomial order factor in CFL frequency. */
+  polyFact : (pOrderVpar+1)^2,
+
   /* facDiff = (2/(Delta vpar))^2 * < psi, nuVtSqSum >. */
   facDiff_c : calcInnerProdList(varsC, 1, bC, nuVtSqSum_e),
   if polyOrder>1 then (
     /* Zero out components of alpha which are empty. */
     facDiff_NoZero   : doMakeExprLst(facDiff_c, facDiffVpar),
-    facDiff_NoZero_e : rdvSq4[0]*doExpand(facDiff_NoZero, bC),
+    facDiff_NoZero_e : polyFact*rdvSq4[0]*doExpand(facDiff_NoZero, bC),
 
     /* facDiff = nuVtSqSum. Only used in increment if polyOrder>1. */
     printf(fh, "  double facDiffVpar[~a];~%", NC),
@@ -79,13 +87,17 @@ calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   ) else (
     /* Zero out components of alpha which are empty. */
     facDiff_NoZero   : doMakeExprLst(facDiff_c, nuVtSqSum),
-    facDiff_NoZero_e : rdvSq4[0]*doExpand(facDiff_NoZero, bC)
+    facDiff_NoZero_e : polyFact*rdvSq4[0]*doExpand(facDiff_NoZero, bC)
   ),
 
   /* ..................... mu contribution ...................... */
 
   /* facDiff = (2/(Delta mu))^2 * < psi, 2*m_*bmag_inv*nuVtSqSum*mu >. */
   if vdim > 1 then (
+
+    /* Polynomial order factor in CFL frequency. */
+    polyFact : (polyOrder+1)^2,
+
     BmagInv_e : doExpand1(bmag_inv,bC),
 
     if polyOrder>1 then (
@@ -94,7 +106,7 @@ calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
       /* Zero out components of alpha which are empty. */
       facDiffMu_NoZero : doMakeExprLst(facDiff_c, facDiffMu),
-      facDiff_NoZero_e : facDiff_NoZero_e+2*m_*rdv2[1]*doExpand(facDiffMu_NoZero, bC),
+      facDiff_NoZero_e : facDiff_NoZero_e+polyFact*2*m_*rdv2[1]*doExpand(facDiffMu_NoZero, bC),
 
       /* facDiff = nuVtSqSum. Only used in increment if polyOrder>1. */
       /* facDiff = nuVtSqSum. Only used in increment if polyOrder>1. */
@@ -108,17 +120,14 @@ calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
       ),
       printf(fh, "~%")
     ) else (
-      facDiff_c : calcInnerProdList(varsP,1,bP,2*m_*BmagInv_e*nuVtSqSum_e*(rdv2[1]*varsVAll[2]+rdvSq4[1]*w[vidx1[2]])),
+      facDiff_c : calcInnerProdList(varsP,1,bP,polyFact*2*m_*BmagInv_e*nuVtSqSum_e*(rdv2[1]*varsVAll[2]+rdvSq4[1]*w[vidx1[2]])),
 
       /* Zero out components of alpha which are empty. */
       facDiff_NoZero_e : facDiff_NoZero_e+doExpand(facDiff_c, bP)
     )
   ),
 
-  /* Evaluate facDiff at zr to approximate max(abs(facDiff))/dv_i */
-  polyFact : ((polyOrder+1)^2)/(2*polyOrder+1),
-
-  facDiff_mid : gcfac(float(expand(subst(zr,polyFact*facDiff_NoZero_e)))),
+  facDiff_mid : gcfac(float(expand(subst(zr,facDiff_NoZero_e)))),
 
   /* Replace the rdv2[1]^2: */
   facDiff_mid : subst(rdv2[1]^2=pow(rdv2[1],2), facDiff_mid),

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-vol.mac
@@ -4,8 +4,8 @@ load(stringproc)$
 
 fpprec : 24$
 
-/* This script generates the kernels for the volume term
-   drag contribution from Lenard Bernstein operator to the
+/* This script generates the kernels for the drag volume
+   kernel of the Lenard Bernstein operator for the
    gyrokinetic equation. */
 
 varsVAll : [vpar, mu]$
@@ -16,14 +16,19 @@ vIndex1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 doMakeExprLstOff(vals, S, off)  := makelist(if vals[i] # 0 then S[off+i-1] else 0, i, 1, length(vals))$
 
 calcGkLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [varsC,bC,varsP,bP,NP,NC,zr,vidx1,dir,f_e,nuSum_e,nuUSum_e,nuVtSqSum_e,
-   incrDrag,alphaDrag_mid,alphaDrag_e,expr,i,alphaDrag_NoZero,alphaDrag_NoZero_e],
+  [varsC,bC,varsP,bP,NP,NC,pOrderVpar,zr,vidx1,dir,f_e,nuSum_e,nuUSum_e,nuVtSqSum_e,
+   incrDrag,cflFreq_mid,alphaDrag_e,expr,i,alphaDrag_NoZero,alphaDrag_NoZero_e],
 
   printf(fh, "#include <gkyl_lbo_gyrokinetic_kernels.h> ~%"),
 
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
   NC : length(bC),  NP : length(bP),
+
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean hybrid basis. */
+  pOrderVpar : polyOrder,
+  if polyOrder=1 then ( pOrderVpar : 2 ),
 
   /* Specify a point to evaluate alpha at for use in computing CFL */
   /* Here we choose to evaluate things in the middle of the cell, where
@@ -58,7 +63,7 @@ calcGkLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   printf(fh, "  double alphaDrag[~a]; ~%", vdim*NP),
   incrDrag : 0,
-  alphaDrag_mid : makelist(0, i, 1, vdim),
+  cflFreq_mid : makelist(0, i, 1, vdim),
 
   /* alphaDrag_par = rdv2*< psi, (nuSum*vpar - nuUparSum) >. */
   alphaDrag_e : calcInnerProdList(varsP, 1, bP, -nuSum_e*(w[vidx1[1]]+0.5*dxv[vidx1[1]]*varsVAll[1])+nuUSum_e),
@@ -72,8 +77,9 @@ calcGkLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   /* Zero out components of alpha which are empty. */
   alphaDrag_NoZero   : doMakeExprLstOff(alphaDrag_e, alphaDrag, a0),
   alphaDrag_NoZero_e : doExpand(alphaDrag_NoZero, bP),
-  /* Evaluate alpha_vdim at zr to approximate max(abs(alpha_vdim))/dv_i. */
-  alphaDrag_mid[1] : gcfac(float(expand(subst(zr,0.5*subst(a0=0,alphaDrag_NoZero_e))))),
+  /* Evaluate alpha_vdim at zr to approximate
+     max(abs(alpha_vdim))/(dv_i/(2p+1)). */
+  cflFreq_mid[1] : gcfac(float(expand(subst(zr,(2*pOrderVpar+1)*0.5*subst(a0=0,alphaDrag_NoZero_e))))),
   /* Volume increment from configuration space. */
   incrDrag : incrDrag+subst(a0=0,calcInnerProdList(varsP, 1, diff(bP,varsVAll[1]), alphaDrag_NoZero_e*f_e)),
 
@@ -90,8 +96,9 @@ calcGkLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
     /* Zero out components of alpha which are empty. */
     alphaDrag_NoZero   : doMakeExprLstOff(alphaDrag_e, alphaDrag,a0),
     alphaDrag_NoZero_e : doExpand(alphaDrag_NoZero, bP),
-    /* Evaluate alpha_vdim at zr to approximate max(abs(alpha_vdim))/dv_i. */
-    alphaDrag_mid[2] : gcfac(float(expand(subst(zr,0.5*subst(a0=NP,alphaDrag_NoZero_e))))),
+    /* Evaluate alpha_vdim at zr to approximate
+       max(abs(alpha_vdim))/(dv_i/(2p+1)). */
+    cflFreq_mid[2] : gcfac(float(expand(subst(zr,(2*polyOrder+1)*0.5*subst(a0=NP,alphaDrag_NoZero_e))))),
     /* Volume increment from configuration space. */
     incrDrag : incrDrag+subst(a0=NP,calcInnerProdList(varsP, 1, diff(bP,varsVAll[2]), alphaDrag_NoZero_e*f_e))
   ),
@@ -102,9 +109,9 @@ calcGkLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   writeCExprsCollect1c(radcan(incrDrag)),
   printf(fh, "~%"),
   if vdim = 1 then (
-    printf(fh, "  return fabs(~a); ~%", alphaDrag_mid[1])
+    printf(fh, "  return fabs(~a); ~%", cflFreq_mid[1])
   ) elseif vdim = 2 then (
-    printf(fh, "  return fabs(~a)+fabs(~a); ~%", alphaDrag_mid[1], alphaDrag_mid[2])
+    printf(fh, "  return fabs(~a)+fabs(~a); ~%", cflFreq_mid[1], cflFreq_mid[2])
   ),
   printf(fh, "~%"),
   printf(fh, "} ~%")

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-vol.mac
@@ -4,9 +4,9 @@ load("utilities")$
 load(stringproc)$
 fpprec : 24$
 
-/* This script generates the kernels for the volume term
-   diffusion contribution from Lenard Bernstein operator to the
-   Vlasov equation. */
+/* This script generates the kernels for the diff volume
+   kernel of the Lenard Bernstein operator for the
+   Vlasov equation. It only computes the CFL frequency. */
 
 cidx(cdim)      := makelist(i,i,0,cdim-1)$
 vidx(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
@@ -15,7 +15,7 @@ rdv2     : [rdvx2, rdvy2, rdvz2]$
 rdvSq4   : [rdvxSq4, rdvySq4, rdvzSq4]$
 
 calcVmLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [varsC,bC,varsP,bP,NP,NC,zr,cid,vid,dir,f_e,nuVtSqSum_e,
+  [varsC,bC,varsP,bP,NP,NC,pOrderV,zr,cid,vid,dir,f_e,nuVtSqSum_e,
    facDiff_c,facDiff_NoZero,polyFact,incrDiff,vdir,expr,i],
 
   printf(fh, "#include <gkyl_lbo_vlasov_kernels.h> ~%"),
@@ -25,6 +25,11 @@ calcVmLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   /* Number of basis monomials. */
   NP : length(bP),  NC : length(bC),
+
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean hybrid basis. */
+  pOrderV : polyOrder,
+  if polyOrder=1 then ( pOrderV : 2 ),
 
   /* Specify a point to evaluate alpha at for use in computing CFL */
   /* Here we choose to evaluate things in the middle of the cell, where
@@ -75,8 +80,8 @@ calcVmLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   ),
 
   facDiff_NoZero_e : doExpand(facDiff_NoZero, bC),
-  /* Evaluate facDiff at zr to approximate max(abs(facDiff))/dv_i */
-  polyFact : ((polyOrder+1)^2)/(2*polyOrder+1),
+  /* Evaluate facDiff at zr to approximate max(abs(facDiff))/(dv_i/(2*(p+1)))^2 */
+  polyFact : (pOrderV+1)^2,
 
   incrDiff : 0,
   facDiff_mid : makelist(0, i, 1, vdim),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-vol.mac
@@ -15,9 +15,9 @@ rdv2     : [rdvx2, rdvy2, rdvz2]$
 doMakeExprLstOff(vals, S, off) := makelist(if vals[i] # 0 then S[off+i-1] else 0, i, 1, length(vals))$
 
 calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [varsC,bC,varsP,bP,NP,NC,zr,cid,vid1,dir,f_e,nuSum_e,nuUSum_e,nuVtSqSum_e,
-   incrDrag,alphaDrag_mid,vdir,alphaDrag_e,expr,i,alphaDrag_NoZero,
-   alphaDrag_NoZero_e],
+  [varsC,bC,varsP,bP,NP,NC,pOrderV,zr,cid,vid1,dir,f_e,nuSum_e,nuUSum_e,
+   nuVtSqSum_e,incrDrag,cflFreq_mid,vdir,alphaDrag_e,expr,i,
+   alphaDrag_NoZero,alphaDrag_NoZero_e],
 
   printf(fh, "#include <gkyl_lbo_vlasov_kernels.h> ~%"),
 
@@ -26,6 +26,11 @@ calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   /* Number of basis monomials. */
   NP : length(bP),  NC : length(bC),
+
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean hybrid basis. */
+  pOrderV : polyOrder,
+  if polyOrder=1 then ( pOrderV : 2 ),
 
   /* Specify a point to evaluate alpha at for use in computing CFL */
   /* Here we choose to evaluate things in the middle of the cell, where
@@ -60,7 +65,7 @@ calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   /* alphaDrag = nuSum*v-nuUSum. */
   printf(fh, "  double alphaDrag[~a]; ~%", vdim*NP),
   incrDrag : 0,
-  alphaDrag_mid : makelist(0, i, 1, vdim),
+  cflFreq_mid : makelist(0, i, 1, vdim),
   for vdir : 1 thru vdim do (
     /* alphaDrag = rdv2*< psi, -(nuSum*v - nuUSum) >. */
     alphaDrag_e : calcInnerProdList(varsP, 1, bP, -nuSum_e*(w[vid1[vdir]]+0.5*dxv[vid1[vdir]]*vvarsAll[vdir])+subst(a0=NC*(vdir-1),nuUSum_e)),
@@ -74,8 +79,9 @@ calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
     /* Zero out components of alpha which are empty. */
     alphaDrag_NoZero   : doMakeExprLstOff(alphaDrag_e, alphaDrag, a0),
     alphaDrag_NoZero_e : doExpand(alphaDrag_NoZero, bP),
-    /* Evaluate alpha_vdim at zr to approximate max(abs(alpha_vdim))/dv_i. */
-    alphaDrag_mid[vdir] : gcfac(float(expand(subst(zr,0.5*subst(a0=NP*(vdir-1),alphaDrag_NoZero_e))))),
+    /* Evaluate alpha_vdim at zr to approximate
+       max(abs(alpha_vdim))/(dv_i/(2p+1)). */
+    cflFreq_mid[vdir] : gcfac(float(expand(subst(zr,(2*pOrderV+1)*0.5*subst(a0=NP*(vdir-1),alphaDrag_NoZero_e))))),
     /* Volume increment from configuration space. */
     incrDrag : incrDrag+subst(a0=NP*(vdir-1),calcInnerProdList(varsP, 1, diff(bP,vvarsAll[vdir]), alphaDrag_NoZero_e*f_e))
   ),
@@ -86,11 +92,11 @@ calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   writeCExprsCollect1c(radcan(incrDrag)),
   printf(fh, "~%"),
   if vdim = 1 then (
-    printf(fh, "  return fabs(~a); ~%", alphaDrag_mid[1])
+    printf(fh, "  return fabs(~a); ~%", cflFreq_mid[1])
   ) elseif vdim = 2 then (
-    printf(fh, "  return fabs(~a)+fabs(~a); ~%", alphaDrag_mid[1], alphaDrag_mid[2])
+    printf(fh, "  return fabs(~a)+fabs(~a); ~%", cflFreq_mid[1], cflFreq_mid[2])
   ) else (
-    printf(fh, "  return fabs(~a)+fabs(~a)+fabs(~a); ~%", alphaDrag_mid[1], alphaDrag_mid[2], alphaDrag_mid[3])
+    printf(fh, "  return fabs(~a)+fabs(~a)+fabs(~a); ~%", cflFreq_mid[1], cflFreq_mid[2], cflFreq_mid[3])
   ),
   printf(fh, "~%"),
   printf(fh, "} ~%")

--- a/maxima/g0/maxwell/maxwellFuncs-vol-C.mac
+++ b/maxima/g0/maxwell/maxwellFuncs-vol-C.mac
@@ -75,6 +75,6 @@ calcMaxwellVolUpdater(fh, funcNm, cdim, basisFun, polyOrder) := block(
     printf(fh, "  cflFreq += meq->c/dx[~a]; ~%", d-1)
   ),
   
-  printf(fh, "  return cflFreq; ~%"),
+  printf(fh, "  return ~a*cflFreq; ~%", float(2*polyOrder+1)),
   printf(fh, "} ~%")
 )$

--- a/maxima/g0/maxwell/ms-maxwell-vol.mac
+++ b/maxima/g0/maxwell/ms-maxwell-vol.mac
@@ -8,7 +8,7 @@ load(stringproc)$
 
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
-maxPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
@@ -18,7 +18,7 @@ maxCdim_Ser : 3$
 minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
-maxCdim_Tensor : 0$
+maxCdim_Tensor : 2$
 
 /* ...... END OF USER INPUTS........ */
 

--- a/maxima/g0/vlasov/ms-vlasovMaxwell-vol-C.mac
+++ b/maxima/g0/vlasov/ms-vlasovMaxwell-vol-C.mac
@@ -21,8 +21,8 @@ minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 minVdim_Tensor : 1$    /* see begining of v loop below though. */
-maxCdim_Tensor : 0$
-maxVdim_Tensor : 0$
+maxCdim_Tensor : 2$
+maxVdim_Tensor : 2$
 
 /* ...... END OF USER INPUTS........ */
 

--- a/maxima/g0/vlasov/ms-vlasovPoisson-vol-C.mac
+++ b/maxima/g0/vlasov/ms-vlasovPoisson-vol-C.mac
@@ -23,8 +23,8 @@ minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 minVdim_Tensor : 1$    /* see begining of v loop below though. */
-maxCdim_Tensor : 0$
-maxVdim_Tensor : 0$
+maxCdim_Tensor : 2$
+maxVdim_Tensor : 2$
 
 /* ...... END OF USER INPUTS........ */
 

--- a/maxima/g0/vlasov/ms-vlasovStream-vol-C.mac
+++ b/maxima/g0/vlasov/ms-vlasovStream-vol-C.mac
@@ -22,8 +22,8 @@ minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 minVdim_Tensor : 1$    /* see begining of v loop below though. */
-maxCdim_Tensor : 0$
-maxVdim_Tensor : 0$
+maxCdim_Tensor : 2$
+maxVdim_Tensor : 2$
 
 /* ...... END OF USER INPUTS........ */
 

--- a/maxima/g0/vlasov/vlasovMaxwellFuncs-vol-C.mac
+++ b/maxima/g0/vlasov/vlasovMaxwellFuncs-vol-C.mac
@@ -48,6 +48,11 @@ calcVlasovMaxwellVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bloc
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
 
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean hybrid basis. */
+  pOrderV : polyOrder,
+  if polyOrder=1 then ( pOrderV : 2 ),
+
   /* Number of basis monomials. */
   NP : length(bP),
   NC : length(bC),
@@ -91,8 +96,8 @@ calcVlasovMaxwellVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bloc
     )
   ),
 
-  /* alpha_mid is our approximation of sum_i max(abs(alpha_i))/dx_i */
-  printf(fh, "  double alpha_mid = 0.0; ~%"),
+  /* cflFreq_mid is our approximation of sum_i max(abs(alpha_i))/(dx_i/(2p+1)) */
+  printf(fh, "  double cflFreq_mid = 0.0; ~%"),
 
   /* alpha_cdim = v, alpha_vdim = q/m (E + v x B) */
   printf(fh, "  double alpha_cdim[~a] = {0.0}; ~%", cdim*NP),
@@ -111,7 +116,7 @@ calcVlasovMaxwellVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bloc
     for i : 1 thru NP do (
       if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", alpha_cdim[NP*(cdir-1)+i-1], expr[i])
     ),
-    printf(fh, "  alpha_mid += fabs(~a)+~a; ~%", wdx[cdir], 0.5*dvdx[cdir]),
+    printf(fh, "  cflFreq_mid += ~a*(fabs(~a)+~a); ~%", float(2*polyOrder+1), wdx[cdir], 0.5*dvdx[cdir]),
     printf(fh, "~%"),
     /* zero out components of alpha which are empty */
     alpha_cdim_NoZero   : doMakeExprLstOff(alpha_cdim_c, alpha_cdim, a0),
@@ -137,9 +142,10 @@ calcVlasovMaxwellVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bloc
     alpha_vdim_NoZero   : doMakeExprLstOff(alpha_vdim_c, alpha_vdim, a0),
     alpha_vdim_NoZero_e : doExpand(alpha_vdim_NoZero, bP),
 
-    /* evaluate alpha_vdim at cflPt to approximate max(abs(alpha_vdim))/dv_i */
+    /* evaluate alpha_vdim at cflPt to approximate
+    ** max(abs(alpha_vdim))/(dv_i/(2p+1)) */
     amid : gcfac(float(expand(subst(cflPt,0.5*subst(a0=NP*(vdir-1),alpha_vdim_NoZero_e))))),
-    printf(fh, "  alpha_mid += fabs(~a); ~%", amid),
+    printf(fh, "  cflFreq_mid += ~a*fabs(~a); ~%", float(2*pOrderV+1), amid),
     printf(fh, "~%"),
     /* Volume increment from configuration space. */
     incr_vdim : incr_vdim+subst(a0=NP*(vdir-1),calcInnerProdList(varsP, 1, diff(bP,varsP[cdim+vdir]), alpha_vdim_NoZero_e*f_e))
@@ -150,6 +156,6 @@ calcVlasovMaxwellVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bloc
   writeCExprsCollect1c(radcan(incr_cdim+incr_vdim)),
 
   printf(fh, "~%"),
-  printf(fh, "  return alpha_mid; ~%"),
+  printf(fh, "  return cflFreq_mid; ~%"),
   printf(fh, "} ~%")
 )$

--- a/maxima/g0/vlasov/vlasovMaxwellSRFuncs-vol-C.mac
+++ b/maxima/g0/vlasov/vlasovMaxwellSRFuncs-vol-C.mac
@@ -111,8 +111,8 @@ calcVlasovMaxwellSRVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bl
     )
   ),
 
-  /* alpha_mid is our approximation of sum_i max(abs(alpha_i))/dx_i */
-  printf(fh, "  double alpha_mid = 0.0; ~%"),
+  /* cflFreq_mid is our approximation of sum_i max(abs(alpha_i))/(dx_i/(2p+1)) */
+  printf(fh, "  double cflFreq_mid = 0.0; ~%"),
 
   /* alpha_cdim = p/gamma, alpha_vdim = q/m (E + p/gamma x B) */
   printf(fh, "  double alpha_cdim[~a] = {0.0}; ~%", cdim*length(bP)),
@@ -136,9 +136,10 @@ calcVlasovMaxwellSRVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bl
     alpha_cdim_NoZero   : doMakeExprLst(alpha_cdim_c, alpha_cdim),
     alpha_cdim_NoZero_e : doExpandLst(alpha_cdim_NoZero, bP),
     
-    /* evaluate alpha_cdim at cflPt to approximate max(abs(alpha_vdim))/dv_i */
+    /* evaluate alpha_cdim at cflPt to approximate
+    ** max(abs(alpha_vdim))/(dv_i/(2p+1)). */
     amid : gcfac(float(expand(subst(cflPt,0.5*subst(a0=NP*(cdir-1),alpha_cdim_NoZero_e))))),
-    printf(fh, "  alpha_mid += fabs(~a); ~%", amid),
+    printf(fh, "  cflFreq_mid += ~a*fabs(~a); ~%", float(2*polyOrder+1), amid),
     printf(fh, "~%"),
 
     /* Volume increment from configuration space. */
@@ -161,9 +162,10 @@ calcVlasovMaxwellSRVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bl
     alpha_vdim_NoZero   : doMakeExprLst(alpha_vdim_c, alpha_vdim),
     alpha_vdim_NoZero_e : doExpandLst(alpha_vdim_NoZero, bP),
 
-    /* evaluate alpha_vdim at cflPt to approximate max(abs(alpha_vdim))/dv_i */
+    /* evaluate alpha_vdim at cflPt to approximate
+    ** max(abs(alpha_vdim))/(dv_i/(2p+1)) */
     amid : gcfac(float(expand(subst(cflPt,0.5*subst(a0=NP*(vdir-1),alpha_vdim_NoZero_e))))),
-    printf(fh, "  alpha_mid += fabs(~a); ~%", amid),
+    printf(fh, "  cflFreq_mid += ~a*fabs(~a); ~%", float(2*polyOrder+1), amid),
     printf(fh, "~%"),
     /* Volume increment from configuration space. */
     incr_vdim : incr_vdim+subst(a0=NP*(vdir-1),calcInnerProdList(varsP, 1, diff(bP,varsP[cdim+vdir]), alpha_vdim_NoZero_e*f_e))
@@ -174,6 +176,6 @@ calcVlasovMaxwellSRVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bl
   writeCExprsCollect1c(radcan(incr_cdim+incr_vdim)),
 
   printf(fh, "~%"),
-  printf(fh, "  return alpha_mid; ~%"),
+  printf(fh, "  return cflFreq_mid; ~%"),
   printf(fh, "} ~%")
 )$

--- a/maxima/g0/vlasov/vlasovPoissonFuncs-vol-C.mac
+++ b/maxima/g0/vlasov/vlasovPoissonFuncs-vol-C.mac
@@ -38,6 +38,11 @@ calcVlasovPhiVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder, hasB) := bl
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
 
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean hybrid basis. */
+  pOrderV : polyOrder,
+  if polyOrder=1 then ( pOrderV : 2 ),
+
   numC : length(bC),
   numP : length(bP),
 
@@ -88,8 +93,8 @@ calcVlasovPhiVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder, hasB) := bl
     )
   ),
 
-  /* alpha_mid is our approximation of sum_i max(abs(alpha_i))/dx_i */
-  printf(fh, "  double alpha_mid = 0.0; ~%"),
+  /* cflFreq_mid is our approximation of sum_i max(abs(alpha_i))/(dx_i/(2p+1)) */
+  printf(fh, "  double cflFreq_mid = 0.0; ~%"),
 
   /* alpha_cdim = v, alpha_vdim = -fac*grad(phi) */
   /* fac = q/m for plasma, fac = G*m for self gravitating systems */
@@ -120,7 +125,7 @@ calcVlasovPhiVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder, hasB) := bl
       if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", alpha_cdim[numP*(cdir-1)+i-1], expr[i])
     ),
 
-    printf(fh, "  alpha_mid += fabs(~a)+~a; ~%", wdx[cdir], 0.5*dvdx[cdir]),
+    printf(fh, "  cflFreq_mid += ~a*(fabs(~a)+~a); ~%", float(2*polyOrder+1), wdx[cdir], 0.5*dvdx[cdir]),
     printf(fh, "~%"),
 
     /* Zero out components of alpha which are empty. */
@@ -161,9 +166,10 @@ calcVlasovPhiVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder, hasB) := bl
     alpha_vdim_NoZero   : doMakeExprLst(alpha_vdim_c, alpha_vdim),
     alpha_vdim_NoZero_e : doExpand(alpha_vdim_NoZero, bP),
 
-    /* Evaluate alpha_vdim at cflPt to approximate max(abs(alpha_vdim))/dv_i. */
+    /* Evaluate alpha_vdim at cflPt to approximate
+       max(abs(alpha_vdim))/(dv_i/(2p+1)). */
     amid : gcfac(float(expand(subst(cflPt,0.5*subst(a0=numP*(vdir-1),alpha_vdim_NoZero_e))))),
-    printf(fh, "  alpha_mid += fabs(~a); ~%", amid),
+    printf(fh, "  cflFreq_mid += ~a*fabs(~a); ~%", float(2*pOrderV+1), amid),
     printf(fh, "~%"),
 
     /* Volume increment from configuration space. */
@@ -176,7 +182,7 @@ calcVlasovPhiVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder, hasB) := bl
   writeCExprsCollect1c(radcan(incr_cdim+incr_vdim)),
 
   printf(fh, "~%"),
-  printf(fh, "  return alpha_mid; ~%"),
+  printf(fh, "  return cflFreq_mid; ~%"),
   printf(fh, "} ~%"),
   printf(fh, "~%")
 )$

--- a/maxima/g0/vlasov/vlasovSRStreamFuncs-vol-C.mac
+++ b/maxima/g0/vlasov/vlasovSRStreamFuncs-vol-C.mac
@@ -73,8 +73,8 @@ calcVlasovSRStreamVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := blo
   ),
   printf(fh, "~%"),
 
-  /* alpha_mid is our approximation of sum_i max(abs(alpha_i))/dx_i */
-  printf(fh, "  double alpha_mid = 0.0; ~%"),
+  /* cflFreq_mid is our approximation of sum_i max(abs(alpha_i))/(dx_i/(2p+1)) */
+  printf(fh, "  double cflFreq_mid = 0.0; ~%"),
 
   /* alpha_cdim = p/gamma, alpha_vdim = q/m (E + p/gamma x B) */
   printf(fh, "  double alpha_cdim[~a] = {0.0}; ~%", cdim*length(bP)),
@@ -99,7 +99,7 @@ calcVlasovSRStreamVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := blo
     
     /* evaluate alpha_cdim at cflPt to approximate max(abs(alpha_vdim))/dv_i */
     amid : gcfac(float(expand(subst(cflPt,0.5*subst(a0=NP*(cdir-1),alpha_cdim_NoZero_e))))),
-    printf(fh, "  alpha_mid += fabs(~a); ~%", amid),
+    printf(fh, "  cflFreq_mid += fabs(~a); ~%", amid),
     printf(fh, "~%"),
 
     /* Volume increment from configuration space. */
@@ -111,6 +111,6 @@ calcVlasovSRStreamVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := blo
   writeCExprsCollect1c(radcan(incr_cdim)),
 
   printf(fh, "~%"),
-  printf(fh, "  return alpha_mid; ~%"),
+  printf(fh, "  return ~a*cflFreq_mid; ~%",float(2*polyOrder+1)),
   printf(fh, "} ~%")
 )$

--- a/maxima/g0/vlasov/vlasovStreamFuncs-vol-C.mac
+++ b/maxima/g0/vlasov/vlasovStreamFuncs-vol-C.mac
@@ -57,6 +57,6 @@ calcVlasovStreamVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block
   for d : 2 thru cdim do (
     strOut : sconcat(strOut,"+fabs(w",vid1[d],"Ddx",d-1,")+0.5*dv",vid1[d],"Ddx",d-1)
   ),
-  printf(fh, "  return ~a;~%",strOut),
+  printf(fh, "  return ~a*(~a);~%",float(2*polyOrder+1),strOut),
   printf(fh, "} ~%")
 )$


### PR DESCRIPTION
This addresses issue 56 in gkylzero: https://github.com/ammarhakim/gkylzero/issues/56

Previously kernels 

- did not incorporate the factors of 2p+1 for advection terms
- incorporated a factor of ((p+1)^2)/(2p+1) for diffusion terms

and we multiplied the CFL frequency by 2p+1 at the app level.

In this commit we

- Incorporate the 2p+1 factor for advection terms in vlasov,  gyrokinetic, and LBO volume kernels.
- Modify the factor to (p+1)^2 in diffusion terms of LBO volume kernels.
- Incorporate a factor of 2/dx that was missing in advection equation volume terms.
- Incorporate a factor of (p+1)^2 in dg_diffusion volume terms that was missing.

I checked

rt_lbo_vlasov_relax_1x2v_p1
rt_lbo_vlasov_relax_1x2v_p2
rt_neut_lbo_sod_shock_2v
rt_sheath_1v
rt_twostream
rt_twostream_p1
rt_weibel_4d
rt_weibel_4d_p1
rt_advect_1x
rt_advect_2x
rt_diffusion_2x

All p=2 tests except for the last 3 gave identical results as before. The last 3 changed slightly because their CFL frequency was calculated incorrectly before. The p=1 tests changed by minuscule amounts because they weren't accounting for hybrid basis in the CFL frequency, now they are.

(I also tried rt_diffusion_1x but there's an error associated with kernel selection and hybrid basis)

