### PR TITLE
Limited 1-cell recovery options

### DIFF
--- a/maxima/g0/recovery-calc/recovery-1cell.mac
+++ b/maxima/g0/recovery-calc/recovery-1cell.mac
@@ -1,4 +1,4 @@
-calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxup, lo, ce, up) := block(
+calcRecov1CellFull(basisNm, recDir, dirs, polyOrder, C, numMomentMatch, dxlo, dxce, dxup, lo, ce, up) := block(
   /* Returns recovered polynomial defined over 1 cell with a 3-cell stencil
   Inputs:
     basisNm : name of used basis function ("Ser", "Tensor", or "Max");
@@ -27,7 +27,7 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
   numDims, recDirIdx, perpDirs, recDirPolyOrder,
   vdim, cdim, jnk1, jnk2, pvars, pbasis,
   DoF, r, rLo, rUp, rExp, rSol, rSub,
-  recEqList, projSubList,
+  recEqList, projSubList, removeList, reducedBasis,
   varsa,
   ba, baLo1D, baCe1D, baUp1D, baLoND, baCeND, baUpND, baVars,
   dimProjLo, dimProjCe, dimProjUp, qLo1D, qCe1D, qUp1D,
@@ -37,9 +37,9 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
   ],
 
   numDims : length(dirs),
-  for i : 1 thru numDims do (
+  for i : 1 thru numDims do
     if recDir=dirs[i] then recDirIdx : i
-  ),
+  ,
 
   perpDirs : delete(recDir, dirs),
 
@@ -60,7 +60,6 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
 
     if charat(string(recDir),1)="v" then
       recDirPolyOrder : polyOrder+1
-    
   ) else (
     [varsa,ba] : loadBasis(basisNm, 1, polyOrder),
     ba : subst(x=recDir, ba)
@@ -69,97 +68,86 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
   baCe1D : etaDir(recDir, 0, dxce[recDirIdx], ba),
   baLo1D : etaDir(recDir, -dxce[recDirIdx]/2-dxlo[recDirIdx]/2, dxlo[recDirIdx], ba),
   baUp1D : etaDir(recDir, dxce[recDirIdx]/2+dxup[recDirIdx]/2, dxup[recDirIdx], ba),
-  /* Note that unlike in 2-cell or 3-cell recovery, the left and right
-  basis functions are not required for the first part (1D) recovery;
-  still, they are still required in the same spot as in the case of
-  the other methods for clarity */
 
-  DoF : recDirPolyOrder + 1,
+  if numMomentMatch=-1 then
+    DoF : recDirPolyOrder + 1
+  else
+    DoF : numMomentMatch,
+
   if is(op(lo)=dg) then
-  (
     DoF : DoF + 1 + C
-    )
   elseif is(op(lo)=bc) then
-  (
     DoF : DoF + 1
-    )
   elseif is(op(lo)=bcs) then
-  (
-    DoF : DoF + length(args(lo))
-    ),
+    DoF : DoF + length(args(lo)),
+
   if is(op(up)=dg) then
-  (
     DoF : DoF + 1 + C
-    )
-  elseif is(op(up)=bc) then (
+  elseif is(op(up)=bc) then
     DoF : DoF + 1
-    )
-  elseif is(op(up)=bcs) then (
-    DoF : DoF + length(args(up))
-    ),
-  
+  elseif is(op(up)=bcs) then
+    DoF : DoF + length(args(up)),
+
   /* Forming and solving the equation system */
   rExp : doExpand(r, makelist(recDir^i, i, 0, DoF-1)),
+
   /* New solution is weakly equal to the original representation */
-  recEqList : calcInnerProdList([recDir], 1, baCe1D,
-    rExp-doExpand(qCe1D, baCe1D)),
-  
-  if is(op(lo)=dg) then
-  (
+  if numMomentMatch=-1 then
+    recEqList : calcInnerProdList([recDir], 1, baCe1D,
+      rExp-doExpand(qCe1D, baCe1D))
+  else (
+    removeList : makelist(baCe1D[i], i, numMomentMatch+1, polyOrder+1),
+    reducedBasis : baCe1D,
+    for i : 1 thru length(removeList) do
+      reducedBasis : delete(removeList[i], reducedBasis),
+    if length(reducedBasis)>0 then
+      recEqList : calcInnerProdList([recDir], 1, reducedBasis,
+        rExp-doExpand(qCe1D, reducedBasis))
+    else
+      recEqList : []
+  ),
+
+  if is(op(lo)=dg) then (
     if length(args(lo)) > 1 then
-    (
       rLo : calcRecov2CellGenNonuniform(basisNm, recDir, [recDir], polyOrder,
         dxlo, dxce, dg(qLo1D, args(lo)[2]), dg(qCe1D))
-      )
     else
-    (
       rLo : calcRecov2CellGenNonuniform(basisNm, recDir, [recDir], polyOrder,
-        dxlo, dxce, dg(qLo1D), dg(qCe1D))
-      ),
+        dxlo, dxce, dg(qLo1D), dg(qCe1D)),
     for i : 0 thru C do
-    (
       recEqList : append(
         recEqList,
         [subst(recDir=0, diff(rLo, recDir, i))
           - subst(recDir=-dxce[recDirIdx]/2, diff(rExp, recDir, i))]
-        )
       )
-    )
-  elseif is(op(lo)=bc) then
-  (
+  ) elseif is(op(lo)=bc) then (
     recEqList : append(
       recEqList,
       [subst(args(lo), val - D*subst(recDir=-dxce[recDirIdx]/2, rExp)
         - N*subst(recDir=-dxce[recDirIdx]/2, diff(rExp, recDir)))]
-      )
     )
-  elseif is(op(lo)=bcs) then
-  (
+  ) elseif is(op(lo)=bcs) then (
     for i : 1 thru length(args(lo)) do
-    (
       recEqList : append(
         recEqList,
         [subst(args(lo)[i], val)
           - subst(recDir=-dxce[recDirIdx]/2, diff(rExp, recDir, subst(args(lo)[i], der)))]
-        )
       )
-    ),
-  
+  ),
+
   if is(op(up)=dg) then (
-    if length(args(up)) > 1 then (
+    if length(args(up)) > 1 then
       rUp : calcRecov2CellGenNonuniform(basisNm, recDir, [recDir], polyOrder,
         dxce, dxup, dg(qCe1D), dg(qUp1D, args(up)[2]))
-    ) else (
+    else
       rUp : calcRecov2CellGenNonuniform(basisNm, recDir, [recDir], polyOrder,
-        dxce, dxup, dg(qCe1D), dg(qUp1D))
-    ),
-    for i : 0 thru C do (
+        dxce, dxup, dg(qCe1D), dg(qUp1D)),
+    for i : 0 thru C do
       recEqList : append(
         recEqList,
         [subst(recDir=0, diff(rUp, recDir, i))
           - subst(recDir=dxce[recDirIdx]/2, diff(rExp, recDir, i))]
       )
-    )
   ) elseif is(op(up)=bc) then (
     recEqList : append(
       recEqList,
@@ -167,26 +155,25 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
         - N*subst(recDir=dxce[recDirIdx]/2, diff(rExp, recDir)))]
     )
   ) elseif is(op(up)=bcs) then (
-    for i : 1 thru length(args(up)) do (
+    for i : 1 thru length(args(up)) do
       recEqList : append(
         recEqList,
         [subst(args(up)[i], val)
           - subst(recDir=dxce[recDirIdx]/2, diff(rExp, recDir, subst(args(up)[i], der)))]
       )
-    )
   ),
 
   rSol : linsolve(recEqList, makelist(r[i], i, 1, DoF)),
   rSub : fullratsimp(subst(rSol, rExp)),
