### PR TITLE
Combine primitive moments u and vtsq

### DIFF
--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-boundary-surf.mac
@@ -48,16 +48,21 @@ calcGkLBOBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   hsol_r : cons(subst(surfVar=0,hr_e),makelist(subst(surfVar=0,diff(hr_e,surfVar,ord)/(ord!)),ord,1,hOrder)),
   /*............. RECOVERY DONE ..............................*/
         
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:         Cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:       Cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // m_:           species mass.~%"),
-  printf(fh, "  // bmag_inv:     1/(magnetic field magnitude). ~%"),
-  printf(fh, "  // nuSum:        collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:    sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum[~a]: sum of thermal speeds squared time their respective collisionalities. ~%", NC),
-  printf(fh, "  // fskin/edge:   Distribution function in cells ~%"),
-  printf(fh, "  // out:          Incremented distribution function in cell ~%"),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: Cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: Cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // m_: species mass.~%"),
+  printf(fh, "  // bmag_inv: 1/(magnetic field magnitude). ~%"),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (1+1)*NC),
+  printf(fh, "  // fskin/edge: Distribution function in cells ~%"),
+  printf(fh, "  // out: Incremented distribution function in cell ~%"),
+  printf(fh, "~%"),
+
+  /* Create a pointer to nuVtSqSum. */
+  printf(fh, "  const double *nuVtSqSum = &nuPrimMomsSum[~a];~%", 1*NC),
+  printf(fh, "~%"),
+
   printf(fh, "  double rdvSq4 = 4.0/(dxv[~a]*dxv[~a]); ~%", vidx1[dir], vidx1[dir]),
   printf(fh, "~%"),
 

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-surf.mac
@@ -34,16 +34,21 @@ calcGkLBODiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
     dg(makelist(fl[i-1],i,1,NP)), dg(makelist(fc[i-1],i,1,NP)), dg(makelist(fr[i-1],i,1,NP))),
   /*............. RECOVERY DONE ..............................*/
     
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // m_:            species mass.~%"),
-  printf(fh, "  // bmag_inv:      1/(magnetic field magnitude). ~%"),
-  printf(fh, "  // w[~a]:         cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:       cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // nuSum:         collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:    sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum[~a]: sum of thermal speeds squared time their respective collisionalities. ~%", NC),
-  printf(fh, "  // fl/fc/fr:      distribution function in cells ~%"),
-  printf(fh, "  // out:           incremented distribution function in cell ~%"),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // m_: species mass.~%"),
+  printf(fh, "  // bmag_inv: 1/(magnetic field magnitude). ~%"),
+  printf(fh, "  // w[~a]: cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (1+1)*NC),
+  printf(fh, "  // fl/fc/fr: distribution function in cells ~%"),
+  printf(fh, "  // out: incremented distribution function in cell ~%"),
+  printf(fh, "~%"),
+
+  /* Create a pointer to nuVtSqSum. */
+  printf(fh, "  const double *nuVtSqSum = &nuPrimMomsSum[~a];~%", 1*NC),
+  printf(fh, "~%"),
+
   printf(fh, "  double rdvSq4 = 4.0/(dxv[~a]*dxv[~a]); ~%", vidx1[dir], vidx1[dir]),
   printf(fh, "  double temp_diff[~a] = {0.0}; ~%", NP),
   printf(fh, "  double diff_incr[~a] = {0.0}; ~%", NP),

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-vol.mac
@@ -14,7 +14,7 @@ varsVAll : [vpar, mu]$
 vIndex1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 
 calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [varsC,bC,varsP,bP,NP,NC,pOrderVpar,vidx1,dir,f_e,nuSum_e,nuUSum_e,
+  [varsC,bC,varsP,bP,NP,NC,pOrderVpar,vidx1,dir,f_e,nuSum_e,
    nuVtSqSum_e,zr,facDiff_c,facDiff_NoZero,facDiff_NoZero_e,i,BmagInv_e,
    facDiffMu_NoZero,expr,polyFact,facDiff_mid],
 
@@ -31,16 +31,20 @@ calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   vidx1 : vIndex1(cdim,vdim),
 
-  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fin, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:      cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:    cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // m_:        species mass.~%"),
-  printf(fh, "  // bmag_inv:  1/(magnetic field magnitude). ~%"),
-  printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum:    sum of bulk velocities times their respective collisionalities. ~%"),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
-  printf(fh, "  // fin:       input distribution function.~%"),
-  printf(fh, "  // out:       incremented output ~%"),
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *fin, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // m_: species mass.~%"),
+  printf(fh, "  // bmag_inv: 1/(magnetic field magnitude). ~%"),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%"),
+  printf(fh, "  // fin: input distribution function.~%"),
+  printf(fh, "  // out: incremented output ~%"),
+  printf(fh, "~%"),
+
+  /* Create a pointer to nuVtSqSum. */
+  printf(fh, "  const double *nuVtSqSum = &nuPrimMomsSum[~a];~%", 1*NC),
+  printf(fh, "~%"),
 
   printf(fh, "  double rdv2[~a]; ~%", vdim),
   printf(fh, "  double rdvSq4[~a]; ~%", vdim),
@@ -55,7 +59,6 @@ calcGkLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   /* Expand flow speed sum(nu*u) and sum(nu*vtSq) in configuration basis. */
   nuSum_e     : doExpand1(nuSum, bC),
-  nuUSum_e    : doExpand1(nuUSum, bC),
   nuVtSqSum_e : doExpand1(nuVtSqSum, bC),
 
   /* Specify a point to evaluate alpha at for use in computing CFL.

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-boundary-surf.mac
@@ -17,7 +17,7 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
   [varsC,bC,varsP,bP,vSub,NP,NC,vid1,vv,surfVars,nuSum_e,nuUSum_e,surf_cvars,surf_vvars,
    bSurf,surfNodes,numNodes,alphaDr,alphaDrSurf_l_c,alphaDrSurf_r_c,alst_l,alst_r,
    alphaDrSurf_l_e,alphaDrSurf_r_e,alphaOrd_l_n,alphaOrd_r_n,surfNodesConfig,
-   numNodesConfig,numNodesVel,i,rcoFac,j,fHatSurf_e,Ghat_c,glst1,Ghat_e,incr],
+   numNodesConfig,numNodesVel,i,rcoFac_l,rcoFac_r,j,fHatSurf_e,Ghat_c,glst1,Ghat_e,incr],
 
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
@@ -28,16 +28,21 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
   vv   : varsVAll[1],
   surfVars : delete(vv,varsP),
     
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
   printf(fh, "  // w[~a]:     cell-center coordinates. ~%", cdim+vdim),
   printf(fh, "  // dxv[~a]:   cell spacing. ~%", cdim+vdim),
   printf(fh, "  // m_:        species mass.~%"),
   printf(fh, "  // bmag_inv:  1/(magnetic field magnitude). ~%"),
   printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (1+1)*NC),
   printf(fh, "  // fSkin/Edge:    Distribution function in cells ~%"),
   printf(fh, "  // out:           Incremented distribution function in cell ~%"),
+  printf(fh, "~%"),
+
+  /* Create a pointer to nuUSum. */
+  printf(fh, "  const double *nuUSum = nuPrimMomsSum;~%"),
+  printf(fh, "~%"),
+
   printf(fh, "  double rdv2 = 2.0/dxv[~a]; ~%", vid1[1]),
   printf(fh, "~%"),
 
@@ -103,33 +108,25 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
   /* Write out fUpwindQuad for the far left edge */
   /* Within the skin cell, we need alpha_r (alpha evaluated at +1)
      just like how the skin cell is evaluated at +1 */
+  basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
+  rcoFac_r : 1.,  rcoFac_l : 1.,
+  if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    basisStr : sconcat("gkhyb_", cdim, "x", vdim, "v"),
+    /* This subst eliminates the need for another variable, and removes
+       the common factor (for p=1) which is not needed to determine sign. */
+    rcoFac_l : 1./(content(alphaOrd_l_n[1],alphaDrSurf[0])[1]),
+    rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1])
+  ),
   for i : 1 thru numNodesConfig do (
-    if polyOrder=1 then ( /* Force p=1 to use hybrid basis. */
-      /* This subst eliminates the need for another variable, and removes
-         the common factor (for p=1) which is not needed to determine
-         sign (not working for p>1). */
-      rcoFac : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1]),
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac)),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),                                           
-      printf(fh, "  } else { ~%"),                 
-      for j : 1 thru numNodesVel do (              
-        printf(fh, "    fUpwindQuad[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fEdge); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    /* If polyOrder > 1, we just evaluate alpha at the quadrature points with no further substitutions */
-    ) else (
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_r_n[i]),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    )
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%")
   ),
 
   printf(fh, "~%"),
