### PR TITLE
Fix LBO energy conservation for p>1

### DIFF
--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-boundary-surf.mac
@@ -17,9 +17,8 @@ calcGkLBOBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   [varsC,bC,varsP,bP,vSub,NC,NP,pDim,vidx1,surfVar,surfIntVars,bPp,fEdge_e,fSkin_e,bType,hl_e,hr_e,
    hOrder,hsol_l,hsol_r,surfVarPhys,nuVtSqSum_e,bSurf,facDiff_e,basisFac,GhatPhaseFac_l,
    GhatPhaseFac_r,ibpPhaseFac_l,ibpPhaseFac_r,vfSkin_l,vfSkin_r,BmagInv_e,surfVar_l,surfVar_r,
-   facDiff_c,expr,i,facDiff_NoZero,vol_incr_c,Gdiff_l_c,Gdiff_r_c,Gdiff_l_e,Gdiff_r_e,Gdiff2_l_c,
-   Gdiff2_r_c,Gdiff2_l_e,Gdiff2_r_e,temp_diff_rc,temp_edge_lc,diff_incr_rc,edge_incr_lc,temp_diff_lc,
-   temp_edge_rc,diff_incr_lc,edge_incr_rc,vol_out,diff_out,edge_out],
+   facDiff_c,expr,i,facDiff_NoZero,vol_incr_c,Gdiff_c,Gdiff2_c,edgeSurf_c,edgeSurf_incr_c,
+   boundSurf_c,boundSurf_incr_c,vol_out,diff_out,edge_out],
 
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
@@ -126,74 +125,96 @@ calcGkLBOBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   ),
   facDiff_e : doExpand(facDiff_NoZero, bC),
 
-  /* Volume increment. */
-  vol_incr_c : rdvSq4*calcInnerProdList(varsP, 1, basisFac, facDiff_e*fSkin_e),
+  /* Volume increment. Dimensional factor included later. */
+  vol_incr_c : calcInnerProdList(varsP, 1, basisFac, facDiff_e*fSkin_e),
   printf(fh, "  double vol_incr[~a] = {0.0};~%", NP),
   writeCExprs1(vol_incr, vol_incr_c),
   printf(fh, "~%"),
     
-  Gdiff_l_c : calcInnerProdList(surfIntVars,1,bSurf,GhatPhaseFac_l),
-  Gdiff_r_c : calcInnerProdList(surfIntVars,1,bSurf,GhatPhaseFac_r),
-  Gdiff_l_e : doExpand(Gdiff_l_c, bSurf),
-  Gdiff_r_e : doExpand(Gdiff_r_c, bSurf),
-
-  Gdiff2_l_c : calcInnerProdList(surfIntVars,1,bSurf,ibpPhaseFac_l),
-  Gdiff2_r_c : calcInnerProdList(surfIntVars,1,bSurf,ibpPhaseFac_r),
-  Gdiff2_l_e : doExpand(Gdiff2_l_c, bSurf),
-  Gdiff2_r_e : doExpand(Gdiff2_r_c, bSurf),
-
-  printf(fh, "  double temp_diff[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double temp_edge[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double diff_incr[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double edge_incr[~a] = {0.0}; ~%", NP),
+  printf(fh, "  double edgeSurf_incr[~a] = {0.0}; ~%", NP),
+  printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", NP),
   printf(fh, "~%"),
   printf(fh, "  if (edge == -1) { ~%~%"),
     
-  temp_diff_rc : fullratsimp(calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bP), Gdiff_r_e)
-                            -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), Gdiff2_r_e)),
-  writeCExprs1(temp_diff, temp_diff_rc),
-  printf(fh, "~%"),
-    
-  temp_edge_lc : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), vfSkin_l),
-  writeCExprs1(temp_edge, temp_edge_lc),
-  printf(fh, "~%"),
-    
-  diff_incr_rc : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(temp_diff, bP)),
-  writeCExprs1(diff_incr, diff_incr_rc),
-  printf(fh, "~%"),
+  if (polyOrder=1 or sdowncase(basisFun)="tensor") then (
+    /* This simplification only works for p=1 because it is a tensor product of
+       conf and velocity space (remains to be checked for tensor basis). */
 
-  edge_incr_lc : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(temp_edge, bP)),
-  writeCExprs1(edge_incr, edge_incr_lc),
+    Gdiff_c  : calcInnerProdList(surfIntVars,1,bSurf,GhatPhaseFac_r),
+    Gdiff2_c : calcInnerProdList(surfIntVars,1,bSurf,ibpPhaseFac_r),
+
+    printf(fh, "  double edgeSurf[~a] = {0.0}; ~%", NP),
+    edgeSurf_c : fullratsimp(calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bP), doExpand(Gdiff_c, bSurf))
+                            -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), doExpand(Gdiff2_c, bSurf))),
+    writeCExprs1(edgeSurf, edgeSurf_c),
+    printf(fh, "~%"),
+      
+    edgeSurf_incr_c : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(edgeSurf, bP)),
+
+    printf(fh, "  double boundSurf[~a] = {0.0}; ~%", NP),
+    boundSurf_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), vfSkin_l),
+    writeCExprs1(boundSurf, boundSurf_c),
+    printf(fh, "~%"),
+      
+    boundSurf_incr_c : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(boundSurf, bP))
+  ) else (
+    Gdiff_c : calcInnerProdList(varsP,1,bP,facDiff_e*GhatPhaseFac_r),
+
+    edgeSurf_incr_c : fullratsimp(calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bP), subst(surfVar=1,doExpand(Gdiff_c, bP)))
+                                 -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), facDiff_e*ibpPhaseFac_r)),
+
+    boundSurf_incr_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), subst(surfVar=-1,facDiff_e*vfSkin_l))
+  ),
+  writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
+  printf(fh, "~%"),
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
   printf(fh, "~%"),
   
   /* otherwise edge == +1, we are doing the right edge boundary and the skin cell needs to be evaluated at -1 */
   printf(fh, "~%  } else { ~%~%"),
   