-  
+
   /* Backsubstitute the non-recovered directtions if needed */
   if numDims > 1 then (
-    if basisNm="hyb" or basisNm="gkhyb" then (
+    if basisNm="hyb" or basisNm="gkhyb" then
       ba : copylist(pbasis)
-    ) else (
+    else (
       [varsa,ba] : loadBasis(basisNm, numDims, polyOrder),
-      baVars     : listofvars(ba),
-      ba         : psubst(makelist(baVars[i]=dirs[i],i,1,numDims), ba)
+      baVars : listofvars(ba),
+      ba : psubst(makelist(baVars[i]=dirs[i],i,1,numDims), ba)
     ),
     /* rescale basis */
     shiftList : makelist(0, i, 1, numDims),
@@ -200,7 +187,7 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
     given; i.e., a basis function set with one less dimension is
     needed */
     baCeNDw : basisFromVars(basisNm, perpDirs, polyOrder),
-    
+
     projSubList : [],
     if is(op(lo)=dg) then (
       dimProjLo : calcInnerProdListGen([recDir],
@@ -210,8 +197,7 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
         projSubList,
         makelist(qLo1D[i]=dimProjLo[i], i, 1, length(baCe1D))
       )
-    )
-    elseif is(op(lo)=bc) then (
+    ) elseif is(op(lo)=bc) then (
       bcExp : subst(args(lo), dg),
       if not atom(bcExp) then (
         projSubList : append(
@@ -227,7 +213,7 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
       projSubList,
       makelist(qCe1D[i]=dimProjCe[i], i, 1, length(baCe1D))
     ),
-    
+
     if is(op(up)=dg) then (
       dimProjUp : calcInnerProdListGen([recDir], [[dxce[recDirIdx]/2, dxce[recDirIdx]/2+dxup[recDirIdx]]],
         1, baUp1D, doExpand(args(up)[1], baUpND)),
@@ -244,32 +230,38 @@ calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxu
         )
       )
     )
-  )
-  else (
+  ) else (
     projSubList : [],
-    if is(op(lo)=dg) then (
+    if is(op(lo)=dg) then
       projSubList : append (
         projSubList,
         makelist(qLo1D[i]=args(lo)[1][i], i, 1, length(baCe1D))
-      )
-    ),
+      ),
     projSubList : append(
       projSubList,
       makelist(qCe1D[i]=args(ce)[1][i], i, 1, length(baCe1D))
     ),
-    if is(op(up)=dg) then (
+    if is(op(up)=dg) then
       projSubList : append (
         projSubList,
         makelist(qUp1D[i]=args(up)[1][i], i, 1, length(baCe1D))
       )
-    )
   ),