@@ -176,32 +173,15 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
   /* Within the skin cell, we need alpha_l (alpha evaluated at -1)
      just like how the skin cell is evaluated at -1 */
   for i : 1 thru numNodesConfig do (
-    if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
-      /* This subst eliminates the need for another variable, and removes
-         the common factor (for p=1) which is not needed to determine
-         sign (not working for p>1). */
-      rcoFac : 1./(content(alphaOrd_l_n[1],alphaDrSurf[0])[1]),
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac)),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),                                           
-      printf(fh, "  } else { ~%"),                 
-      for j : 1 thru numNodesVel do (              
-        printf(fh, "    fUpwindQuad[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fSkin); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    /* If polyOrder > 1, we just evaluate alpha at the quadrature points with no further substitutions */
-    ) else (
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_l_n[i]),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    )
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%")
   ),
 
   printf(fh, "~%"),
@@ -242,7 +222,7 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
 );
 
 calcGkLBOBoundaryDragUpdateMu(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonuniform) := block(
-  [varsC,bC,varsP,bP,vSub,NP,NC,vid1,vv,surfVars,nuSum_e,nuUSum_e,
+  [varsC,bC,varsP,bP,vSub,NP,NC,vid1,vv,surfVars,nuSum_e,
    bSurf,alphaDr,fSkin_e,fEdge_e,alphaDrSurf_l_c,alphaDrSurf_r_c,alst_l,alst_r,
    alphaDrSurf_l_e,alphaDrSurf_r_e,alphaOrd_l_n,alphaOrd_r_n,
    Ghat_c,glst1,Ghat_e,incr],
@@ -256,14 +236,13 @@ calcGkLBOBoundaryDragUpdateMu(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   vv   : varsVAll[2],
   surfVars : delete(vv,varsP),
 
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
   printf(fh, "  // w[~a]:     cell-center coordinates. ~%", cdim+vdim),
   printf(fh, "  // dxv[~a]:   cell spacing. ~%", cdim+vdim),
   printf(fh, "  // m_:        species mass.~%"),
   printf(fh, "  // bmag_inv:  1/(magnetic field magnitude). ~%"),
   printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (1+1)*NC),
   printf(fh, "  // fSkin/Edge:    Distribution function in cells ~%"),
   printf(fh, "  // out:           Incremented distribution function in cell ~%"),
   printf(fh, "  double rdv2 = 2.0/dxv[~a]; ~%", vid1[dir]),

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-surf.mac
@@ -28,16 +28,21 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
   vv       : varsVAll[1],
   surfVars : delete(vv,varsP),
 
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
   printf(fh, "  // w[~a]:     cell-center coordinates. ~%", cdim+vdim),
   printf(fh, "  // dxv[~a]:   cell spacing. ~%", cdim+vdim),
   printf(fh, "  // m_:        species mass.~%"),
   printf(fh, "  // bmag_inv:  1/(magnetic field magnitude). ~%"),
   printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (1+1)*NC),
   printf(fh, "  // fl/fc/fr:  distribution function in cells ~%"),
   printf(fh, "  // out:       incremented distribution function in cell ~%"),
+  printf(fh, "~%"),
+
+  /* Create a pointer to nuUSum. */
+  printf(fh, "  const double *nuUSum = nuPrimMomsSum;~%"),
+  printf(fh, "~%"),
+
   printf(fh, "  double rdv2 = 2.0/dxv[~a]; ~%", vid1[1]),
   printf(fh, "~%"),
     
@@ -104,55 +109,37 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
   printf(fh, "  double Ghat_l[~a] = {0.0}; ~%", length(bSurf)),
   printf(fh, "  double Ghat_r[~a] = {0.0}; ~%", length(bSurf)),
   printf(fh, "~%"),
+
+  basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
+  rcoFac_l : 1.,  rcoFac_r : 1.,
+  if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    basisStr : sconcat("gkhyb_", cdim, "x", vdim, "v"),
+    /* This subst eliminates the need for another variable, and removes
+       the common factor (for p=1) which is not needed to determine sign. */
+    rcoFac_l : 1./(content(alphaOrd_l_n[1],alphaDrSurf_l[0])[1]),
+    rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf_r[0])[1])
+  ),
+
   for i : 1 thru numNodesConfig do (
-    if polyOrder=1 then ( /* Force p=1 to use hybrid basis. */
-      /* This subst eliminates the need for another variable, and removes
-         the common factor (for p=1) which is not needed to determine
-         sign (not working for p>1). */
-      rcoFac_l : 1./(content(alphaOrd_l_n[1],alphaDrSurf_l[0])[1]),
-      rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf_r[0])[1]),
-      /* Drag term on left side of interface */
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),  
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fc); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%"),
-      /* Drag term on right side of interface.*/
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),  
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_r[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),                                      
-      printf(fh, "  } else { ~%"),            
-      for j : 1 thru numNodesVel do (         
-        printf(fh, "    fUpwindQuad_r[~a] = gkhyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fr); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    /* If polyOrder > 1, we just evaluate alpha at the quadrature points with no further substitutions */
-    ) else (
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_l_n[i]),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fc); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%"),
-      /* Drag term on right side of interface */
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_r_n[i]),  
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_r[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_r[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fr); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    )
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%"),
+    /* Drag term on right side of interface */
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fr); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%")
   ),
 
   printf(fh, "~%"),