-  temp_diff_lc : fullratsimp(calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bP), Gdiff_l_e)
-                            -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), Gdiff2_l_e)),
-  writeCExprs1(temp_diff, temp_diff_lc),
+  if (polyOrder=1 or sdowncase(basisFun)="tensor") then (
+    /* This simplification only works for p=1 because it is a tensor product of
+       conf and velocity space (remains to be checked for tensor basis). */
+
+    Gdiff_c  : calcInnerProdList(surfIntVars,1,bSurf,GhatPhaseFac_l),
+    Gdiff2_c : calcInnerProdList(surfIntVars,1,bSurf,ibpPhaseFac_l),
+
+    printf(fh, "  double edgeSurf[~a] = {0.0}; ~%", NP),
+    edgeSurf_c : fullratsimp(calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bP), doExpand(Gdiff_c, bSurf))
+                            -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), doExpand(Gdiff2_c, bSurf))),
+    writeCExprs1(edgeSurf, edgeSurf_c),
+    printf(fh, "~%"),
+      
+    edgeSurf_incr_c : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(edgeSurf, bP)),
+
+    printf(fh, "  double boundSurf[~a] = {0.0}; ~%", NP),
+    boundSurf_c : -calcInnerProdList(surfIntVars, 1,  subst(surfVar=1, bPp), vfSkin_r),
+    writeCExprs1(boundSurf, boundSurf_c),
+    printf(fh, "~%"),
+      
+    boundSurf_incr_c : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(boundSurf, bP))
+  ) else (
+    Gdiff_c : calcInnerProdList(varsP,1,bP,facDiff_e*GhatPhaseFac_l),
+
+    edgeSurf_incr_c : fullratsimp(calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bP), subst(surfVar=-1,doExpand(Gdiff_c, bP)))
+                                 -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), facDiff_e*ibpPhaseFac_l)),
+
+    boundSurf_incr_c : -calcInnerProdList(surfIntVars, 1,  subst(surfVar=1, bPp), subst(surfVar=1,facDiff_e*vfSkin_r))
+  ),
+
+  writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
   printf(fh, "~%"),
-    
-  temp_edge_rc : -calcInnerProdList(surfIntVars, 1,  subst(surfVar=1, bPp), vfSkin_r),
-  writeCExprs1(temp_edge, temp_edge_rc),
-  printf(fh, "~%"),
-    
-  diff_incr_lc : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(temp_diff, bP)),
-  writeCExprs1(diff_incr, diff_incr_lc),
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
   printf(fh, "~%"),
 
-  edge_incr_rc : calcInnerProdList(varsP, facDiff_e, bP, doExpand1(temp_edge, bP)),
-  writeCExprs1(edge_incr, edge_incr_rc),
-  printf(fh, "~%"),
   printf(fh, "  } ~%"),
   printf(fh, "~%"),
 
   vol_out  : makelist(vol_incr[i-1],i,1,NP),
-  diff_out : makelist(diff_incr[i-1],i,1,NP),
-  edge_out : makelist(edge_incr[i-1],i,1,NP),
-  writeCIncrExprs1(out, rdvSq4*(diff_out + edge_out) + vol_out),
+  diff_out : makelist(edgeSurf_incr[i-1],i,1,NP),
+  edge_out : makelist(boundSurf_incr[i-1],i,1,NP),
+  writeCIncrExprsNoExpand1(out, rdvSq4*(diff_out + edge_out + vol_out)),
 
   printf(fh, "} ~%")
 );