-  
+
   return(expand(subst(projSubList, rSub)))
+) $
+
+calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dxlo, dxce, dxup, lo, ce, up) :=
+  calcRecov1CellGenFull(basisNm, recDir, dirs, polyOrder, C, -1, dxlo, dxce, dxup, lo, ce, up) $
+
+calcRecov1CellGenLim(basisNm, recDir, dirs, polyOrder, C, numMomentMatch, lo, ce, up) := block(
+  [dx],
+  dx : makelist(2, i, 1, length(dirs)),
+  return(calcRecov1CellFull(basisNm, recDir, dirs, polyOrder, C, numMomentMatch, dx, dx, dx, lo, ce, up))
 ) $
 
 calcRecov1CellGen(basisNm, recDir, dirs, polyOrder, C, lo, ce, up) := block(
   [dx],
   dx : makelist(2, i, 1, length(dirs)),
-  return(calcRecov1CellGenNonuniform(basisNm, recDir, dirs, polyOrder, C, dx, dx, dx, lo, ce, up))
-)$
+  return(calcRecov1CellFull(basisNm, recDir, dirs, polyOrder, C, -1, dx, dx, dx, lo, ce, up))
+) $

--- a/maxima/g0/recovery-calc/recovery-2cell.mac
+++ b/maxima/g0/recovery-calc/recovery-2cell.mac
@@ -35,9 +35,8 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
   ],
 
   numDims : length(dirs),
