### PR TITLE
Implement ambipolar Boltzmann electron field solver model

### DIFF
--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -40,10 +40,8 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   /* Get the Gaussian quadrature weights and ordinates (in [-1,1] space) for
      quadrature in one dimension lower. */
   if dim>1 then (
-    ordWeight : gaussOrdWeight(numQuad,dim-1),
-    normOrds  : float(ordWeight[1]),
-    weights   : float(ordWeight[2]),
-    ordNum    : length(normOrds)
+    [normOrds, weights] : gaussOrdWeight(numQuad,dim-1),
+    ordNum : length(normOrds)
   ),
 
   boundaryStr : ["lower","upper"],
@@ -87,10 +85,12 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
     m0Ion_e : doExpand(m0Ion_c,basis),
 
     m0IonS_c : calcInnerProdList(vars, 1, basis, subst(sheathVar=skinEvSign[bS],m0Ion_e)),
+    printf(fh,"  // Particle number density evaluate at the sheath entrance~%"),
     expr : float(m0IonS_c),
     for i : 1 thru length(expr) do (
-      if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", out[(bS-1)*2*numB+i-1], gcfac(expr[i]))
+      if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", out[i-1], gcfac(expr[i]))
     ),
+    printf(fh,"~%"),
 
     /* Compute the sheath potential
          phiS = (T_e/q_e)*log( sqrt(2*pi)*GammaJac_i/(n_i*sqrt(T_e/m_e)) )
@@ -138,14 +138,15 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
         )
       ),
       writeCExprsNoExpand1(phiSlowD, phiSlowD_c),
-      phiSlowD_e : doExpand(phiSlowD_c, basisLowD)
+      phiSlowD_e : doExpand(phiSlowD_c, basisLowD),
+      printf(fh,"~%")
     ),
-    printf(fh,"~%"),
 
     phiS_c : calcInnerProdList(vars, 1, basis, phiSlowD_e),
+    printf(fh,"  // Sheath potential~%"),
     expr : float(phiS_c),
     for i : 1 thru length(expr) do (
-      if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", out[((bS-1)*2+1)*numB+i-1], gcfac(expr[i]))
+      if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", out[numB+i-1], gcfac(expr[i]))
     ),
     printf(fh,"~%"),
 
@@ -156,7 +157,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
 
 genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   /* Compute the potential in the domain volume using Gaussian quadrature. */