-
-

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-diff-surf.mac
@@ -13,7 +13,7 @@ varsVAll  : [vpar, mu]$
 vIndex1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 
 calcGkLBODiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonuniform) := block(
-  [varsC,bC,varsP,bP,vSub,NC,NP,pDim,vidx1,surfVar,bType,h_e,temp_diff_c,nuVtSqSum_e,diffFac_e,diff_incr_c],
+  [varsC,bC,varsP,bP,vSub,NC,NP,pDim,vidx1,surfVar,bType,h_e,f_xx_c,nuVtSqSum_e,diffFac_e,incr_c],
   
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
@@ -50,24 +50,15 @@ calcGkLBODiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   printf(fh, "~%"),
 
   printf(fh, "  double rdvSq4 = 4.0/(dxv[~a]*dxv[~a]); ~%", vidx1[dir], vidx1[dir]),
-  printf(fh, "  double temp_diff[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double diff_incr[~a] = {0.0}; ~%", NP),
+  printf(fh, "  double incr[~a] = {0.0}; ~%", NP),
   printf(fh, "~%"),
     
-  /* Write out the second derivative of the recovered distribution. */
-  if dir=1 then (
-    temp_diff_c : calcInnerProdList(varsP, 1, bP, diff(h_e, surfVar, 2))
-  ) elseif dir=2 then (
-    temp_diff_c : calcInnerProdList(varsP, 1, bP, diff((w[cdim+1]+(dxv[cdim+1]/2)*surfVar)*diff(h_e, surfVar), surfVar))
-  ),
-  writeCExprs1(temp_diff, temp_diff_c),
-  printf(fh, "~%"),
-
   nuVtSqSum_e : doExpand1(nuVtSqSum,bC),
   BmagInv_e   : doExpand1(bmag_inv,bC),
     
   if dir=1 then (
-    diffFac_e : nuVtSqSum_e 
+    diffFac_e : nuVtSqSum_e,
+    f_xx_e    : diff(h_e, surfVar, 2)
   ) elseif dir=2 then (
     diffFac_c : calcInnerProdList(varsC,1,bC,2*m_*BmagInv_e*nuVtSqSum_e),
     printf(fh, "  double diffFac[~a] = {0.}; ~%", NC),
@@ -75,12 +66,27 @@ calcGkLBODiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
     printf(fh, "~%"),
 
     diffFacNoZeros_c : doMakeExprLst(diffFac_c, diffFac),
-    diffFac_e : doExpand(diffFacNoZeros_c, bC)
+    diffFac_e : doExpand(diffFacNoZeros_c, bC),
+    f_xx_e    : diff((w[cdim+1]+(dxv[cdim+1]/2)*surfVar)*diff(h_e, surfVar), surfVar)
   ),
-  diff_incr_c : calcInnerProdList(varsP, diffFac_e, bP, doExpand1(temp_diff,bP)),
-  writeCExprs1(diff_incr, diff_incr_c),
+
+  if (polyOrder=1 or sdowncase(basisFun)="tensor") then (
+    /* This simplification only works for p=1 because it is a tensor product of
+       conf and velocity space (remains to be checked for tensor basis). */
+
+    /* Write out the second derivative of the recovered distribution. */
+    printf(fh, "  double f_xx[~a] = {0.0}; ~%", NP),
+    f_xx_c : calcInnerProdList(varsP, 1, bP, f_xx_e),
+    writeCExprs1(f_xx, f_xx_c),
+    printf(fh, "~%"),
+
+    f_xx_e : doExpand(makelistNoZeros(f_xx_c, f_xx),bP)
+  ),
+
+  incr_c : calcInnerProdList(varsP, diffFac_e, bP, f_xx_e),
+  writeCExprs1(incr, incr_c),
   printf(fh, "~%"),
   
-  writeCIncrExprs1(out, rdvSq4*makelist(diff_incr[i-1],i,1,NP)), 
+  writeCIncrExprs1(out, rdvSq4*makelistNoZeros(incr_c, incr)), 
   printf(fh, "} ~%")
 );

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-boundary-surf.mac
@@ -108,9 +108,11 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
   /* Write out fUpwindQuad for the far left edge */
   /* Within the skin cell, we need alpha_r (alpha evaluated at +1)
      just like how the skin cell is evaluated at +1 */
+  alphaSimp(a) := float(expand(fullratsimp(a))),
   basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
   rcoFac_r : 1.,  rcoFac_l : 1.,
   if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    alphaSimp(a) := fullratsimp(a),
     basisStr : sconcat("gkhyb_", cdim, "x", vdim, "v"),
     /* This subst eliminates the need for another variable, and removes
        the common factor (for p=1) which is not needed to determine sign. */
@@ -118,7 +120,7 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
     rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1])
   ),
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_r_n[i]*rcoFac_r)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -173,7 +175,7 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
   /* Within the skin cell, we need alpha_l (alpha evaluated at -1)
      just like how the skin cell is evaluated at -1 */
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_l_n[i]*rcoFac_l)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-boundary-surf.mac
@@ -118,7 +118,7 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
     rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1])
   ),
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -173,7 +173,7 @@ calcGkLBOBoundaryDragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isN
   /* Within the skin cell, we need alpha_l (alpha evaluated at -1)
      just like how the skin cell is evaluated at -1 */
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-surf.mac
@@ -109,9 +109,11 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
   printf(fh, "  double Ghat_r[~a] = {0.0}; ~%", length(bSurf)),
   printf(fh, "~%"),
 
+  alphaSimp(a) := float(expand(fullratsimp(a))),
   basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
   rcoFac_l : 1.,  rcoFac_r : 1.,
   if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    alphaSimp(a) := fullratsimp(a),
     basisStr : sconcat("gkhyb_", cdim, "x", vdim, "v"),
     /* This subst eliminates the need for another variable, and removes
        the common factor (for p=1) which is not needed to determine sign. */
@@ -120,7 +122,7 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
   ),
 
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_l_n[i]*rcoFac_l)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -130,7 +132,7 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
     ),
     printf(fh, "  } ~%"),
     /* Drag term on right side of interface */
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_r_n[i]*rcoFac_r)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/gkLBOFuncs-drag-surf.mac
@@ -3,7 +3,6 @@ load("out-scripts");
 load("nodal_operations/nodal_functions")$
 load("utilities")$
 load(stringproc)$