@@ -205,7 +192,7 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
 );
 
 calcGkLBODragUpdateMu(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonuniform) := block( 
-  [varsC,bC,varsP,bP,vSub,NP,NC,pDim,vid1,vv,surfVars,nuSum_e,nuUSum_e,alphaDr,
+  [varsC,bC,varsP,bP,vSub,NP,NC,pDim,vid1,vv,surfVars,nuSum_e,alphaDr,
    fl_e,fc_e,fr_e,bSurf,alphaDrSurf_l_c,alphaDrSurf_r_c,alst_l,alst_r,
    alphaDrSurf_l_e,alphaDrSurf_r_e,Ghat_l_c,Ghat_r_c,GhatNoZero_l,GhatNoZero_r,
    Ghat_l_e,Ghat_r_e,incr_l,incr_r],
@@ -219,24 +206,23 @@ calcGkLBODragUpdateMu(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonuniform)
   vv       : varsVAll[2],
   surfVars : delete(vv,varsP),
 
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:     cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:   cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // m_:        species mass.~%"),
-  printf(fh, "  // bmag_inv:  1/(magnetic field magnitude). ~%"),
-  printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
-  printf(fh, "  // fl/fc/fr:  distribution function in cells ~%"),
-  printf(fh, "  // out:       incremented distribution function in cell ~%"),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // m_: species mass.~%"),
+  printf(fh, "  // bmag_inv: 1/(magnetic field magnitude). ~%"),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (vdim+1)*NC),
+  printf(fh, "  // fl/fc/fr: distribution function in cells ~%"),
+  printf(fh, "  // out: incremented distribution function in cell ~%"),
+  printf(fh, "~%"),
+
   printf(fh, "  double rdv2 = 2.0/dxv[~a]; ~%", vid1[2]),
   printf(fh, "~%"),
 
   /* Surface contribution is defined as integral(phi^- Ghat) over the surface. */
 
   nuSum_e : doExpand1(nuSum,bC),
-  /* Expand the mean flow speed in the configuration basis. */
-  nuUSum_e : doExpand1(nuUSum,bC),
   /* Calculate the alpha-velocity due to drag. */
   alphaDr : 2.0*nuSum_e*((1/2)*dxv[vid1[2]]*vv+w[vid1[2]]),
     

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-vol.mac
@@ -16,7 +16,7 @@ vIndex1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 doMakeExprLstOff(vals, S, off)  := makelist(if vals[i] # 0 then S[off+i-1] else 0, i, 1, length(vals))$
 
 calcGkLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [varsC,bC,varsP,bP,NP,NC,pOrderVpar,zr,vidx1,dir,f_e,nuSum_e,nuUSum_e,nuVtSqSum_e,
+  [varsC,bC,varsP,bP,NP,NC,pOrderVpar,zr,vidx1,dir,f_e,nuSum_e,nuUSum_e,
    incrDrag,cflFreq_mid,alphaDrag_e,expr,i,alphaDrag_NoZero,alphaDrag_NoZero_e],
 
   printf(fh, "#include <gkyl_lbo_gyrokinetic_kernels.h> ~%"),
@@ -37,29 +37,32 @@ calcGkLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   vidx1 : vIndex1(cdim,vdim),
 
-  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:      cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:    cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // m_:        species mass.~%"),
-  printf(fh, "  // bmag_inv:  1/(magnetic field magnitude). ~%"),
-  printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum:    sum of bulk velocities times their respective collisionalities. ~%"),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
-  printf(fh, "  // f:         input distribution function.~%"),
-  printf(fh, "  // out:       incremented output ~%"),
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // m_: species mass.~%"),
+  printf(fh, "  // bmag_inv: 1/(magnetic field magnitude). ~%"),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%"),
+  printf(fh, "  // f: input distribution function.~%"),
+  printf(fh, "  // out: incremented output ~%"),
+  printf(fh, "~%"),
+
+  /* Create a pointer to nuUSum. */
+  printf(fh, "  const double *nuUSum = nuPrimMomsSum;~%"),
+  printf(fh, "~%"),
 
   printf(fh, "  double rdv2[~a]; ~%", vdim),
   for dir : 1 thru vdim do (
-    printf(fh, "  rdv2[~a]   = 2.0/dxv[~a]; ~%", dir-1, vidx1[dir])
+    printf(fh, "  rdv2[~a] = 2.0/dxv[~a]; ~%", dir-1, vidx1[dir])
   ),
   printf(fh, "~%"),
 
   /* Expand distribution function f in phase basis.            */
   f_e : doExpand1(f, bP),
-  /* Expand flow speed sum(nu*u) and sum(nu*vtSq) in configuration basis. */
-  nuSum_e     : doExpand1(nuSum, bC),
-  nuUSum_e    : doExpand1(nuUSum, bC),
-  nuVtSqSum_e : doExpand1(nuVtSqSum, bC),
+  /* Expand flow speed sum(nu*u) in configuration basis. */
+  nuSum_e  : doExpand1(nuSum, bC),
+  nuUSum_e : doExpand1(nuUSum, bC),
 
   printf(fh, "  double alphaDrag[~a]; ~%", vdim*NP),
   incrDrag : 0,

--- a/maxima/g0/lenard_bernstein_operator/ms-gkLBO-header.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-gkLBO-header.mac
@@ -44,20 +44,20 @@ vvars : [vpar, mu]$
 
 printPrototypeDrag(deco, ci, vi, bStr, pi) := block([si],
 
-  printf(fh, "~adouble lbo_gyrokinetic_drag_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~adouble lbo_gyrokinetic_drag_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
   for si : 1 thru vi do (
-    printf(fh, "~avoid lbo_gyrokinetic_drag_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi),
-    printf(fh, "~avoid lbo_gyrokinetic_drag_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi)
+    printf(fh, "~avoid lbo_gyrokinetic_drag_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi),
+    printf(fh, "~avoid lbo_gyrokinetic_drag_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi)
   ),
   printf(fh, "~%")
 )$
 
 printPrototypeDiff(deco, ci, vi, bStr, pi) := block([si],
 
-  printf(fh, "~adouble lbo_gyrokinetic_diff_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fin, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~adouble lbo_gyrokinetic_diff_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *fin, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
   for si : 1 thru vi do (
-    printf(fh, "~avoid lbo_gyrokinetic_diff_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi),
-    printf(fh, "~avoid lbo_gyrokinetic_diff_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi)
+    printf(fh, "~avoid lbo_gyrokinetic_diff_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi),
+    printf(fh, "~avoid lbo_gyrokinetic_diff_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double m_, const double *bmag_inv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, vvars[si], ci, vi, bStr, pi)
   ),
   printf(fh, "~%")
 )$

--- a/maxima/g0/lenard_bernstein_operator/ms-vmLBO-header.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-vmLBO-header.mac
@@ -42,20 +42,20 @@ cvars : [x, y, z]$
 
 printPrototypeDrag(deco, ci, vi, bStr, pi) := block([si],
 
-  printf(fh, "~adouble lbo_vlasov_drag_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~adouble lbo_vlasov_drag_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
   for si : 1 thru vi do (
-    printf(fh, "~avoid lbo_vlasov_drag_boundary_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi),
-    printf(fh, "~avoid lbo_vlasov_drag_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi)
+    printf(fh, "~avoid lbo_vlasov_drag_boundary_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi),
+    printf(fh, "~avoid lbo_vlasov_drag_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi)
   ),
   printf(fh, "~%")
 )$
 
 printPrototypeDiff(deco, ci, vi, bStr, pi) := block([si],
 
-  printf(fh, "~adouble lbo_vlasov_diff_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~adouble lbo_vlasov_diff_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
   for si : 1 thru vi do (
-    printf(fh, "~avoid lbo_vlasov_diff_boundary_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi),
-    printf(fh, "~avoid lbo_vlasov_diff_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi)
+    printf(fh, "~avoid lbo_vlasov_diff_boundary_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, int edge, const double *fEdge, const double *fSkin, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi),
+    printf(fh, "~avoid lbo_vlasov_diff_surfv~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", deco, cvars[si], ci, vi, bStr, pi)
   ),
   printf(fh, "~%")
 )$

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-boundary-surf.mac
@@ -46,14 +46,18 @@ calcBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, is
   hsol_r : cons(subst(vv=0,hr_e),makelist(subst(vv=0,diff(hr_e,vv,ord)/(ord!)),ord,1,hOrder)),
   /*............. RECOVERY DONE ..............................*/
         
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:         Cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:       Cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // nuSum:         collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:    sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum[~a]: sum of thermal speeds squared time their respective collisionalities. ~%", NC),
-  printf(fh, "  // fSkin/Edge:    Distribution function in cells ~%"),
-  printf(fh, "  // out:           Incremented distribution function in cell ~%"),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: Cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: Cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (vdim+1)*NC),
+  printf(fh, "  // fSkin/Edge: Distribution function in cells ~%"),
+  printf(fh, "  // out: Incremented distribution function in cell ~%"),
+
+  /* Create a pointer to nuVtSqSum. */
+  printf(fh, "  const double *nuVtSqSum = &nuPrimMomsSum[~a];~%", vdim*NC),
+  printf(fh, "~%"),
+
   printf(fh, "  double rdvSq4 = 4.0/(dxv[~a]*dxv[~a]); ~%", vid1[dir], vid1[dir]),
   printf(fh, "~%"),
   /* First compute the contribution coming from the second

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-surf.mac
@@ -33,14 +33,19 @@ calcVmLBODiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   h_e : calcRecov1CellGen(bType, vv, varsP, polyOrder, 1, dg(makelist(fl[i-1],i,1,NP)), dg(makelist(fc[i-1],i,1,NP)), dg(makelist(fr[i-1],i,1,NP))),
   /*............. RECOVERY DONE ..............................*/
     
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:         cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:       cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // nuSum:         collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:    sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum[~a]: sum of thermal speeds squared time their respective collisionalities. ~%", NC),
-  printf(fh, "  // fl/fc/fr:      distribution function in cells ~%"),
-  printf(fh, "  // out:           incremented distribution function in cell ~%"),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%", (vdim+1)*NC),
+  printf(fh, "  // fl/fc/fr: distribution function in cells ~%"),
+  printf(fh, "  // out: incremented distribution function in cell ~%"),
+  printf(fh, "~%"),
+
+  /* Create a pointer to nuVtSqSum. */
+  printf(fh, "  const double *nuVtSqSum = &nuPrimMomsSum[~a];~%", vdim*NC),
+  printf(fh, "~%"),
+
   printf(fh, "  double rdvSq4 = 4.0/(dxv[~a]*dxv[~a]); ~%", vid1[dir], vid1[dir]),
   printf(fh, "  double temp_diff[~a] = {0.0}; ~%", NP),
   printf(fh, "  double diff_incr[~a] = {0.0}; ~%", NP),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-vol.mac
@@ -36,16 +36,19 @@ calcVmLBODiffVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
      coordinates = 0. */
   zr : makelist(varsP[d]=0, d, 1, length(varsP)),
 
-  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:      Cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:    Cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum:    sum of bulk velocities times their respective collisionalities. ~%"),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
-  printf(fh, "  // f:         Input distribution function.~%"),
-  printf(fh, "  // out:       Incremented output ~%"),
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: Cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: Cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum: sum of bulk velocities and thermal speeds squared times their respective collisionalities. ~%"),
+  printf(fh, "  // f: Input distribution function.~%"),
+  printf(fh, "  // out: Incremented output ~%"),
   cid : cidx(cdim),
   vid : vidx(cdim,vdim),
+
+  /* Create a pointer to nuVtSqSum. */
+  printf(fh, "  const double *nuVtSqSum = &nuPrimMomsSum[~a];~%", vdim*NC),
+  printf(fh, "~%"),
 
   for dir : 1 thru vdim do (
     printf(fh, "  const double rd~aSq4 = 4.0/(dxv[~a]*dxv[~a]); ~%", varsVAll[dir], vid[dir], vid[dir])

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-boundary-surf.mac
@@ -18,7 +18,7 @@ vidx1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonuniform) := block(
   [varsC,bC,varsP,bP,NP,NC,pDim,vid1,vv,surfVars,nuSum_e,nuUSum_e,bSurf,alphaDr,alphaDrSurf_l_c,
    alphaDrSurf_r_c,alst_l,alst_r,alphaDrSurf_l_e,alphaDrSurf_r_e,surf_cdim,surf_vdim,surfNodes,numNodes,
-   alphaOrd_l_n,alphaOrd_r_n,surfNodesConfig,numNodesConfig,numNodesVel,i,rcoFac,fHatSurf_e,Ghat_c,
+   alphaOrd_l_n,alphaOrd_r_n,surfNodesConfig,numNodesConfig,numNodesVel,i,rcoFac_l,rcoFac_r,fHatSurf_e,Ghat_c,
    glst1,Ghat_e,incr],
 
   /* Load basis of dimensionality requested. */
@@ -33,14 +33,13 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   vv   : vvarsAll[dir],
   surfVars : delete(vv,varsP),
 
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:         Cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:       Cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // nuSum:         collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:    sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum[~a]: sum of thermal speeds squared time their respective collisionalities. ~%", NC),
-  printf(fh, "  // fSkin/Edge:    Distribution function in cells ~%"),
-  printf(fh, "  // out:           Incremented distribution function in cell ~%"),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const int edge, const double *fSkin, const double *fEdge, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: Cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: Cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds (squared) times their respective collisionalities. ~%", (vdim+1)*NC),
+  printf(fh, "  // fSkin/Edge: Distribution function in cells ~%"),
+  printf(fh, "  // out: Incremented distribution function in cell ~%"),
   printf(fh, "  double rdv2 = 2.0/dxv[~a]; ~%", vid1[dir]),
   printf(fh, "~%"),
 
@@ -48,7 +47,7 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   /* Expand the mean flow speed in the configuration basis. */
   nuUSum_e : doExpand1(nuUSumx[dir],bC),
   /* Create pointer to component of u relevant to this surface. */
-  printf(fh, "  const double *sumNuU~a = &nuUSum[~a]; ~%", varsCAll[dir], NC*(dir-1)),
+  printf(fh, "  const double *sumNuU~a = &nuPrimMomsSum[~a]; ~%", varsCAll[dir], NC*(dir-1)),
   printf(fh, "~%"),
 
   /* Surface basis. Equivalent to basis of one lower
@@ -109,33 +108,25 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   /* Write out fUpwindQuad for the far left edge */
   /* Within the skin cell, we need alpha_r (alpha evaluated at +1)
      just like how the skin cell is evaluated at +1 */
+  basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
+  rcoFac_l : 1.,  rcoFac_r : 1.,
+  if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    basisStr : sconcat("hyb_", cdim, "x", vdim, "v"),
+    /* This subst eliminates the need for another variable, and removes
+       the common factor (for p=1) which is not needed to determine sign. */
+    rcoFac_l : 1./(content(alphaOrd_l_n[1],alphaDrSurf[0])[1]),
+    rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1])
+  ),
   for i : 1 thru numNodesConfig do (
-    if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
-      /* This subst eliminates the need for another variable, and removes
-         the common factor (for p=1) which is not needed to determine
-         sign (not working for p>1). */
-      rcoFac : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1]),
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac)),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fEdge); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    /* If polyOrder > 1, we just evaluate alpha at the quadrature points with no further substitutions */
-    ) else (
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_r_n[i]),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    )
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%")
   ),
 
   printf(fh, "~%"),
@@ -183,32 +174,15 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   /* Within the skin cell, we need alpha_l (alpha evaluated at -1)
      just like how the skin cell is evaluated at -1 */
   for i : 1 thru numNodesConfig do (
-    if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
-      /* This subst eliminates the need for another variable, and removes
-         the common factor (for p=1) which is not needed to determine
-         sign (not working for p>1). */
-      rcoFac : 1./(content(alphaOrd_l_n[1],alphaDrSurf[0])[1]),
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac)),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fSkin); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    /* If polyOrder > 1, we just evaluate alpha at the quadrature points with no further substitutions */
-    ) else (
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_l_n[i]),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    )
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%")
   ),
 
   printf(fh, "~%"),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-surf.mac
@@ -33,14 +33,13 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   vv   : vvarsAll[dir],
   surfVars : delete(vv,varsP),
 
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:         cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:       cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // nuSum:         collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum[~a]:    sum of bulk velocities times their respective collisionalities. ~%", vdim*NC),
-  printf(fh, "  // nuVtSqSum[~a]: sum of thermal speeds squared time their respective collisionalities. ~%", NC),
-  printf(fh, "  // fl/fc/fr:      distribution function in cells ~%"),
-  printf(fh, "  // out:           incremented distribution function in cell ~%"),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum[~a]: sum of bulk velocities and thermal speeds (squared) times their respective collisionalities. ~%", (vdim+1)*NC),
+  printf(fh, "  // fl/fc/fr: distribution function in cells ~%"),
+  printf(fh, "  // out: incremented distribution function in cell ~%"),
   printf(fh, "  double rdv2 = 2.0/dxv[~a]; ~%", vid1[dir]),
   printf(fh, "~%"),
 
@@ -48,7 +47,7 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   /* Expand the mean flow speed in the configuration basis. */
   nuUSum_e : doExpand1(nuUSumx[dir],bC),
   /* Create pointer to component of u relevant to this surface. */
-  printf(fh, "  const double *sumNuU~a = &nuUSum[~a]; ~%", varsCAll[dir], NC*(dir-1)),
+  printf(fh, "  const double *sumNuU~a = &nuPrimMomsSum[~a]; ~%", varsCAll[dir], NC*(dir-1)),
   printf(fh, "~%"),
   /* Calculate the alpha-velocity due to drag. */
   alphaDr : nuSum_e*((1/2)*dxv[vid1[dir]]*vv+w[vid1[dir]])-nuUSum_e,
@@ -112,55 +111,38 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   printf(fh, "  double Ghat_l[~a] = {0.0}; ~%", length(bSurf)),
   printf(fh, "  double Ghat_r[~a] = {0.0}; ~%", length(bSurf)),
   printf(fh, "~%"),
+
+  basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
+  rcoFac_l : 1.,  rcoFac_r : 1.,
+  if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    basisStr : sconcat("hyb_", cdim, "x", vdim, "v"),
+    /* This subst eliminates the need for another variable, and removes
+       the common factor (for p=1) which is not needed to determine sign. */
+    rcoFac_l : 1./(content(alphaOrd_l_n[1],alphaDrSurf_l[0])[1]),
+    rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf_r[0])[1])
+  ),
+
   for i : 1 thru numNodesConfig do (
-    if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
-      /* This subst eliminates the need for another variable, and removes
-         the common factor (for p=1) which is not needed to determine
-         sign (not working for p>1). */
-      rcoFac_l : 1./(content(alphaOrd_l_n[1],alphaDrSurf_l[0])[1]),
-      rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf_r[0])[1]),
-      /* Drag term on left side of interface */
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),  
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fc); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%"),
-      /* Drag term on right side of interface */
-      printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),  
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_r[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_r[~a] = hyb_~ax~av_p1_surfx~a_eval_quad_node_~a_l(fr); ~%", (j-1)+(i-1)*numNodesVel, cdim, vdim, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    ) else (
-      /* If polyOrder > 1, we just evaluate alpha at the quadrature points with no further substitutions */
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_l_n[i]),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_l[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fc); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%"),
-      /* Drag term on right side of interface */
-      printf(fh, "  if (~a < 0) { ~%", alphaOrd_r_n[i]),  
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_r[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } else { ~%"),
-      for j : 1 thru numNodesVel do (
-        printf(fh, "    fUpwindQuad_r[~a] = ~a_~ax_p~a_surfx~a_eval_quad_node_~a_l(fr); ~%", (j-1)+(i-1)*numNodesVel, basisFun, cdim+vdim, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
-      ),
-      printf(fh, "  } ~%")
-    )
+    /* Drag term on left side of interface */
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%"),
+    /* Drag term on right side of interface */
+    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } else { ~%"),
+    for j : 1 thru numNodesVel do (
+      printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_l(fr); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
+    ),
+    printf(fh, "  } ~%")
   ),
 
   printf(fh, "~%"),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-vol.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-vol.mac