-  [numQuad,vars,basis,numB,ordWeight,normOrds,weights,ordNum,m0JacIon_e,
+  [numQuad,vars,basis,numB,normOrds,weights,ordNum,m0JacIon_e,
   jacInv_e,m0Ion_c,m0Ion_e,m0Ion_noZero_c,m0IonS_e,phiS_e,m0Ion_n,m0IonS_n,
   phiS_n,nOrd,cSub,phi_n,phi_c],
 
@@ -166,10 +167,8 @@ genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   numB : length(basis),
 
   /* Get the Gaussian quadrature weights and ordinates (in [-1,1] space) */
-  ordWeight : gaussOrdWeight(numQuad,dim),
-  normOrds  : float(ordWeight[1]),
-  weights   : float(ordWeight[2]),
-  ordNum    : length(normOrds),
+  [normOrds, weights] : gaussOrdWeight(numQuad,dim),
+  ordNum : length(normOrds),
 
   printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi) ~%{ ~%")),
   printf(fh,"  // q_e:        electron change.~%"),

--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -48,7 +48,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   ghostEvSign : [1, -1],  skinEvSign  : [-1, 1],
 
   for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(const double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out) ~%{ ~%"), boundaryStr[bS]),
+    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out) ~%{ ~%"), boundaryStr[bS]),
     printf(fh,"  // sheathDirDx: cell length in direction of the sheath.~%"),
     printf(fh,"  // q_e:         electron change.~%"),
     printf(fh,"  // m_e:         electron mass.~%"),

--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -1,0 +1,232 @@
+/*
+  Functions to generate kernels that compute the sheath potential, the
+  sheath entrance ion density, and the potential in the whole domain,
+  assume ambipolar fluxes and Boltzmann electrons.
+*/
+
+load("modal-basis");
+load("out-scripts");
+load(stringproc)$
+load("nodal_operations/quadrature_functions")$
+fpprec : 24$
+
+genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
+  /* Compute the sheath entrance potential using Gaussian quadrature. */
+  [numQuad,vars,basis,numB,sheathDir,sheathVar,sheathSurfVars,varsLowD,basisLowD,numBLowD,
+   boundaryStr,ghostEvSign,skinEvSign,GammaJacIon_e,GammaJacIonB_c,GammaJacIonB_noZero_c,
+   GammaJacIonB_e,m0JacIon_e,m0JacIonB_c,m0JacIonB_noZero_c,m0JacIonB_e,phiSlowD_c,
+   phiSlowD_e,phiS_c,expr,jacInv_e,m0Ion_c,m0Ion_e,m0IonS_c],
+
+  numQuad : polyOrder+1, /* Number of quarature points in 1D. */
+
+  [vars, basis] : loadBasis(basisNm, dim, polyOrder),
+  numB : length(basis),
+
+  sheathDir : dim,  /* Assume the last dimension is the sheath direction. */
+  sheathVar : vars[sheathDir],
+  sheathSurfVars : delete(sheathVar, vars),
+
+  /* Load a basis of one fewer dimension for projecting onto sheath surface. */
+  if dim>1 then (
+    [basisLowD, varsLowD] : loadBasis(basisNm, dim-1, polyOrder),
+    subList   : makelist(varsLowD[i]=sheathSurfVars[i],i,1,dim-1),
+    varsLowD  : psubst(subList, varsLowD),
+    basisLowD : psubst(subList, basisLowD)
+  ) else (
+    varsLowD : [x],  basisLowD : [1/innerProd(varsLowD,1,1,1)]
+  ),
+  numBLowD : length(basisLowD),
+
+  /* Get the Gaussian quadrature weights and ordinates (in [-1,1] space) for
+     quadrature in one dimension lower. */
+  if dim>1 then (
+    ordWeight : gaussOrdWeight(numQuad,dim-1),
+    normOrds  : float(ordWeight[1]),
+    weights   : float(ordWeight[2]),
+    ordNum    : length(normOrds)
+  ),
+
+  boundaryStr : ["lower","upper"],
+  ghostEvSign : [1, -1],  skinEvSign  : [-1, 1],
+
+  for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
+    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(const double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out) ~%{ ~%"), boundaryStr[bS]),
+    printf(fh,"  // sheathDirDx: cell length in direction of the sheath.~%"),
+    printf(fh,"  // q_e:         electron change.~%"),
+    printf(fh,"  // m_e:         electron mass.~%"),
+    printf(fh,"  // T_e:         electron temperature.~%"),
+    printf(fh,"  // jacInv:      reciprocal of the geometry Jacobian (1/J).~%"),
+    printf(fh,"  // GammaJac_i:  ion particle flux (times the Jacobian) through sheath entrance.~%"),
+    printf(fh,"  // m0JacIon:    ion density (times the geometry Jacobian).~%"),
+    printf(fh,"  // out:         ion density and electrostatic potential at the sheath entrance.~%"),
+    printf(fh,"~%"),
+
+    /* Particle flux expanded in basis. Need to multiply by an extra dx/2
+       because of the way the boundary fluxes are computed. */
+    GammaJacIon_e : (sheathDirDx/2)*doExpand1(GammaJac_i, basis),
+    /* Evaluate the (ghost cell) flux at the boundary surface. */
+    GammaJacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=ghostEvSign[bS], GammaJacIon_e)),
+    GammaJacIonB_noZero_c : doMakeExprLst(GammaJacIonB_c, GammaJacIonB),
+    GammaJacIonB_e : doExpand(GammaJacIonB_noZero_c,basisLowD),
+    printf(fh,"  double GammaJacIonB[~a];~%", numBLowD),
+    writeCExprs1(GammaJacIonB, GammaJacIonB_c),
+    printf(fh,"~%"),
+
+    m0JacIon_e : doExpand1(m0JacIon, basis),
+    /* Evaluate the (skin cell) ion density at the boundary surface. */
+    m0JacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=skinEvSign[bS], m0JacIon_e)),
+    m0JacIonB_noZero_c : doMakeExprLst(m0JacIonB_c, m0JacIonB),
+    m0JacIonB_e : doExpand(m0JacIonB_noZero_c,basisLowD),
+    printf(fh,"  double m0JacIonB[~a];~%", numBLowD),
+    writeCExprs1(m0JacIonB, m0JacIonB_c),
+    printf(fh,"~%"),
+
+    /* Density at the sheath entrance. */
+    jacInv_e : doExpand1(jacInv,basis),
+    m0Ion_c : calcInnerProdList(vars, jacInv_e, basis, m0JacIon_e),
+    m0Ion_e : doExpand(m0Ion_c,basis),
+
+    m0IonS_c : calcInnerProdList(vars, 1, basis, subst(sheathVar=skinEvSign[bS],m0Ion_e)),
+    expr : float(m0IonS_c),
+    for i : 1 thru length(expr) do (
+      if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", out[(bS-1)*2*numB+i-1], gcfac(expr[i]))
+    ),
+
+    /* Compute the sheath potential
+         phiS = (T_e/q_e)*log( sqrt(2*pi)*GammaJac_i/(n_i*sqrt(T_e/m_e)) )
+       using quadrature. If dim=1 no quadrature is needed. */
+    phiSlowD_c : makelist(0,i,1,numBLowD),
+    if dim=1 then (
+      printf(fh,"  double phiS_qp[1];~%"),
+      phiSlowD_c : [(T_e/q_e)*log(sqrt(2*%pi)*GammaJacIonB_e/(m0JacIonB_e*sqrt(T_e/m_e)))],
+      printf(fh,"  if ((isfinite(~a)) && (~a>0.) && (~a>0.)) {~%",GammaJacIonB_e,GammaJacIonB_e,m0JacIonB_e),
+      printf(fh,"    phiS_qp[0] = ~a;~%",float(expand(phiSlowD_c[1]))),
+      printf(fh,"  } else {~%"),
+      printf(fh,"    phiS_qp[0] = 0.0;~%"),
+      printf(fh,"  }~%"),
+      printf(fh,"~%"),
+      phiSlowD_e : phiS_qp[0]
+    ) else (
+      m0JacIonB_n    : makelist(0,i,1,ordNum),
+      GammaJacIonB_n : makelist(0,i,1,ordNum),
+      for i : 1 thru ordNum do (
+        nOrd : normOrds[i],
+        cSub : makelist(varsLowD[d]=normOrds[i][d],d,1,dim-1),
+
+        m0JacIonB_n[i]    : subst(cSub, m0JacIonB_e),
+        GammaJacIonB_n[i] : subst(cSub, GammaJacIonB_e)
+      ),
+
+      printf(fh,"  double phiS_qp[~a];~%", ordNum),
+      phiS_n : makelist(0,i,1,ordNum),
+      for i : 1 thru ordNum do (
+        phiS_n[i] : (T_e/q_e)**log(sqrt(2*%pi)*GammaJacIonB_n[i]/(m0JacIonB_n[i]*sqrt(T_e/m_e))),
+        printf(fh,"  if ((isfinite(~a)) && (~a>0.) && (~a>0.)) {~%",GammaJacIonB_n[i],GammaJacIonB_n[i],m0JacIonB_n[i]),
+        printf(fh,"    phiS_qp[~a] = ~a;~%",i-1,float(expand(phiS_n[i]))),
+        printf(fh,"  } else {~%"),
+        printf(fh,"    phiS_qp[~a] = 0.0;~%",i-1),
+        printf(fh,"  }~%")
+      ),
+      printf(fh,"~%"),
+
+      phiSlowD_c : makelist(0,i,1,numBLowD),
+      for i : 1 thru ordNum do (
+        nOrd : normOrds[i],
+        /* Add contribution to each DG coefficient. */
+        for k : 1 thru numBLowD do (
+          phiSlowD_c[k] : phiSlowD_c[k]+weights[i]*subst(makelist(varsLowD[d]=nOrd[d],d,1,dim-1),basisLowD[k])*phiS_qp[i-1]
+        )
+      ),
+      writeCExprsNoExpand1(phiSlowD, phiSlowD_c),
+      phiSlowD_e : doExpand(phiSlowD_c, basisLowD)
+    ),
+    printf(fh,"~%"),
+
+    phiS_c : calcInnerProdList(vars, 1, basis, phiSlowD_e),
+    expr : float(phiS_c),
+    for i : 1 thru length(expr) do (
+      if expr[i] # 0.0 then printf(fh, "  ~a = ~a; ~%", out[((bS-1)*2+1)*numB+i-1], gcfac(expr[i]))
+    ),
+    printf(fh,"~%"),
+
+    printf(fh, "}~%"),
+    printf(fh, "~%")
+  )
+)$
+
+genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
+  /* Compute the potential in the domain volume using Gaussian quadrature. */
+  [numQuad,vars,basis,numB,ordWeight,normOrds,weights,ordNum,m0JacIon_e,
+  jacInv_e,m0Ion_c,m0Ion_e,m0Ion_noZero_c,m0IonS_e,phiS_e,m0Ion_n,m0IonS_n,
+  phiS_n,nOrd,cSub,phi_n,phi_c],
+
+  numQuad : polyOrder+1, /* Number of quarature points in 1D. */
+
+  [vars, basis] : loadBasis(basisNm, dim, polyOrder),
+  numB : length(basis),
+
+  /* Get the Gaussian quadrature weights and ordinates (in [-1,1] space) */
+  ordWeight : gaussOrdWeight(numQuad,dim),
+  normOrds  : float(ordWeight[1]),
+  weights   : float(ordWeight[2]),
+  ordNum    : length(normOrds),
+
+  printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi) ~%{ ~%")),
+  printf(fh,"  // q_e:        electron change.~%"),
+  printf(fh,"  // T_e:        electron temperature.~%"),
+  printf(fh,"  // jacInv:     reciprocal of the geometry Jacobian (1/J).~%"),
+  printf(fh,"  // m0JacIon:   ion density.~%"),
+  printf(fh,"  // sheathvals: ion density and electrostatic potential at the sheath entrance.~%"),
+  printf(fh,"  // phi:        electrostatic potential in domain volume.~%"),
+  printf(fh,"~%"),
+
+  m0JacIon_e : doExpand1(m0JacIon, basis),
+
+  jacInv_e : doExpand1(jacInv,basis),
+  m0Ion_c : calcInnerProdList(vars, jacInv_e, basis, m0JacIon_e),
+  m0Ion_e : doExpand(m0Ion_c,basis),
+  m0Ion_noZero_c : doMakeExprLst(m0Ion_c, m0Ion),
+  m0Ion_e : doExpand(m0Ion_noZero_c,basis),
+  printf(fh,"  double m0Ion[~a];~%", numB),
+  writeCExprs1(m0Ion, m0Ion_c),
+  printf(fh,"~%"),
+
+  m0IonS_e : doExpand(makelist(sheathvals[i-1],i,1,numB), basis),
+  phiS_e   : doExpand(makelist(sheathvals[numB+i-1],i,1,numB), basis),
+
+  m0Ion_n  : makelist(0,i,1,ordNum),
+  m0IonS_n : makelist(0,i,1,ordNum),
+  phiS_n   : makelist(0,i,1,ordNum),
+  for i : 1 thru ordNum do (
+    nOrd : normOrds[i],
+    cSub : makelist(vars[d]=normOrds[i][d],d,1,dim),
+
+    m0Ion_n[i]  : subst(cSub, m0Ion_e),
+    /* In principle the following two should be evaluated at the boundary like
+         m0IonS_n[i] : subst(cSub, subst(sheathVar=skinEvSign[bS],m0IonS_e)),
+       but the second DG coefficient in m0IonS_e (for 1x p=1) is zero anyway. */
+    m0IonS_n[i] : subst(cSub, m0IonS_e),
+    phiS_n[i]   : subst(cSub, phiS_e)
+  ),
+
+  phi_n : makelist(0,i,1,ordNum),
+  for i : 1 thru ordNum do (
+    phi_n[i] : phiS_n[i] - (T_e/q_e)*log(m0Ion_n[i]/m0IonS_n[i])
+  ),
+  printf(fh,"  double phi_qp[~a];~%", ordNum),
+  writeCExprs1(phi_qp, phi_n),
+  printf(fh,"~%"),
+
+  phi_c : makelist(0,i,1,numB),
+  for i : 1 thru ordNum do (
+    nOrd : normOrds[i],
+    /* Add contribution to each DG coefficient. */
+    for k : 1 thru numB do (
+      phi_c[k] : phi_c[k]+weights[i]*subst(makelist(vars[d]=nOrd[d],d,1,dim),basis[k])*phi_qp[i-1]
+    )
+  ),
+
+  writeCExprsNoExpand1(phi, phi_c),
+  printf(fh, "}~%"),
+  printf(fh, "~%")
+)$

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
@@ -1,0 +1,40 @@
+/* Create header file for updater computing the sheath potential
+   and the potential everywhere via quadrature assuming ambipolar
+   sheath fluxes and Boltzmann electrons. */
+
+polyOrderMax : 2$
+bName        : ["ser","tensor"]$
+boundaryStr  : ["lower","upper"]$
+
+fh : openw("~/max-out/gkyl_ambi_bolt_potential_kernels.h")$
+
+printf(fh, "#pragma once~%")$
+printf(fh, "~%")$
+printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "#include <math>~%~%")$
+printf(fh, "~%")$
+
+printf(fh, "EXTERN_C_BEG~%")$
+printf(fh, "~%")$
+
+for bInd : 1 thru length(bName) do (
+
+   for pi : 1 thru polyOrderMax do (
+     for ci : 1 thru 3 do (
+
+       for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
+         printf(fh, "  void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(const double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
+       ),
+       printf(fh, "  void ambi_bolt_potential_phi_calc_~ax_~a_p~a(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi); ~%", ci, bName[bInd], pi),
+       printf(fh, "~%")
+
+     ),
+     printf(fh, "~%")
+   )
+
+)$
+
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_END~%")$
+printf(fh, "~%")$
+close(fh)$

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
@@ -8,6 +8,13 @@ boundaryStr  : ["lower","upper"]$
 
 fh : openw("~/max-out/gkyl_ambi_bolt_potential_kernels.h")$
 