-
 fpprec : 24$
 
 /* This script generates the kernels for the surface term
@@ -121,7 +120,7 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
   ),
 
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -131,7 +130,7 @@ calcGkLBODragUpdateVPar(fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonunifor
     ),
     printf(fh, "  } ~%"),
     /* Drag term on right side of interface */
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/lenard_bernstein_operator/ms-gkLBO-diff-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-gkLBO-diff-boundary-surf.mac
@@ -63,7 +63,7 @@ for bInd : 1 thru length(bName) do (
           isNonuniform : gridType[gridInd],
           if isNonuniform then (gridStr : "nonuniform") else (gridStr : ""),
           disp(printf(false,sconcat("Creating diff boundary surface gyrokinetic LBO ~a",bName[bInd]," ~ax~av p~a"),gridStr,c,v,polyOrder)),
-          for dir:1 thru v do (
+          for dir : 1 thru v do (
             fname : sconcat("~/max-out/lbo_gyrokinetic_diff_boundary_surf", varsV[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder , ".c"),
             fh : openw(fname),
             funcName : sconcat("lbo_gyrokinetic_diff_boundary_surf", varsV[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder),

--- a/maxima/g0/lenard_bernstein_operator/ms-gkLBO-diff-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-gkLBO-diff-surf.mac
@@ -15,8 +15,8 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 minVdim_Ser : 1$    /* see begining of v loop below though. */
-maxCdim_Ser : 1$
-maxVdim_Ser : 1$
+maxCdim_Ser : 3$
+maxVdim_Ser : 2$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p = 1, is equivalent to Tensor */
@@ -25,8 +25,8 @@ minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 minVdim_Tensor : 1$    /* see begining of v loop below though. */
-maxCdim_Tensor : 0$
-maxVdim_Tensor : 0$
+maxCdim_Tensor : 1$
+maxVdim_Tensor : 2$
 
 /* Number of velocity dimensions allowed for each
    configuration-space dimension. */

--- a/maxima/g0/lenard_bernstein_operator/ms-gkLBO-diff-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-gkLBO-diff-surf.mac
@@ -15,8 +15,8 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 minVdim_Ser : 1$    /* see begining of v loop below though. */
-maxCdim_Ser : 3$
-maxVdim_Ser : 2$
+maxCdim_Ser : 1$
+maxVdim_Ser : 1$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p = 1, is equivalent to Tensor */
@@ -25,8 +25,8 @@ minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 minVdim_Tensor : 1$    /* see begining of v loop below though. */
-maxCdim_Tensor : 1$
-maxVdim_Tensor : 2$
+maxCdim_Tensor : 0$
+maxVdim_Tensor : 0$
 
 /* Number of velocity dimensions allowed for each
    configuration-space dimension. */

--- a/maxima/g0/lenard_bernstein_operator/ms-gkLBO-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-gkLBO-drag-boundary-surf.mac
@@ -62,7 +62,7 @@ for bInd : 1 thru length(bName) do (
           isNonuniform : gridType[gridInd],
           if isNonuniform then (gridStr : "nonuniform") else (gridStr : ""),
           disp(printf(false,sconcat("Creating drag boundary surface Gyrokinetic LBO ~a ",bName[bInd]," ~ax~av p~a"),gridStr,c,v,polyOrder)),
-          for dir:1 thru v do (
+          for dir : 1 thru v do (
             if dir = 1 then (
               fname : sconcat("~/max-out/lbo_gyrokinetic_drag_boundary_surf", varsV[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder , ".c"),
               fh : openw(fname),

--- a/maxima/g0/lenard_bernstein_operator/ms-gkLBO-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-gkLBO-drag-surf.mac
@@ -62,7 +62,7 @@ for bInd : 1 thru length(bName) do (
           isNonuniform : gridType[gridInd],
           if isNonuniform then (gridStr : "nonuniform") else (gridStr : ""),
           disp(printf(false,sconcat("Creating drag surface gyrokinetic LBO ~a",bName[bInd]," ~ax~av p~a"),gridStr,c,v,polyOrder)),
-          for dir:1 thru v do (
+          for dir : 1 thru v do (
             if dir = 1 then (
               fname : sconcat("~/max-out/lbo_gyrokinetic_drag_surf", varsVAll[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder , ".c"),
               fh : openw(fname),

--- a/maxima/g0/lenard_bernstein_operator/ms-vmLBO-diff-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-vmLBO-diff-boundary-surf.mac
@@ -11,12 +11,12 @@ load(stringproc)$
 /* ...... USER INPUTS........ */
 
 /* Serendipity basis. */
-minPolyOrder_Ser : 2$
+minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
-minVdim_Ser : 2$    /* see begining of v loop below though. */
-maxCdim_Ser : 1$
-maxVdim_Ser : 2$
+minVdim_Ser : 1$    /* see begining of v loop below though. */
+maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p = 1, is equivalent to Tensor */

--- a/maxima/g0/lenard_bernstein_operator/ms-vmLBO-diff-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-vmLBO-diff-surf.mac
@@ -61,7 +61,7 @@ for bInd : 1 thru length(bName) do (
           isNonuniform : gridType[gridInd],
           if isNonuniform then (gridStr : "nonuniform") else (gridStr : ""),
           disp(printf(false,sconcat("Creating diff surface Vlasov LBO ~a",bName[bInd]," ~ax~av p~a"),gridStr,c,v,polyOrder)),
-          for dir:1 thru v do (
+          for dir : 1 thru v do (
             fname : sconcat("~/max-out/lbo_vlasov_diff_surf", vvarsAll[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder , ".c"),
             fh : openw(fname),
             funcName : sconcat("lbo_vlasov_diff_surf", vvarsAll[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder),

--- a/maxima/g0/lenard_bernstein_operator/ms-vmLBO-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-vmLBO-drag-boundary-surf.mac
@@ -60,7 +60,7 @@ for bInd : 1 thru length(bName) do (
           isNonuniform : gridType[gridInd],
           if isNonuniform then (gridStr : "nonuniform") else (gridStr : ""),
           disp(printf(false,sconcat("Creating drag boundary surface Vlasov LBO ~a",bName[bInd]," ~ax~av p~a"),gridStr,c,v,polyOrder)),
-          for dir:1 thru v do (
+          for dir : 1 thru v do (
             fname : sconcat("~/max-out/lbo_vlasov_drag_boundary_surf", varsV[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder , ".c"),
             fh : openw(fname),
             funcName : sconcat("lbo_vlasov_drag_boundary_surf", varsV[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder),

--- a/maxima/g0/lenard_bernstein_operator/ms-vmLBO-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/ms-vmLBO-drag-surf.mac
@@ -60,7 +60,7 @@ for bInd : 1 thru length(bName) do (
           isNonuniform : gridType[gridInd],
           if isNonuniform then (gridStr : "nonuniform") else (gridStr : ""),
           disp(printf(false,sconcat("Creating drag surface Vlasov LBO ~a",bName[bInd]," ~ax~av p~a"),gridStr,c,v,polyOrder)),
-          for dir:1 thru v do (
+          for dir : 1 thru v do (
             fname : sconcat("~/max-out/lbo_vlasov_drag_surf", vvarsAll[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder , ".c"),
             fh : openw(fname),
             funcName : sconcat("lbo_vlasov_drag_surf", vvarsAll[dir],"_", gridStr, c, "x", v, "v_", bName[bInd], "_p", polyOrder),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-boundary-surf.mac
@@ -14,7 +14,7 @@ vidx1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 calcBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,NP,NC,pDim,vid1,surfVar,surfIntVars,bPp,fEdge_e,fSkin_e,bType,
    hl_e,hr_e,hOrder,hsol_l,hsol_r,nuVtSqSum_e,bSurf,facDiff_c,expr,i,facDiff_NoZero,
-   facDiff_e,vol_incr_e,Gdiff_c,Gdiff_e,edgeSurf_c,boundSurf_c,
+   facDiff_e,vol_incr_e,Gdiff_c,Gdiff_e,Gdiff2_c,Gdiff2_e,edgeSurf_c,boundSurf_c,
    edgeSurf_incr_c,boundSurf_incr_c,vol_out,diff_out,edge_out],
 
   /* Load basis of dimensionality requested. */
@@ -90,7 +90,7 @@ calcBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder) :=
 
   facDiff_e : doExpand(facDiff_NoZero, bC),
 
-  /* Volume increment (dimensional factors included at the end). */
+  /* Volume increment (dimensional factor included later). */
   vol_incr_e : calcInnerProdList(varsP, 1, diff(bP,surfVar,2), facDiff_e*fSkin_e),
   printf(fh, "  double vol_incr[~a] = {0.0}; ~%", NP),
   writeCExprs1(vol_incr, vol_incr_e),
@@ -101,32 +101,78 @@ calcBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder) :=
   printf(fh, "~%"),
   printf(fh, "  if (edge == -1) { ~%~%"),
     
-  Gdiff_c  : calcInnerProdList(varsP,1,bP,nuVtSqSum_e*hsol_r[2]),
-  Gdiff_e  : doExpand(Gdiff_c, bP),
+  if (polyOrder=1 or sdowncase(basisFun)="tensor") then (
+    /* This simplification only works for p=1 because it is a tensor product of
+       conf and velocity space (remains to be checked for tensor basis). */
 
-  edgeSurf_c : fullratsimp( calcInnerProdList(surfIntVars, 1, subst(surfVar=1,bP), subst(surfVar=1,Gdiff_e))
-                           -calcInnerProdList(surfIntVars, 1, subst(surfVar=1,bPp), nuVtSqSum_e*hsol_r[1]) ),
-  writeCExprs1(edgeSurf_incr, edgeSurf_c),
+    Gdiff_c  : calcInnerProdList(surfIntVars,1,bSurf,hsol_r[2]),
+    Gdiff2_c : calcInnerProdList(surfIntVars,1,bSurf,hsol_r[1]),
+  
+    printf(fh, "  double edgeSurf[~a] = {0.0}; ~%", NP),
+    edgeSurf_c : fullratsimp(calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bP), doExpand(Gdiff_c, bSurf))
+                            -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), doExpand(Gdiff2_c, bSurf))),
+    writeCExprs1(edgeSurf, edgeSurf_c),
+    printf(fh, "~%"),
+      
+    edgeSurf_incr_c : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(edgeSurf, bP)),
+  
+    printf(fh, "  double boundSurf[~a] = {0.0}; ~%", NP),
+    boundSurf_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), subst(surfVar=-1, fSkin_e)),
+    writeCExprs1(boundSurf, boundSurf_c),
+    printf(fh, "~%"),
+
+    boundSurf_incr_c : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(boundSurf, bP))
+  ) else (
+    Gdiff_c  : calcInnerProdList(varsP,1,bP,nuVtSqSum_e*hsol_r[2]),
+
+    edgeSurf_incr_c : fullratsimp(calcInnerProdList(surfIntVars, 1, subst(surfVar=1,bP), subst(surfVar=1,doExpand(Gdiff_c, bP)))
+                                 -calcInnerProdList(surfIntVars, 1, subst(surfVar=1,bPp), nuVtSqSum_e*hsol_r[1])),
+  
+    boundSurf_incr_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), subst(surfVar=-1,nuVtSqSum_e*fSkin_e))
+  ),
+  writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
   printf(fh, "~%"),
-
-  boundSurf_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), subst(surfVar=-1,nuVtSqSum_e*fSkin_e)),
-  writeCExprs1(boundSurf_incr, boundSurf_c),
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
   printf(fh, "~%"),
   
   /* otherwise edge == +1, we are doing the right edge boundary and the skin cell needs to be evauluated at -1 */
   printf(fh, "~%  } else { ~%~%"),
   
-  Gdiff_c  : calcInnerProdList(varsP,1,bP,nuVtSqSum_e*hsol_l[2]),
-  Gdiff_e  : doExpand(Gdiff_c, bP),
+  if (polyOrder=1 or sdowncase(basisFun)="tensor") then (
+    /* This simplification only works for p=1 because it is a tensor product of
+       conf and velocity space (remains to be checked for tensor basis). */
 
-  edgeSurf_c : fullratsimp( calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,bP), subst(surfVar=-1,Gdiff_e))
-                           -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,bPp), nuVtSqSum_e*hsol_l[1]) ),
-  writeCExprs1(edgeSurf_incr, edgeSurf_c),
+    Gdiff_c  : calcInnerProdList(surfIntVars,1,bSurf,hsol_l[2]),
+    Gdiff2_c : calcInnerProdList(surfIntVars,1,bSurf,hsol_l[1]),
+
+    printf(fh, "  double edgeSurf[~a] = {0.0}; ~%", NP),
+    edgeSurf_c : fullratsimp(calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bP), doExpand(Gdiff_c, bSurf))
+                            -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), doExpand(Gdiff2_c, bSurf))),
+    writeCExprs1(edgeSurf, edgeSurf_c),
+    printf(fh, "~%"),
+      
+    edgeSurf_incr_c : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(edgeSurf, bP)),
+
+    printf(fh, "  double boundSurf[~a] = {0.0}; ~%", NP),
+    boundSurf_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), subst(surfVar=1, fSkin_e)),
+    writeCExprs1(boundSurf, boundSurf_c),
+    printf(fh, "~%"),
+
+    boundSurf_incr_c : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(boundSurf, bP))
+  ) else (
+    Gdiff_c  : calcInnerProdList(varsP,1,bP,nuVtSqSum_e*hsol_l[2]),
+
+    edgeSurf_incr_c : fullratsimp(calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,bP), subst(surfVar=-1,doExpand(Gdiff_c, bP)))
+                                 -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,bPp), nuVtSqSum_e*hsol_l[1])),
+  
+    boundSurf_incr_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), subst(surfVar=1,nuVtSqSum_e*fSkin_e))
+  ),
+
+  writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
+  printf(fh, "~%"),
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
   printf(fh, "~%"),
 