-  for i : 1 thru numDims do (
-    if recDir=dirs[i] then recDirIdx : i
-  ),
+  for i : 1 thru numDims do
+    if recDir=dirs[i] then recDirIdx : i,
 
   perpDirs : delete(recDir, dirs),
 
@@ -67,46 +66,41 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
     [varsaCe1D,baCe1D] : loadBasis(basisNm, 1, polyOrder),
     baCe1D : subst(x=recDir, baCe1D)
   ),
-  
+
   baLo1D : etaDir(recDir, -dxlo[recDirIdx]/2, dxlo[recDirIdx], baCe1D),
   baUp1D : etaDir(recDir, dxup[recDirIdx]/2, dxup[recDirIdx], baCe1D),
- 
+
   /* forming and solving the equation system */
   DoF : 0,
+
   if is(op(lo)=dg) then (
     DoF : DoF + recDirPolyOrder + 1,
     if length(args(lo)) > 1 then (
-      if is(op(args(lo)[2])=bc) then (
+      if is(op(args(lo)[2])=bc) then
         DoF : DoF + 1 /* only 1 DoF for BC */
-      )
-      else (
+      else
         DoF : DoF + length(args(args(lo)[2]))
-      )
     )
-  )
-  elseif is(op(lo)=bc) then (
+  ) elseif is(op(lo)=bc) then (
     DoF : DoF + 1 /* only 1 DoF for BC */
-  )
-  elseif is(op(lo)=bcs) then (
+  ) elseif is(op(lo)=bcs) then (
     DoF : DoF + length(args(lo))
   ),
+
   if is(op(up)=dg) then (
     DoF : DoF + recDirPolyOrder + 1,
     if length(args(up)) > 1 then (
-      if is(op(args(up)[2])=bc) then (
+      if is(op(args(up)[2])=bc) then
         DoF : DoF + 1 /* only 1 DoF for BC */
-      )
-      else (
+      else
         DoF : DoF + length(args(args(up)[2]))
-      )
     )
-  )
-  elseif is(op(up)=bc) then (
+  ) elseif is(op(up)=bc) then (
     DoF : DoF + 1 /* only 1 DoF for BC */
-  )
-  elseif is(op(up)=bcs) then (
+  ) elseif is(op(up)=bcs) then (
     DoF : DoF + length(args(up))
   ),
+
   rExp : doExpand(r, makelist(recDir^i, i, 0, DoF-1)), /* recovery polynomial */
 
   recEqList : [], /* equation set from the weak equality formulation */
@@ -117,40 +111,34 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
         baLo1D, rExp-doExpand(qLo1D, baLo1D))
     ),
     if length(args(lo)) > 1 then (
-      if is(op(args(lo)[2])=bc) then (
+      if is(op(args(lo)[2])=bc) then
         recEqList : append(
           recEqList,
           [subst(args(args(lo)[2]), val - D*subst(recDir=-dxlo[recDirIdx], rExp)
             - N*subst(recDir=-dxlo[recDirIdx], diff(rExp, recDir)))]
         )
-      )
-      elseif is(op(args(lo)[2])=bcs) then (
-        for i : 1 thru length(args(args(lo)[2])) do (
+      elseif is(op(args(lo)[2])=bcs) then
+        for i : 1 thru length(args(args(lo)[2])) do
           recEqList : append(
             recEqList,
             [subst(args(args(lo)[2])[i], val)
               - subst(recDir=-dxlo[recDirIdx], diff(rExp, recDir, subst(args(args(lo)[2])[i], der)))]
           )
-        )
-      )
     )
   )