@@ -16,7 +16,7 @@ doMakeExprLstOff(vals, S, off) := makelist(if vals[i] # 0 then S[off+i-1] else 0
 
 calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,NP,NC,pOrderV,zr,cid,vid1,dir,f_e,nuSum_e,nuUSum_e,
-   nuVtSqSum_e,incrDrag,cflFreq_mid,vdir,alphaDrag_e,expr,i,
+   incrDrag,cflFreq_mid,vdir,alphaDrag_e,expr,i,
    alphaDrag_NoZero,alphaDrag_NoZero_e],
 
   printf(fh, "#include <gkyl_lbo_vlasov_kernels.h> ~%"),
@@ -36,14 +36,17 @@ calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   /* Here we choose to evaluate things in the middle of the cell, where
      coordinates = 0. */
   zr : makelist(varsP[d]=0, d, 1, cdim+vdim),
-  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double *nuSum, const double *nuUSum, const double *nuVtSqSum, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
-  printf(fh, "  // w[~a]:      Cell-center coordinates. ~%", cdim+vdim),
-  printf(fh, "  // dxv[~a]:    Cell spacing. ~%", cdim+vdim),
-  printf(fh, "  // nuSum:     collisionalities added (self and cross species collisionalities). ~%"),
-  printf(fh, "  // nuUSum:    sum of bulk velocities times their respective collisionalities. ~%"),
-  printf(fh, "  // nuVtSqSum: sum of thermal speeds squared time their respective collisionalities. ~%"),
-  printf(fh, "  // f:         Input distribution function.~%"),
-  printf(fh, "  // out:       Incremented output ~%"),
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double *nuSum, const double *nuPrimMomsSum, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[~a]: Cell-center coordinates. ~%", cdim+vdim),
+  printf(fh, "  // dxv[~a]: Cell spacing. ~%", cdim+vdim),
+  printf(fh, "  // nuSum: collisionalities added (self and cross species collisionalities). ~%"),
+  printf(fh, "  // nuPrimMomsSum: sum of bulk velocities and thermal speeds (squared) times their respective collisionalities. ~%"),
+  printf(fh, "  // f: Input distribution function.~%"),
+  printf(fh, "  // out: Incremented output ~%"),
+
+  /* Create a pointer to nuUSum. */
+  printf(fh, "  const double *nuUSum = nuPrimMomsSum;~%"),
+  printf(fh, "~%"),
 
   cid  : cidx(cdim),
   vid1 : vidx1(cdim,vdim),