-  boundSurf_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), subst(surfVar=1,nuVtSqSum_e*fSkin_e)),
-  writeCExprs1(boundSurf_incr, boundSurf_c),
-  printf(fh, "~%"),
   printf(fh, "  } ~%"),
   printf(fh, "~%"),
 

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-boundary-surf.mac
@@ -14,9 +14,8 @@ vidx1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 calcBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,NP,NC,pDim,vid1,surfVar,surfIntVars,bPp,fEdge_e,fSkin_e,bType,
    hl_e,hr_e,hOrder,hsol_l,hsol_r,nuVtSqSum_e,bSurf,facDiff_c,expr,i,facDiff_NoZero,
-   facDiff_e,vol_incr_e,Gdiff_l_c,Gdiff_r_c,Gdiff_l_e,Gdiff_r_e,Gdiff2_l_c,Gdiff2_r_c,
-   Gdiff2_l_e,Gdiff2_r_e,temp_diff_le,temp_diff_re,temp_edge_le,temp_edge_re,diff_incr_le,
-   diff_incr_re,edge_incr_le,edge_incr_re,vol_out,diff_out,edge_out],
+   facDiff_e,vol_incr_e,Gdiff_c,Gdiff_e,edgeSurf_c,boundSurf_c,
+   edgeSurf_incr_c,boundSurf_incr_c,vol_out,diff_out,edge_out],
 
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
@@ -91,71 +90,49 @@ calcBoundaryDiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder) :=
 
   facDiff_e : doExpand(facDiff_NoZero, bC),
 