-  elseif is(op(lo)=bc) then (
+  elseif is(op(lo)=bc) then
     recEqList : append(
       recEqList,
       [subst(args(lo), val - D*subst(recDir=0, rExp)
         - N*subst(recDir=0, diff(rExp, recDir)))]
     )
-  )
-  else (
-    for i : 1 thru length(args(lo)) do (
+  else
+    for i : 1 thru length(args(lo)) do
       recEqList : append(
         recEqList,
         [subst(args(lo)[i], val)
           - subst(recDir=0, diff(rExp, recDir, subst(args(lo)[i], der)))]
-      )
-    )
-  ),
+      ),
 
   if is(op(up)=dg) then (
     recEqList : append(
@@ -159,48 +147,42 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
         baUp1D, rExp-doExpand(qUp1D, baUp1D))
     ),
     if length(args(up)) > 1 then (
-      if is(op(args(up)[2])=bc) then (
+      if is(op(args(up)[2])=bc) then
         recEqList : append(
           recEqList,
           [subst(args(args(up)[2]), val - D*subst(recDir=dxup[recDirIdx], rExp)
             - N*subst(recDir=dxup[recDirIdx], diff(rExp, recDir)))]
         )
-      )
-      elseif is(op(args(up)[2])=bcs) then (
-        for i : 1 thru length(args(args(up)[2])) do (
+      elseif is(op(args(up)[2])=bcs) then
+        for i : 1 thru length(args(args(up)[2])) do
           recEqList : append(
             recEqList,
             [subst(args(args(up)[2])[i], val)
               - subst(recDir=dxup[recDirIdx], diff(rExp, recDir, subst(args(args(up)[2])[i], der)))]
           )
-        )
-      )
     )
   )
-  elseif is(op(up)=bc) then (
+  elseif is(op(up)=bc) then
     recEqList : append(
       recEqList,
       [subst(args(up), val - D*subst(recDir=0, rExp)
         - N*subst(recDir=0, diff(rExp, recDir)))]
     )
-  )
-  else (
-    for i : 1 thru length(args(up)) do (
+  else
+    for i : 1 thru length(args(up)) do
       recEqList : append(
         recEqList,
         [subst(args(up)[i], val) - subst(recDir=0, diff(rExp, recDir, subst(args(up)[i], der)))]
-      )
-    )
-  ),
+      ),
 
   rSol : linsolve(recEqList, makelist(r[i], i, 1, DoF)),
   rSub : fullratsimp(subst(rSol, rExp)),
-  
+
   /* backsubstitute the non-recovered directtions if needed */
   if numDims > 1 then (
-    if basisNm="hyb" or basisNm="gkhyb" then (
+    if basisNm="hyb" or basisNm="gkhyb" then
       baCeND : copylist(pbasis)
-    ) else (
+    else (
       [varsaCeND,baCeND] : loadBasis(basisNm, numDims, polyOrder),
       baVars : listofvars(baCeND),
       baCeND : psubst(makelist(baVars[i]=dirs[i],i,1,numDims), baCeND)
@@ -216,7 +198,7 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
     given; i.e., a basis function set with one less dimension is
     needed */
     baCeNDw : basisFromVars(basisNm, perpDirs, polyOrder),
-    
+
     projSubList : [],
     if is(op(lo)=dg) then (
       dimProjLo : (2/dxlo[recDirIdx])*calcInnerProdListGen([recDir], [[-dxlo[recDirIdx], 0]],
@@ -227,12 +209,11 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
       ),
       if length(args(lo)) > 1 then (
         bcExp : subst(args(args(lo)[2]), dg),
-        if not atom(bcExp) then (
+        if not atom(bcExp) then
           projSubList : append(
             projSubList,
             [val=doExpand(bcExp, baCeNDw)]
           )
-        )
       )
     ),
     if is(op(up)=dg) then (
@@ -244,37 +225,34 @@ calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dxlo, dxup, lo, up
       ),
       if length(args(up)) > 1 then (
         bcExp : subst(args(args(up)[2]), dg),
-        if not atom(bcExp) then (
+        if not atom(bcExp) then
           projSubList : append(
             projSubList,
             [val=doExpand(bcExp, baCeNDw)]
           )
-        )
       )
     )
   )
   else (
     projSubList : [],
-    if is(op(lo)=dg) then (
+    if is(op(lo)=dg) then
       projSubList : append (
         projSubList,
         makelist(qLo1D[i]=args(lo)[1][i], i, 1, length(baCe1D))
-      )
-    ),
-    if is(op(up)=dg) then (
+      ),
+    if is(op(up)=dg) then
       projSubList : append (
         projSubList,
         makelist(qUp1D[i]=args(up)[1][i], i, 1, length(baCe1D))
       )
-    )
   ),
   return(expand(subst(projSubList, rSub)))
