### PR TITLE
Kernels to translate dimensionality of a field

### DIFF
--- a/maxima/g0/translate_dim/ms-trans_dim-header.mac
+++ b/maxima/g0/translate_dim/ms-trans_dim-header.mac
@@ -1,0 +1,63 @@
+/*
+  Generate the kernels header file for the updater which translates
+  the DG coefficients of a lower dimensional donor field to a higher
+  dim target field.
+*/
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* Vdim possibilities for each of Cdim=[1,2,3]. */
+gkVdims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+printPrototypes(fh) := block([],
+
+  for bInd : 1 thru length(bName) do (
+    for c : max(2,minCdim[bInd]) thru maxCdim[bInd] do (
+      for gkV : 1 thru length(gkVdims[c]) do (
+        v : gkVdims[c][gkV],
+  
+        maxPolyOrderB : maxPolyOrder[bInd],
+        if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+        for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+
+          for c_low : 1 thru c-1 do (
+            printf(fh, "GKYL_CU_DH void translate_dim_gyrokinetic_~ax~av_~a_p~a_from_~ax~av_p~a(const double *flow, double *fout);~%", c, v, bName[bInd], polyOrder, c_low, v, polyOrder)
+          ),
+          printf(fh, "~%")
+        )
+      )
+    )
+  )
+)$
+
+fh : openw("~/max-out/gkyl_translate_dim_gyrokinetic_kernels.h")$
+printf(fh, "#pragma once~%")$
+printf(fh, "~%")$
+printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_BEG~%")$
+printf(fh, "~%")$
+printPrototypes(fh)$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_END~%")$
+close(fh)$

--- a/maxima/g0/translate_dim/ms-trans_dim.mac
+++ b/maxima/g0/translate_dim/ms-trans_dim.mac
@@ -1,0 +1,55 @@
+/*
+  Generate kernels to translate a lower dimensional
+  field to a higher dimensional field.
+*/
+load("translate_dim/trans_dim.mac")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* Vdim possibilities for each of Cdim=[1,2,3]. */
+gkVdims : [[1,2], [2], [2]]$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+/* Generate kernels of selected types. */
+for bInd : 1 thru length(bName) do (
+  for c : max(2,minCdim[bInd]) thru maxCdim[bInd] do (
+    for gkV : 1 thru length(gkVdims[c]) do (
+      v : gkVdims[c][gkV],
+
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        fname : sconcat("~/max-out/translate_dim_gyrokinetic_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        disp(printf(false,"Creating file: ~a",fname)),
+  
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_translate_dim_gyrokinetic_kernels.h> ~%"),
+        printf(fh, "~%"),
+
+        funcName : sconcat("translate_dim_gyrokinetic_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+        gen_trans_dim_gk_kernel(fh, funcName, c, v, bName[bInd], polyOrder),
+        close(fh)
+      )
+    )
+  )
+)$

--- a/maxima/g0/translate_dim/trans_dim.mac
+++ b/maxima/g0/translate_dim/trans_dim.mac
@@ -1,0 +1,47 @@
+/**
+ * Create kernels which translate DG coefficients of a low-dimensional field
+ * into the DG coefficients of our current (higher dimensional) field.
+ *
+ */
+load("modal-basis");
+load("out-scripts");
+fpprec : 24$
+
+gen_trans_dim_gk_kernel(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [vdim_low,polyOrder_low,varsC,bC,varsP,bP,vSub,cdim_low,varsC_low,
+   bC_low,varsP_low,bP_low,vSub_low,flow_e,fout_c],
+
+  /* Assume vdim and polyOrder remain the same. */
+  vdim_low : vdim,
+  polyOrder_low : polyOrder,
+
+  /* Get desired basis. */
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  for cdim_low : 1 thru cdim-1 do (
+
+    printf(fh, "GKYL_CU_DH void ~a_from_~ax~av_p~a(const double *flow, double *fout) ~%{ ~%", funcNm, cdim_low, vdim_low, polyOrder_low),
+    printf(fh, "  // flow: lower dimensional field to get DG coefficients from.~%"),
+    printf(fh, "  // fout: field whose DG coefficients to populate.~%"),
+    printf(fh, "~%"),
+
+    /* Load low-dimensional basis. */
+    [varsC_low,bC_low,varsP_low,bP_low,vSub_low] : loadGkBasis(basisFun, cdim_low, vdim_low, polyOrder_low),
+    /* In 1x2v x is actually z */
+    if (cdim_low = 1) then (
+      varsC_low  : subst(x=z,varsC_low),
+      bC_low     : subst(x=z,bC_low   ),
+      varsP_low  : subst(x=z,varsP_low),
+      bP_low     : subst(x=z,bP_low   )
+    ),
+
+    flow_e : doExpand1(flow,bP_low),
+
+    fout_c : calcInnerProdList(varsP,1,bP,flow_e),
+    writeCExprsWithZeros1(fout, fout_c),
+
+    printf(fh, "}~%"),
+    printf(fh, "~%")
+  )
+
+)$


### PR DESCRIPTION
Kernels for an updater that translates the DG coefficients of a lower dimensionality field to those of a higher dimensionality field (e.g. for loading 2x distributions as ICs in a 3x sim).

This goes with PR 479 in gkylzero: https://github.com/ammarhakim/gkylzero/pull/479