-  /* Volume increment from configuration space. */
-  vol_incr_e : rdvSq4*calcInnerProdList(varsP, 1, diff(bP,surfVar,2), facDiff_e*fSkin_e),
+  /* Volume increment (dimensional factors included at the end). */
+  vol_incr_e : calcInnerProdList(varsP, 1, diff(bP,surfVar,2), facDiff_e*fSkin_e),
   printf(fh, "  double vol_incr[~a] = {0.0}; ~%", NP),
   writeCExprs1(vol_incr, vol_incr_e),
   printf(fh, "~%"),
     
-  Gdiff_l_c : calcInnerProdList(surfIntVars,1,bSurf,hsol_l[2]),
-  Gdiff_r_c : calcInnerProdList(surfIntVars,1,bSurf,hsol_r[2]),
-  Gdiff_l_e : doExpand(Gdiff_l_c, bSurf),
-  Gdiff_r_e : doExpand(Gdiff_r_c, bSurf),
-
-  Gdiff2_l_c : calcInnerProdList(surfIntVars,1,bSurf,hsol_l[1]),
-  Gdiff2_r_c : calcInnerProdList(surfIntVars,1,bSurf,hsol_r[1]),
-  Gdiff2_l_e : doExpand(Gdiff2_l_c, bSurf),
-  Gdiff2_r_e : doExpand(Gdiff2_r_c, bSurf),
-
-  printf(fh, "  double temp_diff[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double temp_edge[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double diff_incr[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double edge_incr[~a] = {0.0}; ~%", NP),
+  printf(fh, "  double edgeSurf_incr[~a] = {0.0}; ~%", NP),
+  printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", NP),
   printf(fh, "~%"),
   printf(fh, "  if (edge == -1) { ~%~%"),
     