@@ -58,7 +61,6 @@ calcVmLBODragVolUpdater(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   /* Expand flow speed sum(nu*u) and sum(nu*vtSq) in configuration basis. */
   nuSum_e     : doExpand1(nuSum, bC),
   nuUSum_e    : doExpand1(nuUSum, bC),
-  nuVtSqSum_e : doExpand1(nuVtSqSum, bC),
   /* To allow for multiple components change the cofficient indices in u. */
   nuUSum_e : psubst(makelist(nuUSum[i]=nuUSum[a0+i],i,0,NC-1),nuUSum_e),
 

--- a/maxima/g0/prim_moments/CrossPrimMomsLBO-vlasov-with-fluid.mac
+++ b/maxima/g0/prim_moments/CrossPrimMomsLBO-vlasov-with-fluid.mac
@@ -106,13 +106,19 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block([udim
   NC  : length(bC),
   
   /* Function declaration with input/output variables. */
-  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *u_self, const double *vtsq_self, const double m_other, const double *moms_other, const double *u_other, const double *vtsq_other, const double *fluid, const double *boundary_corrections) ~%{ ~%", funcNm),
+  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *fluid, const double *boundary_corrections) ~%{ ~%", funcNm),
   printf(fh, "  // greene:               Greene's factor. ~%"),
   printf(fh, "  // m:                    mass. ~%"),
   printf(fh, "  // moms:                 moments of the distribution function. ~%"),
-  printf(fh, "  // u,vtSq:               self primitive moments: mean flow velocity and thermal speed squared. ~%"),
+  printf(fh, "  // prim_mom:             self primitive moments: mean flow velocity and thermal speed squared. ~%"),
   printf(fh, "  // boundary_corrections: corrections to momentum and energy conservation due to finite velocity space. ~%"),
-  printf(fh, "  // uCross,vtSqCross:     cross primitive moments: mean flow velocity and thermal speed squared. ~%"),
+  printf(fh, " ~%"),
+
+  /* Create pointers to u and vtsq of each species. */
+  printf(fh, "  const double *u_self = &prim_mom_self[~a];~%", 0*NC),
+  printf(fh, "  const double *vtsq_self = &prim_mom_self[~a];~%", udim*NC),
+  printf(fh, "  const double *u_other = &prim_mom_other[~a];~%", 0*NC),
+  printf(fh, "  const double *vtsq_other = &prim_mom_other[~a];~%", udim*NC),
   printf(fh, " ~%"),
 
   /* In order to avoid dividing by very small, negative or zero densities

--- a/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
+++ b/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
@@ -58,13 +58,19 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   numB : length(basis),
 
   /* Function declaration with input/output variables. */
-  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *u_self, const double *vtsq_self, const double m_other, const double *moms_other, const double *u_other, const double *vtsq_other, const double *boundary_corrections) ~%{ ~%", funcNm),
+  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *boundary_corrections) ~%{ ~%", funcNm),
   printf(fh, "  // greene:               Greene's factor. ~%"),
   printf(fh, "  // m_:                   mass. ~%"),
   printf(fh, "  // moms:                 moments of the distribution function. ~%"),
-  printf(fh, "  // u,vtSq:               self primitive moments: mean flow velocity and thermal speed squared. ~%"),
+  printf(fh, "  // prim_mom              self primitive moments: mean flow velocity and thermal speed squared. ~%"),
   printf(fh, "  // boundary_corrections: corrections to momentum and energy conservation due to finite velocity space. ~%"),
-  printf(fh, "  // uCross,vtSqCross:     cross primitive moments: mean flow velocity and thermal speed squared. ~%"),
+  printf(fh, " ~%"),
+
+  /* Create pointers to u and vtsq of each species. */
+  printf(fh, "  const double *u_self = &prim_mom_self[~a];~%", 0*numB),
+  printf(fh, "  const double *vtsq_self = &prim_mom_self[~a];~%", udim*numB),
+  printf(fh, "  const double *u_other = &prim_mom_other[~a];~%", 0*numB),
+  printf(fh, "  const double *vtsq_other = &prim_mom_other[~a];~%", udim*numB),
   printf(fh, " ~%"),
 
   /* In order to avoid dividing by very small, negative or zero densities

--- a/maxima/g0/prim_moments/ms-gkPrimMoments-header.mac
+++ b/maxima/g0/prim_moments/ms-gkPrimMoments-header.mac
@@ -39,7 +39,7 @@ printf(fh, "#include <gkyl_util.h> ~%")$
 printf(fh, " ~%")$
 printf(fh, "EXTERN_C_BEG ~%")$
 printf(fh, " ~%")$
-printf(fh, "GKYL_CU_DH void prim_lbo_gyrokinetic_copy_sol(const struct gkyl_mat *rhs, const int nc, const int vdim, double* GKYL_RESTRICT u, double* GKYL_RESTRICT vtSq); ~%")$
+printf(fh, "GKYL_CU_DH void prim_lbo_gyrokinetic_copy_sol(const struct gkyl_mat *rhs, const int nc, const int udim, double* GKYL_RESTRICT out); ~%")$
 printf(fh, " ~%")$
 
 for bInd : 1 thru length(bName) do (
@@ -56,7 +56,7 @@ for bInd : 1 thru length(bName) do (
         printf(fh, "GKYL_CU_DH void gyrokinetic_self_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *moms, const double *boundary_corrections); ~%", ci, vi, bName[bInd], pi),
 
         /* Primitive moments for cross-collision GkLBO terms. */
-        printf(fh, "GKYL_CU_DH void gyrokinetic_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *greene, const double m_self, const double *moms_self, const double *u_self, const double *vtsq_self,~%  const double m_other, const double *moms_other, const double *u_other, const double *vtsq_other,~%  const double *boundary_corrections); ~%", ci, vi, bName[bInd], pi),
+        printf(fh, "GKYL_CU_DH void gyrokinetic_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self,~%  const double m_other, const double *moms_other, const double *prim_mom_other,~%  const double *boundary_corrections); ~%", ci, vi, bName[bInd], pi),
 
         printf(fh, "~%")
       )

--- a/maxima/g0/prim_moments/ms-vlasovPrimMoments-header.mac
+++ b/maxima/g0/prim_moments/ms-vlasovPrimMoments-header.mac
@@ -33,11 +33,11 @@ maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 printPrototype(deco, ci, vi, bStr, pi) := block([si],
   /* Primitive moments for collision terms. */
   printf(fh, "~avoid vlasov_self_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *moms, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
-  printf(fh, "~avoid vlasov_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *u_self, const double *vtsq_self, const double m_other, const double *moms_other, const double *u_other, const double *vtsq_other, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~avoid vlasov_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
 
   /* Primitive moments for Vlasov parallel kinetic with perp pressure model collision terms. */
   printf(fh, "~avoid vlasov_with_fluid_self_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *moms, const double *fluid, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
-  printf(fh, "~avoid vlasov_with_fluid_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *u_self, const double *vtsq_self, const double m_other, const double *moms_other, const double *u_other, const double *vtsq_other, const double *fluid, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~avoid vlasov_with_fluid_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *fluid, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
   printf(fh, "~%")  
 )$
 
@@ -54,7 +54,7 @@ printf(fh, "#include <gkyl_util.h> ~%")$
 printf(fh, " ~%")$
 printf(fh, "EXTERN_C_BEG ~%")$
 printf(fh, " ~%")$
-printf(fh, "GKYL_CU_DH void prim_lbo_copy_sol(const struct gkyl_mat *rhs, const int nc, const int vdim,~%  double* GKYL_RESTRICT u, double* GKYL_RESTRICT vtSq); ~%")$
+printf(fh, "GKYL_CU_DH void prim_lbo_copy_sol(const struct gkyl_mat *rhs, const int nc, const int udim,~%  double* GKYL_RESTRICT out); ~%")$
 printf(fh, " ~%")$
 printf(fh, "~%")$
 


### PR DESCRIPTION
The primitive moments u and vtSq are nearly always needed together, in cross primitive moment updaters or LBO kernels. So it makes sense to just put them into a single gkyl_array. This simplifies the Apps, doesn't change kernels much, and simplifies inter-species communication.

g0 unit and regression tests pass on both CPU and GPU (although I saw a weird nvlink warning, see gkylzero's 96dda276333efda82b0f4d77bdf4622e693f0e08). g2 vmLBO and gkLBO regression tests also pass.