+printf(fh, "// Gkyl ------------------------------------------------------------------------~%")$
+printf(fh, "//~%")$
+printf(fh, "// Header file for Ambipolar Boltzmann electron potential solver.~%")$
+printf(fh, "//~%")$
+printf(fh, "//    _______     ___~%")$
+printf(fh, "// + 6 @ |||| # P ||| +~%")$
+printf(fh, "//------------------------------------------------------------------------------~%")$
 printf(fh, "#pragma once~%")$
 printf(fh, "~%")$
 printf(fh, "#include <gkyl_util.h>~%")$
@@ -23,9 +30,9 @@ for bInd : 1 thru length(bName) do (
      for ci : 1 thru 3 do (
 
        for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-         printf(fh, "  void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(const double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
+         printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(const double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
        ),
-       printf(fh, "  void ambi_bolt_potential_phi_calc_~ax_~a_p~a(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi); ~%", ci, bName[bInd], pi),
+       printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_phi_calc_~ax_~a_p~a(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi); ~%", ci, bName[bInd], pi),
        printf(fh, "~%")
 
      ),

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
@@ -30,7 +30,7 @@ for bInd : 1 thru length(bName) do (
      for ci : 1 thru 3 do (
 
        for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-         printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(const double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
+         printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
        ),
        printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_phi_calc_~ax_~a_p~a(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi); ~%", ci, bName[bInd], pi),
        printf(fh, "~%")

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential.mac
@@ -1,0 +1,48 @@
+/* Create kernels to compute the sheath potential and the potential
+   everywhere via quadrature assuming ambipolar sheath fluxes
+   and electron adiabaticity. */
+load("ambi_bolt_potential/ambi_bolt_potential_funcs")$
+load(stringproc)$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+maxPolyOrder_Ser : 2$
+minDim_Ser : 1$
+maxDim_Ser : 1$
+
+/* Tensor basis. */
+maxPolyOrder_Tensor : 2$
+minDim_Tensor : 1$
+maxDim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+maxPolyOrder : [maxPolyOrder_Ser,maxPolyOrder_Tensor]$
+minDim       : [minDim_Ser,minDim_Tensor]$
+maxDim       : [maxDim_Ser,maxDim_Tensor]$
+
+for bInd : 1 thru length(bName) do (
+  for cD : minDim[bInd] thru maxDim[bInd] do (
+    maxPolyOrderB : maxPolyOrder[bInd],
+
+    for polyOrder : 1 thru maxPolyOrderB do (
+
+      disp(printf(false,sconcat("Creating asheath_potential_ ~ax p~a ",bName[bInd]),cD,polyOrder)),
+
+      fname : sconcat("~/max-out/ambi_bolt_potential_", cD, "x_p", polyOrder, "_", bName[bInd], ".c"),
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_ambi_bolt_potential_kernels.h>~%~%"),
+
+      funcName : sconcat("ambi_bolt_potential_sheath_calc_~a_", cD, "x_", bName[bInd], "_p", polyOrder),
+      genSheathCalcKernel(fh, funcName, cD, bName[bInd], polyOrder),
+
+      funcName : sconcat("ambi_bolt_potential_phi_calc_", cD, "x_", bName[bInd], "_p", polyOrder),
+      genPhiCalcKernel(fh, funcName, cD, bName[bInd], polyOrder),
+
+      close(fh)
+    )
+  )
+);

--- a/maxima/g0/gyrokinetic/gkFuncs-vol.mac
+++ b/maxima/g0/gyrokinetic/gkFuncs-vol.mac
@@ -116,6 +116,7 @@ buildGKVolKernel(fh, funcNm, cdim, vdim, basisFun, polyOrder, varsInB) := block(
     alpha_c    : fullratsimp(calcInnerProdList(varsP, 1, bP, alpha_e)*rdDirVar2),
     alphaLabel : eval_string(sconcat(alpha, dirLabel)),
     writeCExprsNoExpand1(alphaLabel, gcfac(expand(facsum(subst(replaceList, alpha_c),append(rdx2vec,rdv2vec))))),
+    printf(fh, "~%")
     flush_output(fh),
     alphaNoZero_c : doMakeExprLst(alpha_c, alphaLabel),
     alpha_e       : doExpand(alphaNoZero_c, bP),

--- a/maxima/g0/gyrokinetic/gkUtil.mac
+++ b/maxima/g0/gyrokinetic/gkUtil.mac
@@ -35,8 +35,15 @@ expandInputFields(bC,bmagBasis) := block(
 )$
 
 calcAndWrite_HamilES(fH,charge,mass,wv,rdv2,bP,inFlds,sideStr) := block(
-  [varsP,numP,hamil_c,subList,hamilNoZero_c],
+  [varsP,numP,pDim,vdim,bmag_e,phi_e,hamil_e,hamil_c,replaceList,hamilCvar,hamilNoZero_c],
   /* Expand the Hamiltonian, and write them out. */
+
+  varsP : listofvars(bP),
+  numP  : length(bP),
+  pDim  : length(varsP),
+  vdim  : 0,
+  if isInList(vpar,varsP) then vdim : vdim+1,
+  if isInList(mu,varsP) then vdim : vdim+1,
 
   /* Extract magnetic field and electrostatic potential. */
   bmag_e : inFlds[1],
@@ -45,9 +52,6 @@ calcAndWrite_HamilES(fH,charge,mass,wv,rdv2,bP,inFlds,sideStr) := block(
   hamil_e : charge*phi_e,
   if vdim > 0 then ( hamil_e : hamil_e + (1/2)*mass*(wv[1] + vpar/rdv2[1])^2 ),
   if vdim > 1 then ( hamil_e : hamil_e + (wv[2]+mu/rdv2[2])*bmag_e ),
-
-  varsP : listofvars(bP),
-  numP  : length(bP),
 
   /* Project Hamiltonian onto basis functions */
   hamil_c : calcInnerProdList(varsP, 1, bP, hamil_e),

--- a/maxima/g0/gyrokinetic/gkUtil.mac
+++ b/maxima/g0/gyrokinetic/gkUtil.mac
@@ -462,7 +462,7 @@ calcAndWrite_upwindIncr_wQuadNodeAlpha(fH,basisType,polyOrder,bP,surfDir,sideStr
 
   Ghat_c : calcInnerProdList(surfIntVars, alphaSurf_e, bSurf, fHatSurf_e),
   Ghat_e : doExpand(Ghat_c, bSurf),
-  printf(fH, "  double Ghat~a[~a] = {0.}; ~%", sideStr, numP),
+  printf(fH, "  double Ghat~a[~a] = {0.}; ~%", sideStr, length(bSurf)),
   writeCExprs1(eval_string(sconcat("Ghat",sideStr)), Ghat_c),
   printf(fH, "~%"),
   flush_output(fH),

--- a/maxima/g0/nodal_operations/ms-basis_surf_quad_upwind_accepted_results.mac
+++ b/maxima/g0/nodal_operations/ms-basis_surf_quad_upwind_accepted_results.mac
@@ -1,0 +1,81 @@
+
+/*
+/* This first section produces accepted results for the test of header files evaluating at quad nodes on surface. */
+*/
+
+kill(all);
+
+load("modal-basis");
+load("nodal_operations/nodal_functions");
+
+polyOrder : 1$
+cdim : 1$
+vdim : 2$
+basisFun : "GkHybrid"$
+surfDir : 3$
+evAtSide : 1$ /* -1 for left, 1 for right */
+load(sconcat("basis-precalc/basis",basisFun,cdim,"x",vdim,"v"));
+
+pDim : cdim+vdim$
+bP : basisP[polyOrder]$
+surfVar     : varsP[surfDir]$
+surfIntVars : delete(surfVar,varsP)$
+surf_cvars : delete(surfVar, makelist(varsP[i],i,1,cdim))$
+surf_vvars : delete(surfVar, makelist(varsP[cdim+i],i,1,vdim))$
+if polyOrder = 1 then (
+  surfNodes : gaussOrdGkHyb(1+1, surf_cvars, surf_vvars),
+  bSurf     : basisFromVars("gkhyb",surfIntVars,polyOrder)
+) else (
+  surfNodes : gaussOrd(polyOrder+1, pDim-1),
+  bSurf     : basisFromVars(basisFun,surfIntVars,polyOrder)
+)$
+numNodes  : length(surfNodes)$
+
+f_e : doExpand1(fin,bP)$
+fOrdL_n : gcfac(float(evAtNodes(subst(surfVar=evAtSide,f_e),surfNodes,surfIntVars)));
+
+/*
+/* This second section produces accepted results for the test of header files transforming surface nodal coefficients to surface modal coefficients. */
+*/
+
+kill(all);
+
+load("modal-basis");
+load("nodal_operations/nodal_functions");
+
+polyOrder : 1$
+cdim : 1$
+vdim : 2$
+basisFun : "GkHybrid"$
+surfDir : 2$
+load(sconcat("basis-precalc/basis",basisFun,cdim,"x",vdim,"v"));
+
+pDim : cdim+vdim$
+bP : basisP[polyOrder]$
+surfVar     : varsP[surfDir]$
+surfIntVars : delete(surfVar,varsP)$
+surf_cvars : delete(surfVar, makelist(varsP[i],i,1,cdim))$
+surf_vvars : delete(surfVar, makelist(varsP[cdim+i],i,1,vdim))$
+if polyOrder = 1 then (
+  surfNodes : gaussOrdGkHyb(1+1, surf_cvars, surf_vvars),
+  bSurf     : basisFromVars("gkhyb",surfIntVars,polyOrder)
+) else (
+  surfNodes : gaussOrd(polyOrder+1, pDim-1),
+  bSurf     : basisFromVars(basisFun,surfIntVars,polyOrder)
+)$
+numNodes  : length(surfNodes)$
+
+f_e : doExpand1(fin,bP)$
+fOrdL_n : gcfac(float(evAtNodes(subst(surfVar=-1,f_e),surfNodes,surfIntVars)))$
+if polyOrder = 1 then (
+  surf_cdim : length(surf_cvars),
+  surf_vdim : length(surf_vvars),
+  basisNodal : getVarsNodalBasisWithNodesHyb("gkhyb", surf_cdim, surf_vdim, surfIntVars, surfNodes)
+) else (
+  basisNodal : getVarsNodalBasisWithNodes("tensor", pDim-1, polyOrder, surfIntVars, surfNodes)
+)$
+
+fpprec : 24$
+fNodal_e : doExpand(fOrdL_n,basisNodal)$
+f_c : float(expand(fullratsimp(calcInnerProdList(surfIntVars, 1, bSurf, fNodal_e))));
+


### PR DESCRIPTION
This is for use in 1x gyrokinetic simulations. In principle the solvers are written so the potentially work in 3x as well, although we haven't tested that option.

We tested it with mirror simulations and produced identical results (i.e. phi) to the previous g2 simulations, up to a point. After a certain time (t~10 microsec) the simulation becomes unstable, but we think this is due to subtleties in gkhybrid basis and will explore that in another branch.