-  temp_diff_re : fullratsimp(calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bP), Gdiff_r_e)
-                            -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), Gdiff2_r_e)),
-  writeCExprs1(temp_diff, temp_diff_re),
-  printf(fh, "~%"),
-    
-  temp_edge_le : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), subst(surfVar=-1, fSkin_e)),
-  writeCExprs1(temp_edge, temp_edge_le),
-  printf(fh, "~%"),
-    
-  diff_incr_re : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(temp_diff, bP)),
-  writeCExprs1(diff_incr, diff_incr_re),
+  Gdiff_c  : calcInnerProdList(varsP,1,bP,nuVtSqSum_e*hsol_r[2]),
+  Gdiff_e  : doExpand(Gdiff_c, bP),
+
+  edgeSurf_c : fullratsimp( calcInnerProdList(surfIntVars, 1, subst(surfVar=1,bP), subst(surfVar=1,Gdiff_e))
+                           -calcInnerProdList(surfIntVars, 1, subst(surfVar=1,bPp), nuVtSqSum_e*hsol_r[1]) ),
+  writeCExprs1(edgeSurf_incr, edgeSurf_c),
   printf(fh, "~%"),
 
-  edge_incr_le : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(temp_edge, bP)),
-  writeCExprs1(edge_incr, edge_incr_le),
+  boundSurf_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), subst(surfVar=-1,nuVtSqSum_e*fSkin_e)),
+  writeCExprs1(boundSurf_incr, boundSurf_c),
   printf(fh, "~%"),
   
   /* otherwise edge == +1, we are doing the right edge boundary and the skin cell needs to be evauluated at -1 */
   printf(fh, "~%  } else { ~%~%"),
   
-  temp_diff_le : fullratsimp(calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bP), Gdiff_l_e)
-                            -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1, bPp), Gdiff2_l_e)),
-  writeCExprs1(temp_diff, temp_diff_le),
-  printf(fh, "~%"),
-    
-  temp_edge_re : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), subst(surfVar=1, fSkin_e)),
-  writeCExprs1(temp_edge, temp_edge_re),
-  printf(fh, "~%"),
-    
-  diff_incr_le : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(temp_diff, bP)),
-  writeCExprs1(diff_incr, diff_incr_le),
+  Gdiff_c  : calcInnerProdList(varsP,1,bP,nuVtSqSum_e*hsol_l[2]),
+  Gdiff_e  : doExpand(Gdiff_c, bP),
+
+  edgeSurf_c : fullratsimp( calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,bP), subst(surfVar=-1,Gdiff_e))
+                           -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,bPp), nuVtSqSum_e*hsol_l[1]) ),
+  writeCExprs1(edgeSurf_incr, edgeSurf_c),
   printf(fh, "~%"),
 
-  edge_incr_re : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(temp_edge, bP)),
-  writeCExprs1(edge_incr, edge_incr_re),
+  boundSurf_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1, bPp), subst(surfVar=1,nuVtSqSum_e*fSkin_e)),
+  writeCExprs1(boundSurf_incr, boundSurf_c),
   printf(fh, "~%"),
   printf(fh, "  } ~%"),
   printf(fh, "~%"),
 
-  vol_out : makelist(vol_incr[i-1],i,1,NP),
-  diff_out : makelist(diff_incr[i-1],i,1,NP),
-  edge_out : makelist(edge_incr[i-1],i,1,NP),
-  writeCIncrExprs1(out, rdvSq4*(diff_out + edge_out) + vol_out),
+  vol_out  : makelist(vol_incr[i-1],i,1,NP),
+  diff_out : makelist(edgeSurf_incr[i-1],i,1,NP),
+  edge_out : makelist(boundSurf_incr[i-1],i,1,NP),
+  writeCIncrExprsNoExpand1(out, rdvSq4*(diff_out + edge_out + vol_out)),
   printf(fh, "} ~%")
 );

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-diff-surf.mac
@@ -11,7 +11,7 @@ vvarsAll : [vx, vy, vz]$
 vidx1(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
 
 calcVmLBODiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNonuniform) := block(
-  [varsC,bC,varsP,bP,NP,NC,pDim,vid1,surfVar,bType,h_e,nuVtSqSum_e,temp_diff_c,diff_incr_c],
+  [varsC,bC,varsP,bP,NP,NC,pDim,vid1,surfVar,bType,h_e,nuVtSqSum_e,f_xx_c,f_xx_e,incr_c],
 
   /* Load basis of dimensionality requested. */
   [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
@@ -46,21 +46,30 @@ calcVmLBODiffUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   printf(fh, "~%"),
 
   printf(fh, "  double rdvSq4 = 4.0/(dxv[~a]*dxv[~a]); ~%", vid1[dir], vid1[dir]),
-  printf(fh, "  double temp_diff[~a] = {0.0}; ~%", NP),
-  printf(fh, "  double diff_incr[~a] = {0.0}; ~%", NP),
+  printf(fh, "  double incr[~a]; ~%", NP),
   printf(fh, "~%"),
-    
-  /* Write out the second derivative of the recovered distribution. */
+
   nuVtSqSum_e : doExpand1(nuVtSqSum,bC),
     
-  temp_diff_c : calcInnerProdList(varsP, 1, bP, diff(h_e, surfVar, 2)),
-  writeCExprs1(temp_diff, temp_diff_c),
+  if (polyOrder=1 or sdowncase(basisFun)="tensor") then (
+    /* This simplification only works for p=1 because it is a tensor product of
+       conf and velocity space (remains to be checked for tensor basis). */
+
+    /* Write out the second derivative of the recovered distribution. */
+    printf(fh, "  double f_xx[~a] = {0.0}; ~%", NP),
+    f_xx_c : calcInnerProdList(varsP, 1, bP, diff(h_e, surfVar, 2)),
+    writeCExprs1(f_xx, f_xx_c),
+    printf(fh, "~%"),
+
+    f_xx_e : doExpand(makelistNoZeros(f_xx_c, f_xx),bP)
+  ) else (
+    f_xx_e : diff(h_e, surfVar, 2)
+  ),
+
+  incr_c : calcInnerProdList(varsP, nuVtSqSum_e, bP, f_xx_e),
+  writeCExprs1(incr, incr_c),
   printf(fh, "~%"),
     
-  diff_incr_c : calcInnerProdList(varsP, nuVtSqSum_e, bP, doExpand1(temp_diff,bP)),
-  writeCExprs1(diff_incr, diff_incr_c),
-  printf(fh, "~%"),
-  
-  writeCIncrExprs1(out, rdvSq4*makelist(diff_incr[i-1],i,1,NP)), 
+  writeCIncrExprs1(out, rdvSq4*makelistNoZeros(incr_c, incr)),
   printf(fh, "} ~%")
 );

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-boundary-surf.mac
@@ -4,7 +4,6 @@ load("nodal_operations/nodal_functions")$
 load("recovery")$
 load("utilities")$
 load(stringproc)$
-
 fpprec : 24$
 
 /* This script generates the kernels for the boundary surface term
@@ -108,9 +107,11 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   /* Write out fUpwindQuad for the far left edge */
   /* Within the skin cell, we need alpha_r (alpha evaluated at +1)
      just like how the skin cell is evaluated at +1 */
+  alphaSimp(a) := float(expand(fullratsimp(a))),
   basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
   rcoFac_l : 1.,  rcoFac_r : 1.,
   if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    alphaSimp(a) := fullratsimp(a),
     basisStr : sconcat("hyb_", cdim, "x", vdim, "v"),
     /* This subst eliminates the need for another variable, and removes
        the common factor (for p=1) which is not needed to determine sign. */
@@ -118,7 +119,7 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
     rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1])
   ),
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_r_n[i]*rcoFac_r)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -174,7 +175,7 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   /* Within the skin cell, we need alpha_l (alpha evaluated at -1)
      just like how the skin cell is evaluated at -1 */
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_l_n[i]*rcoFac_l)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-boundary-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-boundary-surf.mac
@@ -118,7 +118,7 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
     rcoFac_r : 1./(content(alphaOrd_r_n[1],alphaDrSurf[0])[1])
   ),
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fSkin); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -174,7 +174,7 @@ calcVmLBOBoundaryDragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrde
   /* Within the skin cell, we need alpha_l (alpha evaluated at -1)
      just like how the skin cell is evaluated at -1 */
   for i : 1 thru numNodesConfig do (
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fEdge); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-surf.mac
@@ -124,7 +124,7 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
 
   for i : 1 thru numNodesConfig do (
     /* Drag term on left side of interface */
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_l_n[i]*rcoFac_l)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -134,7 +134,7 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
     ),
     printf(fh, "  } ~%"),
     /* Drag term on right side of interface */