-  ) $
+) $
 
 calcRecov2CellGen(basisNm, recDir, dirs, polyOrder, lo, up) := block(
   [dx],
   dx : makelist(2, i, 1, length(dirs)),
   return(calcRecov2CellGenNonuniform(basisNm, recDir, dirs, polyOrder, dx, dx, lo, up))
-  )$
+) $
 
-calcRecov2Cell(recDir, dirs, polyOrder, lo, up) := calcRecov2CellGen("Ser", recDir, dirs, polyOrder, lo, up)$
+calcRecov2Cell(recDir, dirs, polyOrder, lo, up) := calcRecov2CellGen("Ser", recDir, dirs, polyOrder, lo, up) $

--- a/maxima/g0/recovery-calc/recovery-face.mac
+++ b/maxima/g0/recovery-calc/recovery-face.mac
@@ -9,7 +9,7 @@ calcRecovFaceGen(basisNm, recDirs, dirs, numDer, face, polyOrder, C, lo, ce, up)
   baVars
   ],
 
-  numDims  : length(dirs),
+  numDims : length(dirs),
   perpDirs : delete(recDirs[1], dirs),
 
   ba : basisFromVars(basisNm, perpDirs, polyOrder),
@@ -23,7 +23,7 @@ calcRecovFaceGen(basisNm, recDirs, dirs, numDer, face, polyOrder, C, lo, ce, up)
   ) elseif is(op(lo)=bc) then (
     lo2 : lo
   ),
-  
+
   /* Center input cannot be a BC */
   rCe : calcRecov2CellGen(basisNm, recDirs[1], dirs, polyOrder,
     args(ce)[1], args(ce)[2]),

--- a/maxima/g0/recovery-unit.mac
+++ b/maxima/g0/recovery-unit.mac
@@ -1,3 +1,13 @@
+/* A tool to verify the recovery methods */
+/* Since the recovery is quite important to many aspects of the code, this
+should be tested every time a change is made */
+/* One can run tis directly form command line:
+To create the current results:
+  maxima -r 'load("recovery-unit");testRecov("create");quit();'
+and to test:
+  maxima -r 'load("recovery-unit");testRecov("check");quit();'
+*/
+
 load("recovery") $
 
 testRecov(mode) := block(
@@ -39,7 +49,7 @@ testRecov(mode) := block(
     [["Face 3D p1 C1 yx", calcRecovFaceGen("Ser", [y,x], [x,y,z], 0, 0, 1, 1, dg(dg(qBL),dg(qTL)), dg(dg(qBC),dg(qTC)), dg(dg(qBR),dg(qTR)))]],
     [["Face 3D p1 C1 xy", calcRecovFaceGen("Ser", [x,y], [x,y,z], 0, 0, 1, 1, dg(dg(qBL),dg(qTL)), dg(dg(qBC),dg(qTC)), dg(dg(qBR),dg(qTR)))]]
   ),
-  
+
   if mode="create" then (
     fh : openw(fn),
     for i : 1 thru length(tests) do (

--- a/maxima/g0/recovery-unit.mac
+++ b/maxima/g0/recovery-unit.mac
@@ -5,7 +5,7 @@ should be tested every time a change is made */
 To create the current results:
   maxima -r 'load("recovery-unit");testRecov("create");quit();'
 and to test:
-  maxima -r 'load("recovery-unit");testRecov("check");quit();'
+  maxima -r 'load("recovery-unit");testRecov("check");values;quit();'
 */
 
 load("recovery") $


### PR DESCRIPTION
Adding more options to the 1-cell recovery. It is now possible to recover a new representation in a cell that matches recovered values and slopes at the interfaces but does _not_ have to be weakly equal to the moments in the cell. 