-    printf(fh, "  if (~a < 0) { ~%", fullratsimp(alphaOrd_r_n[i]*rcoFac_r)),
+    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-surf.mac
+++ b/maxima/g0/lenard_bernstein_operator/vmLBOFuncs-drag-surf.mac
@@ -112,9 +112,11 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
   printf(fh, "  double Ghat_r[~a] = {0.0}; ~%", length(bSurf)),
   printf(fh, "~%"),
 
+  alphaSimp(a) := float(expand(fullratsimp(a))),
   basisStr : sconcat(basisFun, "_", cdim+vdim, "x"),
   rcoFac_l : 1.,  rcoFac_r : 1.,
   if polyOrder=1 then (  /* Force p=1 to use hybrid basis. */
+    alphaSimp(a) := fullratsimp(a),
     basisStr : sconcat("hyb_", cdim, "x", vdim, "v"),
     /* This subst eliminates the need for another variable, and removes
        the common factor (for p=1) which is not needed to determine sign. */
@@ -124,7 +126,7 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
 
   for i : 1 thru numNodesConfig do (
     /* Drag term on left side of interface */
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_l_n[i]*rcoFac_l)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_l_n[i]*rcoFac_l)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_l[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fl); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),
@@ -134,7 +136,7 @@ calcVmLBODragUpdateInDir(dir, fh, funcNm, cdim, vdim, basisFun, polyOrder, isNon
     ),
     printf(fh, "  } ~%"),
     /* Drag term on right side of interface */
-    printf(fh, "  if (~a < 0) { ~%", float(expand(fullratsimp(alphaOrd_r_n[i]*rcoFac_r)))),
+    printf(fh, "  if (~a < 0) { ~%", alphaSimp(alphaOrd_r_n[i]*rcoFac_r)),
     for j : 1 thru numNodesVel do (
       printf(fh, "    fUpwindQuad_r[~a] = ~a_p~a_surfx~a_eval_quad_node_~a_r(fc); ~%", (j-1)+(i-1)*numNodesVel, basisStr, polyOrder, cdim+dir, (j-1)+(i-1)*numNodesVel)
     ),

--- a/maxima/g0/utilities.mac
+++ b/maxima/g0/utilities.mac
@@ -8,3 +8,4 @@ isInList(e, lst) := block([],
 /* Create a list of coefficients that are only nonzero (S[i-1])
    if the corresponding vals entry is nonzero. */
 doMakeExprLst(vals, S) := makelist(if vals[i] # 0 then S[i-1] else 0, i, 1, length(vals))$
+makelistNoZeros(vals, name) := makelist(if vals[i] # 0 then name[i-1] else 0, i, 1, length(vals))$


### PR DESCRIPTION
This goes with gkylzero pull request #121: https://github.com/ammarhakim/gkylzero/pull/121

Some simplifications had been done to the diffusion term in the LBO, which broke energy conservation for p>1. This PR corrects that (see the link above for an explanation).

Further optimization of LBO diffusion terms is possible, but we leave that for future work.