### PR TITLE
Can-pb Tensor/Hybrid Basis and Energy Moment Calc

### DIFF
--- a/maxima/g0/canonical_pb/canonical-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/canonical-alpha-surf.mac
@@ -31,7 +31,38 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
 
   kill(varsC,varsP,bC,bP),
 
-  [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+  pOrderV : polyOrder,
+  /* Load basis of dimensionality requested. */
+  if (basisFun="tensor") then (
+    /* If we are using the tensor basis, just use the simple load command */
+    [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+    [varsP,bP] : loadBasis(basisFun, cdim+vdim, polyOrder),
+    /* Do a variable substitution for the lower dimensional tensor basis functions
+       to construct the correct set of variables for the subsequent operations */
+    if (cdim+vdim = 2) then (
+      varsSub : [y=vx],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim+vdim = 3) then (
+      varsSub : [y=vx, z=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim = 2 and vdim = 2) then (
+      varsSub : [vx=y, vy=vx, vz=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+  )
+  else (
+    /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+    [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+
+    /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+       mean hybrid basis. */
+    if polyOrder=1 then ( pOrderV : 2 )
+  ),
   numC : length(bC),  numP : length(bP), pDim  : length(varsP),
 
   surfVar : varsP[surfDir],         /* Surface variable. */
@@ -41,10 +72,24 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
   surfIntVars : delete(surfVar,varsP), 
   surf_cvars : delete(surfVar, makelist(varsP[i],i,1,cdim)),
   surf_vvars : delete(surfVar, makelist(varsP[cdim+i],i,1,vdim)),
-
-  surfNodes : gaussOrd(polyOrder+1, pDim-1),
   nodeVars : surfIntVars,
-  bSurf : basisFromVars(basisFun,surfIntVars,polyOrder),
+
+  /* Generate surface basis. this produces the ndim-1 orthogonal basis with no vv dependence. */
+  /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
+  if (polyOrder=1 and basisFun="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+    bSurf : basisFromVars("hyb",surfIntVars,polyOrder),
+
+    surf_cdim : cdim,  surf_vdim : vdim-1,
+    surfNodes : gaussOrdHyb(1+1, surf_cdim, surf_vdim),
+
+    basisStr : sconcat("hyb_", cdim, "x", vdim, "v", "_p", polyOrder)
+  ) else (
+    bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
+
+    surfNodes : gaussOrd(polyOrder+1, pDim-1),
+
+    basisStr : sconcat(basisFun, "_", cdim+vdim, "x", "_p", polyOrder)
+  ),
 
   NSurf : length(bSurf),
   numNodes  : length(surfNodes),
@@ -86,13 +131,13 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
        quantities such as geometry in the ghost cells where they are not defined */
     printf(fh, "  double *alphaR = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
     printf(fh, "  double *sgn_alpha_surfR = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing),
-    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,polyOrder,basisFun,rdx2vec,rdv2vec,hamil,"R"),
+    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
     calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"R")
   )
   else (
     printf(fh, "  double *alphaL = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
     printf(fh, "  double *sgn_alpha_surfL = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing),
-    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,polyOrder,basisFun,rdx2vec,rdv2vec,hamil,"L"),
+    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
     calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"L")
   ),
   printf(fh, "  return const_sgn_alpha_surf; ~%"),

--- a/maxima/g0/canonical_pb/canonical-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/canonical-alpha-surf.mac
@@ -78,12 +78,17 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
   /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
   if (polyOrder=1 and basisFun="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
     bSurf : basisFromVars("hyb",surfIntVars,polyOrder),
-
-    surf_cdim : cdim,  surf_vdim : vdim-1,
+    if (surfDir <= cdim) then (
+      surf_cdim : cdim-1,  surf_vdim : vdim
+    ) 
+    else (
+      surf_cdim : cdim,  surf_vdim : vdim-1
+    ),
     surfNodes : gaussOrdHyb(1+1, surf_cdim, surf_vdim),
 
     basisStr : sconcat("hyb_", cdim, "x", vdim, "v", "_p", polyOrder)
-  ) else (
+  ) 
+  else (
     bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
 
     surfNodes : gaussOrd(polyOrder+1, pDim-1),
@@ -96,6 +101,11 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
 
   NSurfIndexing : NSurf,
   numNodesIndexing : numNodes,
+
+  /* print("bSurf ", bSurf),
+  print("surfNodes ", surfNodes),
+  print("NSurf ", NSurf),
+  print("numNodes ",numNodes), */
 
   print("Working on ", funcNm),
   printf(fh, "GKYL_CU_DH int ~a(const double *w, const double *dxv, const double *hamil,

--- a/maxima/g0/canonical_pb/canonical-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/canonical-alpha-surf.mac
@@ -139,14 +139,38 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
        set of kernels if we are on the edge so we also can evaluate the correct 
        alpha_surf at the upper configuration space boundary without evaluating
        quantities such as geometry in the ghost cells where they are not defined */
-    printf(fh, "  double *alphaR = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
-    printf(fh, "  double *sgn_alpha_surfR = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing),
+    /* Handle the hybrid space velicty, which has difference NSurfIndexing/numNodesIndexing
+      because of hybrid in velicty or conf space */
+    if (polyOrder=1 and basisFun="ser" and surfDir > cdim) then (
+      surfIntVars_hyb_conf : delete(varsP[1],varsP),
+      bSurf_hyb_conf : basisFromVars("hyb",surfIntVars_hyb_conf,polyOrder),
+      surfNodes_hyb_conf : gaussOrdHyb(1+1, cdim-1, vdim),
+      NSurfIndexing_hyb_conf : length(bSurf_hyb_conf),
+      numNodesIndexing_hyb_conf  : length(surfNodes_hyb_conf),
+      printf(fh, "  double *alphaR = &alpha_surf[~a];~%", cdim*NSurfIndexing_hyb_conf + (surfDir-1-cdim)*NSurfIndexing),
+      printf(fh, "  double *sgn_alpha_surfR = &sgn_alpha_surf[~a];~%", cdim*numNodesIndexing_hyb_conf + (surfDir-1-cdim)*numNodesIndexing)
+    ) 
+    else (
+      printf(fh, "  double *alphaR = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
+      printf(fh, "  double *sgn_alpha_surfR = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing)
+    ),
     alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
     calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"R")
   )
   else (
-    printf(fh, "  double *alphaL = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
-    printf(fh, "  double *sgn_alpha_surfL = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing),
+    if (polyOrder=1 and basisFun="ser" and surfDir > cdim) then (
+      surfIntVars_hyb_conf : delete(varsP[1],varsP),
+      bSurf_hyb_conf : basisFromVars("hyb",surfIntVars_hyb_conf,polyOrder),
+      surfNodes_hyb_conf : gaussOrdHyb(1+1, cdim-1, vdim),
+      NSurfIndexing_hyb_conf : length(bSurf_hyb_conf),
+      numNodesIndexing_hyb_conf  : length(surfNodes_hyb_conf),
+      printf(fh, "  double *alphaL = &alpha_surf[~a];~%", cdim*NSurfIndexing_hyb_conf + (surfDir-1-cdim)*NSurfIndexing),
+      printf(fh, "  double *sgn_alpha_surfL = &sgn_alpha_surf[~a];~%", cdim*numNodesIndexing_hyb_conf + (surfDir-1-cdim)*numNodesIndexing)
+    ) 
+    else (
+      printf(fh, "  double *alphaL = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
+      printf(fh, "  double *sgn_alpha_surfL = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing)
+    ),
     alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
     calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"L")
   ),

--- a/maxima/g0/canonical_pb/canonical-pressure-vars.mac
+++ b/maxima/g0/canonical_pb/canonical-pressure-vars.mac
@@ -25,15 +25,12 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
   /* printf(fh, "#include <gkyl_euler_canonical_pb_kernels.h> ~%"), */
   printf(fh, "#include <gkyl_canonical_pb_kernels.h>  ~%"),
   printf(fh, "#include <gkyl_binop_mul_ser.h> ~%"),
-  printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *M2_ij, const double *v_j, const double *nv_i, double* GKYL_RESTRICT d_Jv_P) ~%{ ~%", funcNm, polyOrder),
+  printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *MEnergy, const double *v_j, const double *nv_i, double* GKYL_RESTRICT d_Jv_P) ~%{ ~%", funcNm, polyOrder),
   printf(fh, "  // h_ij_inv:         Input volume expansion of the inverse metric tensor.~%"),
   printf(fh, "  //                   [Hxx, Hxy, Hxz, ~%"),
   printf(fh, "  //                    Hxy, Hyy, Hyz, ~%"),
   printf(fh, "  //                    Hxz, Hyz, Hzz] ~%"),
-  printf(fh, "  // M2_ij:             Input volume expansion of the M2_ij moment.~%"),
-  printf(fh, "  //                   [M2xx, M2xy, M2xz, ~%"),
-  printf(fh, "  //                    M2xy, M2yy, M2yz, ~%"),
-  printf(fh, "  //                    M2xz, M2yz, M2zz] ~%"),
+  printf(fh, "  // MEnergy:          Input volume expansion of the MEnergy moment.~%"),
   printf(fh, "  // v_j:              Input volume expansion of V_drift.~%"),
   printf(fh, "  //                   [vx, vy, vz] ~%"),
   printf(fh, "  // nv_i:              Input volume expansion of M1i = N*Vdrift.~%"),
@@ -62,22 +59,7 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
   printf(fh, "~%"),
 
 
-  if (cdim = 1) then (
-    printf(fh, "  const double *M2xx = &M2_ij[~a]; ~%", 0*NC)
-  ),
-  if (cdim = 2) then (
-    printf(fh, "  const double *M2xx = &M2_ij[~a]; ~%", 0*NC),
-    printf(fh, "  const double *M2xy = &M2_ij[~a]; ~%", 1*NC),
-    printf(fh, "  const double *M2yy = &M2_ij[~a]; ~%", 2*NC)
-  ),
-  if (cdim = 3) then (
-    printf(fh, "  const double *M2xx = &M2_ij[~a]; ~%", 0*NC),
-    printf(fh, "  const double *M2xy = &M2_ij[~a]; ~%", 1*NC),
-    printf(fh, "  const double *M2xz = &M2_ij[~a]; ~%", 2*NC),
-    printf(fh, "  const double *M2yy = &M2_ij[~a]; ~%", 3*NC),
-    printf(fh, "  const double *M2yz = &M2_ij[~a]; ~%", 4*NC),
-    printf(fh, "  const double *M2zz = &M2_ij[~a]; ~%", 5*NC)
-  ),
+  printf(fh, "  const double *energy = &MEnergy[~a]; ~%", 0*NC),
   printf(fh, "~%"),
 
   if (cdim = 1) then (
@@ -99,36 +81,7 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
   printf(fh, "~%"),
 
 
-  /* First construct the volume expansion of h^{ij}M2_ij */
-  /* Temporary array of h^{ij}M2_ij*/
-  printf(fh, "  // h^{ij}M2_ij ~%"),
-  printf(fh, "  double Hxx_M2xx[~a] = {0.0}; ~%", NC),
-  printf(fh, "  binop_mul_~ad_~a_p~a(Hxx, M2xx, Hxx_M2xx); ~%", cdim, basisFun, polyOrder),
-  printf(fh, " ~%"),
-
-  if (cdim > 1) then (
-    printf(fh, "  double Hxy_M2xy[~a] = {0.0}; ~%", NC),
-    printf(fh, "  binop_mul_~ad_~a_p~a(Hxy, M2xy, Hxy_M2xy); ~%", cdim, basisFun, polyOrder),
-    printf(fh, " ~%"),
-
-    printf(fh, "  double Hyy_M2yy[~a] = {0.0}; ~%", NC),
-    printf(fh, "  binop_mul_~ad_~a_p~a(Hyy, M2yy, Hyy_M2yy); ~%", cdim, basisFun, polyOrder),
-    printf(fh, " ~%")
-  ),
-
-  if (cdim > 2) then (
-    printf(fh, "  double Hxz_M2xz[~a] = {0.0}; ~%", NC),
-    printf(fh, "  binop_mul_~ad_~a_p~a(Hxz, M2xz, Hxz_M2xz); ~%", cdim, basisFun, polyOrder),
-    printf(fh, " ~%"),
-
-    printf(fh, "  double Hyz_M2yz[~a] = {0.0}; ~%", NC),
-    printf(fh, "  binop_mul_~ad_~a_p~a(Hyz, M2yz, Hyz_M2yz); ~%", cdim, basisFun, polyOrder),
-    printf(fh, " ~%"),
-
-    printf(fh, "  double Hzz_M2zz[~a] = {0.0}; ~%", NC),
-    printf(fh, "  binop_mul_~ad_~a_p~a(Hzz, M2zz, Hzz_M2zz); ~%", cdim, basisFun, polyOrder),
-    printf(fh, " ~%")
-  ),
+  /* First construct the volume expansion of 2*MEnergy - Moved to end*/
 
   /* Second construct the volume expansion of h^{ij}*nv_i*v_j */
   /* Temporary array of h^{ij}*nv_i*v_j*/
@@ -174,16 +127,16 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
   ),
 
   for i : 1 thru NC do (
-    printf(fh, "  d_Jv_P[~a] = 0.0; ~%", i-1),
-    printf(fh, "  d_Jv_P[~a] +=  Hxx_M2xx[~a] - Hxx_M1x_Vx[~a]; ~%", i-1, i-1, i-1),
+    printf(fh, "  d_Jv_P[~a] = 2.0*energy[~a]; ~%", i-1, i-1),
+    printf(fh, "  d_Jv_P[~a] += - Hxx_M1x_Vx[~a]; ~%", i-1, i-1),
     if (cdim > 1) then (
-    printf(fh, "  d_Jv_P[~a] += (Hxy_M2xy[~a] - Hxy_M1x_Vy[~a])*2.0; ~%", i-1, i-1, i-1),
-    printf(fh, "  d_Jv_P[~a] +=  Hyy_M2yy[~a] - Hyy_M1y_Vy[~a]; ~%", i-1, i-1, i-1)
+    printf(fh, "  d_Jv_P[~a] += (- Hxy_M1x_Vy[~a])*2.0; ~%", i-1, i-1),
+    printf(fh, "  d_Jv_P[~a] +=  - Hyy_M1y_Vy[~a]; ~%", i-1, i-1)
     ),
     if (cdim > 2) then (
-      printf(fh, "  d_Jv_P[~a] += (Hxz_M2xz[~a] - Hxz_M1x_Vz[~a])*2.0; ~%", i-1, i-1, i-1),
-      printf(fh, "  d_Jv_P[~a] += (Hyz_M2yz[~a] - Hyz_M1y_Vz[~a])*2.0; ~%", i-1, i-1, i-1),
-      printf(fh, "  d_Jv_P[~a] +=  Hzz_M2zz[~a] - Hzz_M1z_Vz[~a]; ~%", i-1, i-1, i-1)
+      printf(fh, "  d_Jv_P[~a] += (- Hxz_M1x_Vz[~a])*2.0; ~%", i-1, i-1),
+      printf(fh, "  d_Jv_P[~a] += (- Hyz_M1y_Vz[~a])*2.0; ~%", i-1, i-1),
+      printf(fh, "  d_Jv_P[~a] +=  - Hzz_M1z_Vz[~a]; ~%", i-1, i-1)
     )
   ),
   printf(fh, " ~%"),

--- a/maxima/g0/canonical_pb/canonical-pressure-vars.mac
+++ b/maxima/g0/canonical_pb/canonical-pressure-vars.mac
@@ -12,7 +12,7 @@ load("scifac")$
 fpprec : 24$
 
 calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
-  [], /*Fill block*/
+  [varsC, bC, NC],
 
   kill(varsC, bC),
 

--- a/maxima/g0/canonical_pb/canonical-vol.mac
+++ b/maxima/g0/canonical_pb/canonical-vol.mac
@@ -26,12 +26,40 @@ buildCanonicalPBVolKernel(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC, varsP, basisC, basisP, modNm, i, bP, bC, numC, cid, vid, dir, 
     pbfac, volfac, fl, Hl, pb, pbBasis],
 
-  kill(varsC, varsP, basisC, basisP),
-  modNm : sconcat("basis-precalc/basis", basisFun, cdim, "x", vdim, "v"),
-  load(modNm),
+  kill(varsC, varsP, bC, bP),
+  pOrderV : polyOrder,
+  /* Load basis of dimensionality requested. */
+  if (basisFun="tensor") then (
+    /* If we are using the tensor basis, just use the simple load command */
+    [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+    [varsP,bP] : loadBasis(basisFun, cdim+vdim, polyOrder),
+    /* Do a variable substitution for the lower dimensional tensor basis functions
+       to construct the correct set of variables for the subsequent operations */
+    if (cdim+vdim = 2) then (
+      varsSub : [y=vx],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim+vdim = 3) then (
+      varsSub : [y=vx, z=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim = 2 and vdim = 2) then (
+      varsSub : [vx=y, vy=vx, vz=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+  )
+  else (
+    /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+    [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
 
-  bP : basisP[polyOrder],
-  bC : basisC[polyOrder],
+    /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+       mean hybrid basis. */
+    if polyOrder=1 then ( pOrderV : 2 )
+  ),
+
   numC : length(bC),
   printf(fh, "double ~a(const double *w, const double *dxv, const double *hamil, const double *f, double *out) ~%{ ~%", funcNm),
   printf(fh, "// w[NDIM]: Cell-center coordinates. dxv[NDIM]: Cell spacing. H/f: Input Hamiltonian/distribution function. out: Incremented output ~%"),

--- a/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
+++ b/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
@@ -64,12 +64,17 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
   /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
   if (polyOrder=1 and basisFun="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
     bSurf : basisFromVars("hyb",surfIntVars,polyOrder),
-
-    surf_cdim : cdim,  surf_vdim : vdim-1,
+    if (surfDir <= cdim) then (
+      surf_cdim : cdim-1,  surf_vdim : vdim
+    ) 
+    else (
+      surf_cdim : cdim,  surf_vdim : vdim-1
+    ),
     surfNodes : gaussOrdHyb(1+1, surf_cdim, surf_vdim),
 
     basisStr : sconcat("hyb_", cdim, "x", vdim, "v", "_p", polyOrder)
-  ) else (
+  ) 
+  else (
     bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
 
     surfNodes : gaussOrd(polyOrder+1, pDim-1),

--- a/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
+++ b/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
@@ -127,8 +127,8 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
   fl_e : doExpand1(fl, bP),
   fc_e : doExpand1(fc, bP),
   fr_e : doExpand1(fr, bP),
-  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fl_e,fc_e,basisStr,"L"),
-  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fc_e,fr_e,basisStr,"R"),
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fl_e,fc_e,basisStr,"L",cdim, vdim, polyOrder,basisFun),
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fc_e,fr_e,basisStr,"R",cdim, vdim, polyOrder,basisFun),
 
   fUpL_e : doExpand1(fUpL, bSurf), 
   fUpR_e : doExpand1(fUpR, bSurf), 
@@ -293,7 +293,7 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
 
   NSurf : length(bSurf),
 
-  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fSkin_e,fEdge_e,basisStr,"R"),
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fSkin_e,fEdge_e,basisStr,"R",cdim, vdim, polyOrder, basisFun),
   fUpR_e : doExpand1(fUpR, bSurf), 
   printf(fh, "  double GhatR[~a] = {0.};~%", NSurf), 
   GhatR_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfR_e*fUpR_e), 
@@ -313,7 +313,7 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
   /* Otherwise, edge == 1, and we are doing the right edge boundary and the skin cell needs to be evaluated at -1 */
   printf(fh, "  } else { ~%~%"), 
 
-  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fEdge_e,fSkin_e,basisStr,"L"),
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fEdge_e,fSkin_e,basisStr,"L",cdim, vdim, polyOrder, basisFun),
   fUpL_e : doExpand1(fUpL, bSurf), 
   printf(fh, "  double GhatL[~a] = {0.};~%", NSurf),
   GhatL_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfL_e*fUpL_e), 

--- a/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
+++ b/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
@@ -15,11 +15,41 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
   [varsC, varsP, bC, bP, numC, numP, pDim, surfVar, varLabel, dirLabel, surfIntVars, surf_cvars, surf_vvars, 
    surfNodes, bSurf, basisStr, NSurf, numNodes, NSurfIndexing, numNodesIndexing, rdSurfVar2, rdx2vec, rdv2vec, 
    hamil, alphaSurfL_e, alphaSurfR_e, fl_e, fc_e, fr_e, fUpL_e, fUpR_e, GhatL_c, GhatR_c, GhatL_e, GhatR_e, 
-   incrL_c, incrR_c, pOrderCFL],
+   incrL_c, incrR_c, pOrderCFL, pOrderV],
 
   kill(varsC,varsP,bC,bP),
+  pOrderV : polyOrder,
+  /* Load basis of dimensionality requested. */
+  if (basisFun="tensor") then (
+    /* If we are using the tensor basis, just use the simple load command */
+    [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+    [varsP,bP] : loadBasis(basisFun, cdim+vdim, polyOrder),
+    /* Do a variable substitution for the lower dimensional tensor basis functions
+       to construct the correct set of variables for the subsequent operations */
+    if (cdim+vdim = 2) then (
+      varsSub : [y=vx],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim+vdim = 3) then (
+      varsSub : [y=vx, z=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim = 2 and vdim = 2) then (
+      varsSub : [vx=y, vy=vx, vz=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+  )
+  else (
+    /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+    [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
 
-  [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+    /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+       mean hybrid basis. */
+    if polyOrder=1 then ( pOrderV : 2 )
+  ),
   numC : length(bC),  numP : length(bP), pDim  : length(varsP),
 
   surfVar : varsP[surfDir],         /* Surface variable. */
@@ -30,9 +60,22 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
   surf_cvars : delete(surfVar, makelist(varsP[i],i,1,cdim)),
   surf_vvars : delete(surfVar, makelist(varsP[cdim+i],i,1,vdim)),
 
-  surfNodes : gaussOrd(polyOrder+1, pDim-1),
-  bSurf     : basisFromVars(basisFun,surfIntVars,polyOrder),
-  basisStr  : sconcat(basisFun, "_", cdim+vdim, "x", "_p", polyOrder),
+  /* Generate surface basis. this produces the ndim-1 orthogonal basis with no vv dependence. */
+  /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
+  if (polyOrder=1 and basisFun="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+    bSurf : basisFromVars("hyb",surfIntVars,polyOrder),
+
+    surf_cdim : cdim,  surf_vdim : vdim-1,
+    surfNodes : gaussOrdHyb(1+1, surf_cdim, surf_vdim),
+
+    basisStr : sconcat("hyb_", cdim, "x", vdim, "v", "_p", polyOrder)
+  ) else (
+    bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
+
+    surfNodes : gaussOrd(polyOrder+1, pDim-1),
+
+    basisStr : sconcat(basisFun, "_", cdim+vdim, "x", "_p", polyOrder)
+  ),
 
   NSurf : length(bSurf),
   numNodes  : length(surfNodes),
@@ -71,8 +114,8 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
 
   /* Compute the surface alpha but do *not* write it out; we already computed it
      We just need to re-compute it here in Maxima to get the right sparsity pattern */
-  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,polyOrder,basisFun,rdx2vec,rdv2vec,hamil,"L"),
-  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,polyOrder,basisFun,rdx2vec,rdv2vec,hamil,"R"),
+  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
+  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
 
   printf(fh, "  const double *alphaL = &alpha_surf_l[~a];~%", (surfDir-1)*NSurfIndexing),
   printf(fh, "  const double *alphaR = &alpha_surf_r[~a];~%", (surfDir-1)*NSurfIndexing),
@@ -115,7 +158,7 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
      Also need to divide out 1/sqrt(2^(pDim-1)) to convert 0th component of surface alpha
      expansion to cell average (so we take the surface averaged alpha as our estimate of the
      maximum velocity to compute the largest frequency) */
-  pOrderCFL : polyOrder,
+  pOrderCFL : pOrderV,
   printf(fh, "  double cflFreq = fmax(fabs(alphaL[0]), fabs(alphaR[0])); ~%"),
   printf(fh, "  return ~a*cflFreq; ~%",float(0.5*(2*pOrderCFL+1)*rdSurfVar2*2.0^(-0.5*(pDim-1)))),
   printf(fh, "~%"),
@@ -128,11 +171,42 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
 calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC, varsP, bC, bP, numC, numP, pDim, surfVar, varLabel, dirLabel, surfIntVars, surf_cvars, surf_vvars, 
    NSurfIndexing, numNodesIndexing, rdSurfVar2, rdx2vec, rdv2vec, hamil, alphaSurfL_e, alphaSurfR_e, 
-   fEdge_e, fSkin_e, fUpR_e, GhatR_c, GhatR_e, incrR_c, fUpL_e, GhatL_c, GhatL_e, incrL_c, pOrderCFL, basisStr],
+   fEdge_e, fSkin_e, fUpR_e, GhatR_c, GhatR_e, incrR_c, fUpL_e, GhatL_c, GhatL_e, incrL_c, pOrderCFL, pOrderV, basisStr],
 
   kill(varsC,varsP,bC,bP),
 
-  [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+  pOrderV : polyOrder,
+  /* Load basis of dimensionality requested. */
+  if (basisFun="tensor") then (
+    /* If we are using the tensor basis, just use the simple load command */
+    [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+    [varsP,bP] : loadBasis(basisFun, cdim+vdim, polyOrder),
+    /* Do a variable substitution for the lower dimensional tensor basis functions
+       to construct the correct set of variables for the subsequent operations */
+    if (cdim+vdim = 2) then (
+      varsSub : [y=vx],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim+vdim = 3) then (
+      varsSub : [y=vx, z=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim = 2 and vdim = 2) then (
+      varsSub : [vx=y, vy=vx, vz=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+  )
+  else (
+    /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+    [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+
+    /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+       mean hybrid basis. */
+    if polyOrder=1 then ( pOrderV : 2 )
+  ),
   numC : length(bC),  numP : length(bP), pDim  : length(varsP),
   
   surfVar : varsP[surfDir],         /* Surface variable. */
@@ -143,7 +217,22 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
   surf_cvars : delete(surfVar, makelist(varsP[i],i,1,cdim)),
   surf_vvars : delete(surfVar, makelist(varsP[cdim+i],i,1,vdim)),
   NSurfIndexing : NSurf,
-  surfNodes : gaussOrd(polyOrder+1, pDim-1),
+  /* Generate surface basis. this produces the ndim-1 orthogonal basis with no vv dependence. */
+  /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
+  if (polyOrder=1 and basisFun="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+    bSurf : basisFromVars("hyb",surfIntVars,polyOrder),
+
+    surf_cdim : cdim,  surf_vdim : vdim-1,
+    surfNodes : gaussOrdHyb(1+1, surf_cdim, surf_vdim),
+
+    basisStr : sconcat("hyb_", cdim, "x", vdim, "v", "_p", polyOrder)
+  ) else (
+    bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
+
+    surfNodes : gaussOrd(polyOrder+1, pDim-1),
+
+    basisStr : sconcat(basisFun, "_", cdim+vdim, "x", "_p", polyOrder)
+  ),
   numNodes  : length(surfNodes),
   numNodesIndexing : numNodes,
 
@@ -182,8 +271,8 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
      We just need to re-compute it here in Maxima to get the right sparsity pattern 
      Further, for boundary surface kernels we will only use one of the surface alphas
      for computing the update (but pre-compute both for convenience here). */
-  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,polyOrder,basisFun,rdx2vec,rdv2vec,hamil,"L"),
-  alphaSurfR_e :  calc_canonical_pb_alpha_no_write(fh,surfDir,bP,polyOrder,basisFun,rdx2vec,rdv2vec,hamil,"R"),
+  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
+  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
 
   /* When we need the surface alpha at +1, we use alpha_edge 
      (which stores the next interior edge surface alpha at -1 and alpha is continuous)
@@ -202,9 +291,7 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
   /* if edge == -1, we are doing the left edge boundary and the skin cell needs to be evaluated at +1 */
   printf(fh, "  if (edge == -1) { ~%~%"),
 
-  bSurf : basisFromVars(basisFun,surfIntVars,polyOrder),
   NSurf : length(bSurf),
-  basisStr  : sconcat(basisFun, "_", cdim+vdim, "x", "_p", polyOrder),
 
   calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fSkin_e,fEdge_e,basisStr,"R"),
   fUpR_e : doExpand1(fUpR, bSurf), 
@@ -248,7 +335,7 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
      Also need to divide out 1/sqrt(2^(pDim-1)) to convert 0th component of surface alpha
      expansion to cell average (so we take the surface averaged alpha as our estimate of the
      maximum velocity to compute the largest frequency) */
-  pOrderCFL : polyOrder,
+  pOrderCFL : pOrderV,
   printf(fh, "  double cflFreq = fmax(fabs(alphaL[0]), fabs(alphaR[0])); ~%"),
   printf(fh, "  return ~a*cflFreq; ~%",float(0.5*(2*pOrderCFL+1)*rdSurfVar2*2.0^(-0.5*(pDim-1)))),
   printf(fh, "~%"),

--- a/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
+++ b/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
@@ -122,10 +122,23 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
   alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
   alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
 
-  printf(fh, "  const double *alphaL = &alpha_surf_l[~a];~%", (surfDir-1)*NSurfIndexing),
-  printf(fh, "  const double *alphaR = &alpha_surf_r[~a];~%", (surfDir-1)*NSurfIndexing),
-  printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_l[~a];~%", (surfDir-1)*numNodesIndexing),
-  printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_r[~a];~%", (surfDir-1)*numNodesIndexing),
+  if (polyOrder=1 and basisFun="ser" and surfDir > cdim) then (
+   surfIntVars_hyb_conf : delete(varsP[1],varsP),
+   bSurf_hyb_conf : basisFromVars("hyb",surfIntVars_hyb_conf,polyOrder),
+   surfNodes_hyb_conf : gaussOrdHyb(1+1, cdim-1, vdim),
+   NSurfIndexing_hyb_conf : length(bSurf_hyb_conf),
+   numNodesIndexing_hyb_conf  : length(surfNodes_hyb_conf),
+   printf(fh, "  const double *alphaL = &alpha_surf_l[~a];~%", cdim*NSurfIndexing_hyb_conf + (surfDir-1-cdim)*NSurfIndexing),
+   printf(fh, "  const double *alphaR = &alpha_surf_r[~a];~%", cdim*NSurfIndexing_hyb_conf + (surfDir-1-cdim)*NSurfIndexing),
+   printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_l[~a];~%", cdim*numNodesIndexing_hyb_conf + (surfDir-1-cdim)*numNodesIndexing),
+   printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_r[~a];~%", cdim*numNodesIndexing_hyb_conf + (surfDir-1-cdim)*numNodesIndexing)
+  ) 
+  else (
+   printf(fh, "  const double *alphaL = &alpha_surf_l[~a];~%", (surfDir-1)*NSurfIndexing),
+   printf(fh, "  const double *alphaR = &alpha_surf_r[~a];~%", (surfDir-1)*NSurfIndexing),
+   printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_l[~a];~%", (surfDir-1)*numNodesIndexing),
+   printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_r[~a];~%", (surfDir-1)*numNodesIndexing)
+  ),
   printf(fh, "  const int *const_sgn_alphaL = &const_sgn_alpha_l[~a];~%", surfDir-1),
   printf(fh, "  const int *const_sgn_alphaR = &const_sgn_alpha_r[~a];~%", surfDir-1),
   printf(fh, "~%"),
@@ -283,10 +296,24 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
      (which stores the next interior edge surface alpha at -1 and alpha is continuous)
      When we need the surface alpha at -1, we use alpha_skin 
      (which stores the skin cell surface alpha at -1 and alpha is continuous) */
-  printf(fh, "  const double *alphaL = &alpha_surf_skin[~a];~%", (surfDir-1)*NSurfIndexing),
-  printf(fh, "  const double *alphaR = &alpha_surf_edge[~a];~%", (surfDir-1)*NSurfIndexing),
-  printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_skin[~a];~%", (surfDir-1)*numNodesIndexing),
-  printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_edge[~a];~%", (surfDir-1)*numNodesIndexing),
+
+  if (polyOrder=1 and basisFun="ser" and surfDir > cdim) then (
+   surfIntVars_hyb_conf : delete(varsP[1],varsP),
+   bSurf_hyb_conf : basisFromVars("hyb",surfIntVars_hyb_conf,polyOrder),
+   surfNodes_hyb_conf : gaussOrdHyb(1+1, cdim-1, vdim),
+   NSurfIndexing_hyb_conf : length(bSurf_hyb_conf),
+   numNodesIndexing_hyb_conf  : length(surfNodes_hyb_conf),   
+   printf(fh, "  const double *alphaL = &alpha_surf_skin[~a];~%", cdim*NSurfIndexing_hyb_conf + (surfDir-1-cdim)*NSurfIndexing),
+   printf(fh, "  const double *alphaR = &alpha_surf_edge[~a];~%", cdim*NSurfIndexing_hyb_conf + (surfDir-1-cdim)*NSurfIndexing),
+   printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_skin[~a];~%", cdim*numNodesIndexing_hyb_conf + (surfDir-1-cdim)*numNodesIndexing),
+   printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_edge[~a];~%", cdim*numNodesIndexing_hyb_conf + (surfDir-1-cdim)*numNodesIndexing)
+  ) 
+  else (
+   printf(fh, "  const double *alphaL = &alpha_surf_skin[~a];~%", (surfDir-1)*NSurfIndexing),
+   printf(fh, "  const double *alphaR = &alpha_surf_edge[~a];~%", (surfDir-1)*NSurfIndexing),
+   printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_skin[~a];~%", (surfDir-1)*numNodesIndexing),
+   printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_edge[~a];~%", (surfDir-1)*numNodesIndexing)
+  ),
   printf(fh, "  const int *const_sgn_alphaL = &const_sgn_alpha_skin[~a];~%", surfDir-1),
   printf(fh, "  const int *const_sgn_alphaR = &const_sgn_alpha_edge[~a];~%", surfDir-1),
   printf(fh, "~%"),

--- a/maxima/g0/canonical_pb/canonicalMomentFuncs.mac
+++ b/maxima/g0/canonical_pb/canonicalMomentFuncs.mac
@@ -1,0 +1,81 @@
+/* Functions (called by moment-calc.mac) that compute specific 
+moments that differ from their Vlasov counterparts for the can-pb
+model. */
+
+load("modal-basis");
+load("out-scripts");
+load("utilities")$
+load(stringproc)$
+fpprec : 24$
+
+volExpr(cdim, vdim) := prod(dxv[cdim+i-1], i, 1, vdim)$
+volExprTot(totDim) := prod(dxv[i-1], i, 1, totDim)$
+pVsub : [x=vx,y=vy,z=vz]$
+vidx(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
+
+
+/* Energy */
+calcCanPBEnergy(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC, bC, varsP, bP, varsV, bV, NC, NP, NV, fl, M, clst],
+  /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+  [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+  /* Number of basis monomials. */
+  NP : length(bP),
+  NC : length(bC),
+  pDim : length(varsP),
+  
+  printf(fh, "GKYL_CU_DH void ~a_MEnergy_~ax~av_~a_p~a(const double *dxv, const double *hamil, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+  printf(fh, "  const double volFact = ~a/~a; ~%", volExpr(cdim, vdim), 2^vdim),
+
+  vid : vidx(cdim,vdim),
+  for i : 1 thru vdim do (
+    printf(fh, "  const double dv1~a = 2.0/dxv[~a]; ~%", i-1, vid[i])
+  ),
+  printf(fh, "~%"),
+  
+  hamill : doExpand1(hamil, bP),
+  fl : doExpand1(f, bP),
+  
+  M : calcInnerProdList(varsP, hamill, bC, fl),
+  
+  clst : [volFact],
+  writeCIncrExprsCollect1(out, volFact*M, clst),
+  
+  printf(fh, "} ~%")
+)$
+
+calcCanPBIntMDist(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC, bC, varsP, bP, varsV, bV, NC, NP, NV, fl, M0, Energy, M3, clst, int],
+  /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+  [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+  /* Number of basis monomials. */
+  NP : length(bP),
+  NC : length(bC),
+  pDim : length(varsP),
+    
+  printf(fh, "GKYL_CU_DH void ~a_int_mom_~ax~av_~a_p~a(const double *dxv, const double *hamil, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+  printf(fh, "  const double volFact = ~a*~a; ~%", volExprTot(cdim+vdim), float(1/(2^(cdim+vdim))) ),
+  for i : 1 thru vdim do (
+    printf(fh, "  const double dv~a = dxv[~a]; ~%", i, cdim+i-1)
+  ),
+
+  fl : doExpand1(f, bP),
+
+  M : [],
+
+  Energy : fullratsimp(innerProd(varsP, 1, doExpand1(hamil, bP), fl)),
+  M  : endcons(Energy, M),
+
+  M : map(letsimp, M),
+  clst : [volFact],
+  writeCIncrExprsCollect1(out, volFact*M, clst),
+
+  printf(fh, "} ~%")
+)$
+
+calcCanPBMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block([],
+  printf(fh, "#include <gkyl_mom_canonical_pb_kernels.h> ~%"),
+  calcCanPBEnergy(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  calcCanPBIntMDist(fh, funcNm, cdim, vdim, basisFun, polyOrder)
+)$

--- a/maxima/g0/canonical_pb/canonicalMomentFuncs.mac
+++ b/maxima/g0/canonical_pb/canonicalMomentFuncs.mac
@@ -5,6 +5,7 @@ model. */
 load("modal-basis");
 load("out-scripts");
 load("utilities")$
+load("canonical_pb/canonicalUtils.mac")$
 load(stringproc)$
 fpprec : 24$
 
@@ -12,6 +13,9 @@ volExpr(cdim, vdim) := prod(dxv[cdim+i-1], i, 1, vdim)$
 volExprTot(totDim) := prod(dxv[i-1], i, 1, totDim)$
 pVsub : [x=vx,y=vy,z=vz]$
 vidx(cdim,vdim) := makelist(i,i,cdim,cdim+vdim-1)$
+
+slcn(lst, n) := makelist(lst[i], i, 1, n)$
+slcn_v(lst, n) := makelist(lst[i], i, n+1, length(lst))$
 
 
 /* Energy */
@@ -46,7 +50,7 @@ calcCanPBEnergy(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 )$
 
 calcCanPBIntMDist(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [varsC, bC, varsP, bP, varsV, bV, NC, NP, NV, fl, M0, Energy, M3, clst, int],
+  [varsC, bC, varsP, bP, varsV, bV, NC, NP, NV, fl, M0, Energy, M1i, clst, int],
   /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
   [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
   /* Number of basis monomials. */
@@ -63,6 +67,30 @@ calcCanPBIntMDist(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   fl : doExpand1(f, bP),
 
   M : [],
+
+  /* Computes: integrated, Density, Momentum, and Energy */
+  M0 : fullratsimp(innerProd(varsP, 1, 1, fl)),
+  M  : endcons(M0,M),
+
+  /* Grab C, V vars */
+  varsP : listofvars(bP),
+  varsV : slcn_v(varsP, cdim),
+  varLabel : makelist(string(varsP[d]),d,1,pDim),
+
+  /* Calculate phase space velocity alpha_d = {z[d], H} = dz[d]/dt. */
+  for d : cdim + 1 thru pDim do (
+    printf(fh, "  const double rd~a2 = 2.0/dxv[~a];~%", varLabel[d], d-1)
+  ),
+  printf(fh, "~%"),
+  rdv2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,cdim+1,pDim),
+  p : varsV, 
+  dp : rdv2vec,
+
+ /* Calculate phase space velocity alpha_d = {z[d], H} = dz[d]/dt = dH/dp_d. */
+  for dir : 1 thru vdim do (
+    M1i : fullratsimp(innerProd(varsP, 1, dp[dir]*diff(doExpand1(hamil, bP), p[dir]), fl)),
+    M  : endcons(M1i,M)
+  ),
 
   Energy : fullratsimp(innerProd(varsP, 1, doExpand1(hamil, bP), fl)),
   M  : endcons(Energy, M),

--- a/maxima/g0/canonical_pb/canonicalMomentFuncs.mac
+++ b/maxima/g0/canonical_pb/canonicalMomentFuncs.mac
@@ -21,8 +21,40 @@ slcn_v(lst, n) := makelist(lst[i], i, n+1, length(lst))$
 /* Energy */
 calcCanPBEnergy(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC, bC, varsP, bP, varsV, bV, NC, NP, NV, fl, M, clst],
-  /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
-  [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+
+  pOrderV : polyOrder,
+  /* Load basis of dimensionality requested. */
+  if (basisFun="tensor") then (
+    /* If we are using the tensor basis, just use the simple load command */
+    [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+    [varsP,bP] : loadBasis(basisFun, cdim+vdim, polyOrder),
+    /* Do a variable substitution for the lower dimensional tensor basis functions
+       to construct the correct set of variables for the subsequent operations */
+    if (cdim+vdim = 2) then (
+      varsSub : [y=vx],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim+vdim = 3) then (
+      varsSub : [y=vx, z=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim = 2 and vdim = 2) then (
+      varsSub : [vx=y, vy=vx, vz=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+  )
+  else (
+    /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+    [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+
+    /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+       mean hybrid basis. */
+    if polyOrder=1 then ( pOrderV : 2 )
+  ),
+
   /* Number of basis monomials. */
   NP : length(bP),
   NC : length(bC),
@@ -51,8 +83,41 @@ calcCanPBEnergy(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
 calcCanPBIntMDist(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC, bC, varsP, bP, varsV, bV, NC, NP, NV, fl, M0, Energy, M1i, clst, int],
-  /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
-  [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+
+
+  pOrderV : polyOrder,
+  /* Load basis of dimensionality requested. */
+  if (basisFun="tensor") then (
+    /* If we are using the tensor basis, just use the simple load command */
+    [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+    [varsP,bP] : loadBasis(basisFun, cdim+vdim, polyOrder),
+    /* Do a variable substitution for the lower dimensional tensor basis functions
+       to construct the correct set of variables for the subsequent operations */
+    if (cdim+vdim = 2) then (
+      varsSub : [y=vx],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim+vdim = 3) then (
+      varsSub : [y=vx, z=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+    else if (cdim = 2 and vdim = 2) then (
+      varsSub : [vx=y, vy=vx, vz=vy],
+      bP : subst(varsSub, copylist(bP)),  
+      varsP : subst(varsSub, copylist(varsP))
+    )
+  )
+  else (
+    /* Load the specific desired basis, including the loading of the hybrid basis if p=1 */
+    [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder),
+
+    /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+       mean hybrid basis. */
+    if polyOrder=1 then ( pOrderV : 2 )
+  ),
+
   /* Number of basis monomials. */
   NP : length(bP),
   NC : length(bC),

--- a/maxima/g0/canonical_pb/canonicalUtils.mac
+++ b/maxima/g0/canonical_pb/canonicalUtils.mac
@@ -18,16 +18,15 @@ PB(f, g, x_vec, y_vec, dx_vec, dy_vec) :=
     i, 1, length(x_vec)
   )$
 
-calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,polyOrder,basisType,rdx2V,rdv2V,hamil,sideStr) := block(
-  [varsP, varsC, varsV, varLabel, dirLabel, wSurf, rdSurfVar2, surfVar, surfIntVars, rdx2vec, rdv2vec,
-   z, q, p, dq, dp, alpha, alphaUp, bSurf, numSurf, evPoint, replaceList, alpha_c, printf, alphaCvar,
+calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,hamil,sideStr) := block(
+  [varsC, varsV, varLabel, dirLabel, wSurf, rdSurfVar2, surfVar, surfIntVars, rdx2vec, rdv2vec,
+   z, q, p, dq, dp, alpha, alphaUp, numSurf, evPoint, replaceList, alpha_c, printf, alphaCvar,
    alphaNoZero_c, alphaSurf, alphaUpSurf], 
   /* Calculate phase space velocity alpha in direction of surfVar. */
   /* We assume alpha.n and hamil is continuous across boundary. */
   /* Distinguish between alpha and alphaUp, where alphaUp is the one used to
      determine upwind direction. */
 
-  varsP : listofvars(bP),
   varsC : slcn(varsP, cdim),
   varsV : slcn_v(varsP, cdim),
   varLabel : makelist(string(varsP[d]),d,1,pDim),
@@ -49,7 +48,6 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,polyOrder,basisType,rdx2V,rdv2V,ham
   dp : rdv2vec,
   alpha : PB(z,hamil,q,p,dq,dp),
 
-  bSurf : basisFromVars(basisType,surfIntVars,polyOrder),
   numSurf : length(bSurf),
 
   if sideStr="L" then (evPoint : -1)
@@ -71,17 +69,16 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,polyOrder,basisType,rdx2V,rdv2V,ham
 
 
 
-calc_canonical_pb_alpha_no_write(fH,surfDir,bP,polyOrder,basisType,rdx2V,rdv2V,
+calc_canonical_pb_alpha_no_write(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,
                    hamil,sideStr) := block(
-  [varsP, varsC, varsV, varLabel, dirLabel, wSurf, rdSurfVar2, surfVar, surfIntVars, rdx2vec, rdv2vec,
-   z, q, p, dq, dp, alpha, alphaUp, bSurf, numSurf, evPoint, replaceList, alpha_c, printf, alphaCvar,
+  [varsC, varsV, varLabel, dirLabel, wSurf, rdSurfVar2, surfVar, surfIntVars, rdx2vec, rdv2vec,
+   z, q, p, dq, dp, alpha, alphaUp, numSurf, evPoint, replaceList, alpha_c, printf, alphaCvar,
    alphaNoZero_c, alphaSurf, alphaUpSurf],
   /* Calculate phase space velocity alpha in direction of surfVar. */
   /* We assume alpha.n is continuous across boundary, although H may not be. */
   /* Distinguish between alpha and alphaUp, where alphaUp is the one used to
      determine upwind direction. */
 
-  varsP    : listofvars(bP),
   varsC : slcn(varsP, cdim),
   varsV : slcn_v(varsP, cdim),
   varLabel : makelist(string(varsP[d]),d,1,pDim),
@@ -104,7 +101,6 @@ calc_canonical_pb_alpha_no_write(fH,surfDir,bP,polyOrder,basisType,rdx2V,rdv2V,
   dp : rdv2vec,
   alpha : PB(z,hamil,q,p,dq,dp),
 
-  bSurf : basisFromVars(basisType,surfIntVars,polyOrder),
   numSurf : length(bSurf),
 
   if sideStr="L" then (evPoint : -1)
@@ -114,7 +110,7 @@ calc_canonical_pb_alpha_no_write(fH,surfDir,bP,polyOrder,basisType,rdx2V,rdv2V,
      onto surface basis and print to C variable alpha. */
   alpha_c : calcInnerProdList(surfIntVars, 1, bSurf, subst(surfVar=evPoint,alpha)),
   alphaCvar : eval_string(sconcat("alpha",sideStr)),
-  alphaNoZero_c : doMakeExprLst(alpha_c, alphaCvar),
+  alphaNoZero_c : makelistNoZeros1(alpha_c, alphaCvar),
   alphaSurf_e   : doExpand(alphaNoZero_c, bSurf),
 
   return(alphaSurf_e)

--- a/maxima/g0/canonical_pb/canonicalUtils.mac
+++ b/maxima/g0/canonical_pb/canonicalUtils.mac
@@ -9,6 +9,8 @@ load("nodal_operations/nodal_functions")$
 load("nodal_operations/quadrature_functions")$
 load("utilities")$
 
+/* Helper functions for expanding in basis functions a quantity we know should be sparse  */
+doMakeExprLst(vals, S)  := makelist(if vals[i] # 0 then S[i-1] else 0, i, 1, length(vals))$
 slcn(lst, n) := makelist(lst[i], i, 1, n)$
 slcn_v(lst, n) := makelist(lst[i], i, n+1, length(lst))$
 
@@ -61,7 +63,7 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,h
   writeCExprsCollect1(alphaCvar, alpha_c, clst),
   printf(fh, "~%"),
   flush_output(fh),
-  alphaNoZero_c : makelistNoZeros1(alpha_c, alphaCvar),
+  alphaNoZero_c : doMakeExprLst(alpha_c, alphaCvar),
   alphaSurf_e   : doExpand(alphaNoZero_c, bSurf),
 
   return(alphaSurf_e)
@@ -110,7 +112,7 @@ calc_canonical_pb_alpha_no_write(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V
      onto surface basis and print to C variable alpha. */
   alpha_c : calcInnerProdList(surfIntVars, 1, bSurf, subst(surfVar=evPoint,alpha)),
   alphaCvar : eval_string(sconcat("alpha",sideStr)),
-  alphaNoZero_c : makelistNoZeros1(alpha_c, alphaCvar),
+  alphaNoZero_c : doMakeExprLst(alpha_c, alphaCvar),
   alphaSurf_e   : doExpand(alphaNoZero_c, bSurf),
 
   return(alphaSurf_e)
@@ -170,7 +172,7 @@ calcAndWrite_CanonicalPBfUpwind(file_handle,surfDir,surfVar,surfIntVars,bSurf,NS
       if (surfDir - cdim > 0) then ( 
         /* Velocity space */
         printf(file_handle, "  hyb_~ax~av_p1_vdir_upwind_quad_to_modal(~a, ~a); ~%", cdim, vdim, sgn_alpha_surfNm, sgn_alphaUpNm)
-      ) else if (surfDir - cdim <= 0) then ( 
+      ) else ( 
         /* configuration space */
         printf(file_handle, "  hyb_~ax~av_p1_xdir_upwind_quad_to_modal(~a, ~a); ~%", cdim, vdim, sgn_alpha_surfNm, sgn_alphaUpNm)
       )

--- a/maxima/g0/canonical_pb/canonicalUtils.mac
+++ b/maxima/g0/canonical_pb/canonicalUtils.mac
@@ -61,7 +61,7 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,h
   writeCExprsCollect1(alphaCvar, alpha_c, clst),
   printf(fh, "~%"),
   flush_output(fh),
-  alphaNoZero_c : doMakeExprLst(alpha_c, alphaCvar),
+  alphaNoZero_c : makelistNoZeros1(alpha_c, alphaCvar),
   alphaSurf_e   : doExpand(alphaNoZero_c, bSurf),
 
   return(alphaSurf_e)
@@ -118,7 +118,8 @@ calc_canonical_pb_alpha_no_write(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V
 
 
 /* Determine the upwinded distribution function in canonical pb */
-calcAndWrite_CanonicalPBfUpwind(file_handle,surfDir,surfVar,surfIntVars,bSurf,NSurf,fl_e,fr_e,basisStr,sideStr) := block(
+calcAndWrite_CanonicalPBfUpwind(file_handle,surfDir,surfVar,surfIntVars,bSurf,NSurf,fl_e,fr_e,basisStr,sideStr,
+                    cdim, vdim, polyOrder,basisFun) := block(
   [fstrL, fstrR, fLNm, fRNm, fUpNm, sgn_alpha_surfNm, sgn_alphaUpNm, fSurfl_c, fSurfr_c, 
    fSurfl_e, fSurfr_e, sgn_alphaUp_e, fUp_c],
    
@@ -162,7 +163,22 @@ calcAndWrite_CanonicalPBfUpwind(file_handle,surfDir,surfVar,surfIntVars,bSurf,NS
     printf(file_handle, "  double f_~a[~a] = {0.};~%", fstrL, NSurf),
     printf(file_handle, "  double f_~a[~a] = {0.};~%", fstrR, NSurf),
     printf(file_handle, "  double sgn_alphaUp~a[~a] = {0.};~%", sideStr, NSurf),
-    printf(file_handle, "  ~a_upwind_quad_to_modal(~a, ~a); ~%", basisStr, sgn_alpha_surfNm, sgn_alphaUpNm),
+    
+    /*printf(file_handle, "  ~a_upwind_quad_to_modal(~a, ~a); ~%", basisStr, sgn_alpha_surfNm, sgn_alphaUpNm),*/
+    printf(file_handle, "  // Project tensor nodal quadrature basis back onto modal basis. ~%"),
+    if (polyOrder=1 and basisFun="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+      if (surfDir - cdim > 0) then ( 
+        /* Velocity space */
+        printf(file_handle, "  hyb_~ax~av_p1_vdir_upwind_quad_to_modal(~a, ~a); ~%", cdim, vdim, sgn_alpha_surfNm, sgn_alphaUpNm)
+      ) else if (surfDir - cdim <= 0) then ( 
+        /* configuration space */
+        printf(file_handle, "  hyb_~ax~av_p1_xdir_upwind_quad_to_modal(~a, ~a); ~%", cdim, vdim, sgn_alpha_surfNm, sgn_alphaUpNm)
+      )
+    ) else (
+      printf(file_handle, "  ~a_upwind_quad_to_modal(~a, ~a); ~%", basisStr, sgn_alpha_surfNm, sgn_alphaUpNm)
+    ),
+
+
     sgn_alphaUp_e : doExpand1(sgn_alphaUpNm, bSurf),
     printf(file_handle, "~%"),
     writeCExprs1(fLNm, fSurfl_c),

--- a/maxima/g0/canonical_pb/ms-canonical-pb-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-alpha-surf.mac
@@ -6,22 +6,27 @@
 load("canonical_pb/canonical-alpha-surf")$
 ratprint: false;
 
-/* ...... USER INPUTS........ */
-
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
+/* Tensor product basis. */
+/* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 3$
+
 /* ...... END OF USER INPUTS........ */
 
 /* To generate other bases, just add corresponding column to arrays below. */
-bName        : ["ser"]$
-minPolyOrder : [minPolyOrder_Ser]$
-maxPolyOrder : [maxPolyOrder_Ser]$
-minCdim      : [minCdim_Ser]$
-maxCdim      : [maxCdim_Ser]$
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$

--- a/maxima/g0/canonical_pb/ms-canonical-pb-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-alpha-surf.mac
@@ -35,44 +35,70 @@ vlabels : ["vx","vy","vz"]$
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
     v : c, /* Canonical PB only supports equal cdim and vdim */
+    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
 
-    maxPolyOrderB : maxPolyOrder[bInd],
-    if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
-    for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-      /* Surface alpha in direction dir in configuration space.*/
-      for dir : 1 thru c do (
-        fname : sconcat("~/max-out/canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
-        disp(printf(false,"Creating alpha surf~a file: ~a",clabels[dir],fname)),
-  
-        fh : openw(fname),
-        printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x3v */
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        /* Surface alpha in direction dir in configuration space.*/
+        for dir : 1 thru c do (
+          fname : sconcat("~/max-out/canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          disp(printf(false,"Creating alpha surf~a file: ~a",clabels[dir],fname)),
+    
+          fh : openw(fname),
+          printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+          if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+dir),
+            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
+          ) 
+          else (
+            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+dir),
+            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
+          ),
 
-        funcName : sconcat("canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
-        close(fh),
+          funcName : sconcat("canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
+          close(fh),
 
-        fname : sconcat("~/max-out/canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
-        disp(printf(false,"Creating alpha edge surf~a file: ~a",clabels[dir],fname)),
-  
-        fh : openw(fname),
-        printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+          fname : sconcat("~/max-out/canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          disp(printf(false,"Creating alpha edge surf~a file: ~a",clabels[dir],fname)),
+    
+          fh : openw(fname),
+          printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+          if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+dir),
+            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
+          ) 
+          else (
+            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+dir),
+            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
+          ),
 
-        funcName : sconcat("canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, true), /* An edge */
-        close(fh)
-      ),
+          funcName : sconcat("canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, true), /* An edge */
+          close(fh)
+        ),
 
-      /* Surface alpha in v direction.*/
-      for v_sub_indx : 1 thru v do (
-        fname : sconcat("~/max-out/canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
-        disp(printf(false,"Creating alpha surfvx file: ~a",fname)),
+        /* Surface alpha in v direction.*/
+        for v_sub_indx : 1 thru v do (
+          fname : sconcat("~/max-out/canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          disp(printf(false,"Creating alpha surfvx file: ~a",fname)),
 
-        fh : openw(fname),
-        printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+          fh : openw(fname),
+          printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+          if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+v_sub_indx),
+            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
+          ) 
+          else (
+            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+v_sub_indx),
+            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
+          ),
 
-        funcName : sconcat("canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        buildCanonicalPBAlphaKernel(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
-        close(fh)
+          funcName : sconcat("canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          buildCanonicalPBAlphaKernel(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
+          close(fh)
+        )
       )
     )
   )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
@@ -31,36 +31,38 @@ printPrototypes() := block([],
   for bInd : 1 thru length(bName) do (
     for c : minCdim[bInd] thru maxCdim[bInd] do (
       v : c, /* Canonical PB only supports equal cdim and vdim */
+      if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
 
-      maxPolyOrderB : maxPolyOrder[bInd],
-      if (c=3) then maxPolyOrderB : 1, /* Only declare p=1 kernels for 3x3v */
-      for polyOrder : 1 thru maxPolyOrderB do (
-        printf(fh, "GKYL_CU_DH double canonical_pb_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,  
-          const double *fin, double* GKYL_RESTRICT out); ~%", c, v, bName[bInd], polyOrder),
-        funcNm : sconcat("canonical_pb_vars_pressure_",  c, "x_", bName[bInd], "_p", polyOrder),
-        printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *M2_ij, const double *v_j, 
-         const double *nv_i, double* GKYL_RESTRICT d_Jv_P);~%", funcNm, polyOrder),
-         
-        for surfDir : 1 thru c+v do ( /* Iterate over each phase space coordinate */
-          if surfDir<=c then (dirlabel : clabels[surfDir]) else (dirlabel : vlabels[surfDir-c]),
-          printf(fh, "GKYL_CU_DH int canonical_pb_alpha_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
-            double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder),
-          if (surfDir < c+1) then ( /* Only for configuration space */
-            printf(fh, "GKYL_CU_DH int canonical_pb_alpha_edge_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
-              double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder)
-          ),
-          printf(fh, "GKYL_CU_DH double canonical_pb_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
-          const double *alpha_surf_l, const double *alpha_surf_r, 
-          const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
-          const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
-          const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder),
-          printf(fh, "GKYL_CU_DH double canonical_pb_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
-          const double *alpha_surf_edge, const double *alpha_surf_skin, 
-          const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
-          const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, 
-          const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder)
-        ), 
-        printf(fh, "~%")
+        maxPolyOrderB : maxPolyOrder[bInd],
+        if (c=3) then maxPolyOrderB : 1, /* Only declare p=1 kernels for 3x3v */
+        for polyOrder : 1 thru maxPolyOrderB do (
+          printf(fh, "GKYL_CU_DH double canonical_pb_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,  
+            const double *fin, double* GKYL_RESTRICT out); ~%", c, v, bName[bInd], polyOrder),
+          funcNm : sconcat("canonical_pb_vars_pressure_",  c, "x_", bName[bInd], "_p", polyOrder),
+          printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *M2_ij, const double *v_j, 
+          const double *nv_i, double* GKYL_RESTRICT d_Jv_P);~%", funcNm, polyOrder),
+          
+          for surfDir : 1 thru c+v do ( /* Iterate over each phase space coordinate */
+            if surfDir<=c then (dirlabel : clabels[surfDir]) else (dirlabel : vlabels[surfDir-c]),
+            printf(fh, "GKYL_CU_DH int canonical_pb_alpha_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
+              double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder),
+            if (surfDir < c+1) then ( /* Only for configuration space */
+              printf(fh, "GKYL_CU_DH int canonical_pb_alpha_edge_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
+                double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder)
+            ),
+            printf(fh, "GKYL_CU_DH double canonical_pb_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
+            const double *alpha_surf_l, const double *alpha_surf_r, 
+            const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
+            const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
+            const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder),
+            printf(fh, "GKYL_CU_DH double canonical_pb_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
+            const double *alpha_surf_edge, const double *alpha_surf_skin, 
+            const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
+            const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, 
+            const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder)
+          ), 
+          printf(fh, "~%")
+        )
       )
     )
   )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
@@ -8,14 +8,21 @@ maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
+/* Tensor product basis. */
+/* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 3$
+
 /* ...... END OF USER INPUTS........ */
 
 /* To generate other bases, just add corresponding column to arrays below. */
-bName        : ["ser"]$
-minPolyOrder : [minPolyOrder_Ser]$
-maxPolyOrder : [maxPolyOrder_Ser]$
-minCdim      : [minCdim_Ser]$
-maxCdim      : [maxCdim_Ser]$
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
@@ -8,15 +8,21 @@ maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
+/* Tensor product basis. */
+/* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 3$
+
 /* ...... END OF USER INPUTS........ */
 
-cvars : [x, y, z]$
-
-bName        : ["ser"]$
-minPolyOrder : [minPolyOrder_Ser]$
-maxPolyOrder : [maxPolyOrder_Ser]$
-minCdim      : [minCdim_Ser]$
-maxCdim      : [maxCdim_Ser]$
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 printPrototype(deco, ci, vi, bStr, pi) := block([si],
   printf(fh, "~avoid canonical_pb_MEnergy_~ax~av_~a_p~a(const double *dxv, const double *hamil, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
@@ -40,13 +40,15 @@ printf(fh, "~%")$
 decorator : "GKYL_CU_DH "$
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
+    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
 
-    minPolyOrderB : minPolyOrder[bInd],
-    maxPolyOrderB : maxPolyOrder[bInd],
-    if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
+      minPolyOrderB : minPolyOrder[bInd],
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
 
-    for polyOrder : minPolyOrderB thru maxPolyOrderB do (
-    printPrototype(decorator, c, c, bName[bInd], polyOrder)
+      for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+      printPrototype(decorator, c, c, bName[bInd], polyOrder)
+      )
     )
   )
 );

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
@@ -1,0 +1,49 @@
+/* Generate the header file for the Special Relativistic Vlasov moment and integrated moment kernels. */
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+/* ...... END OF USER INPUTS........ */
+
+cvars : [x, y, z]$
+
+bName        : ["ser"]$
+minPolyOrder : [minPolyOrder_Ser]$
+maxPolyOrder : [maxPolyOrder_Ser]$
+minCdim      : [minCdim_Ser]$
+maxCdim      : [maxCdim_Ser]$
+
+printPrototype(deco, ci, vi, bStr, pi) := block([si],
+  printf(fh, "~avoid canonical_pb_MEnergy_~ax~av_~a_p~a(const double *dxv, const double *hamil, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~avoid canonical_pb_int_mom_~ax~av_~a_p~a(const double *dxv, const double *hamil, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~%")  
+)$
+
+fh : openw("~/max-out/gkyl_mom_canonical_pb_kernels.h")$
+printf(fh, "#pragma once ~%")$
+printf(fh, "#include <math.h> ~%")$
+printf(fh, "#include <gkyl_util.h> ~%")$
+printf(fh, "EXTERN_C_BEG ~%")$
+printf(fh, "~%")$
+
+decorator : "GKYL_CU_DH "$
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+
+    minPolyOrderB : minPolyOrder[bInd],
+    maxPolyOrderB : maxPolyOrder[bInd],
+    if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
+
+    for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+    printPrototype(decorator, c, c, bName[bInd], polyOrder)
+    )
+  )
+);
+printf(fh, "EXTERN_C_END ~%")$
+close(fh)$
+/* ............ Finished writing out the C header file ............ */

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
@@ -29,19 +29,21 @@ maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
+    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
 
-    minPolyOrderB : minPolyOrder[bInd],
-    maxPolyOrderB : maxPolyOrder[bInd],
-    if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
+      minPolyOrderB : minPolyOrder[bInd],
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
 
-    /* Canonical-pb moment calculators. */
-    for polyOrder : minPolyOrderB thru maxPolyOrderB do (
-      disp(printf(false,sconcat("Creating Canonical-pb Moments ~ax~av", bName[bInd]),c,c)),
-      fname : sconcat("~/max-out/mom_canonical_pb_", c, "x", c, "v_", bName[bInd], "_p", polyOrder, ".c"),
-      fh : openw(fname),
-      funcName : sconcat("canonical_pb"),
-      calcCanPBMoments(fh, funcName, c, c, bName[bInd], polyOrder),
-      close(fh)
+      /* Canonical-pb moment calculators. */
+      for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+        disp(printf(false,sconcat("Creating Canonical-pb Moments ~ax~av", bName[bInd]),c,c)),
+        fname : sconcat("~/max-out/mom_canonical_pb_", c, "x", c, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        fh : openw(fname),
+        funcName : sconcat("canonical_pb"),
+        calcCanPBMoments(fh, funcName, c, c, bName[bInd], polyOrder),
+        close(fh)
+      )
     )
   )
 );

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
@@ -11,14 +11,21 @@ maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
+/* Tensor product basis. */
+/* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
-bName        : ["ser"]$
-minPolyOrder : [minPolyOrder_Ser]$
-maxPolyOrder : [maxPolyOrder_Ser]$
-minCdim      : [minCdim_Ser]$
-maxCdim      : [maxCdim_Ser]$
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
@@ -1,0 +1,40 @@
+/* Generate kernels that compute the moments of the distribution function for special relativistic Vlasov. */
+
+load("canonical_pb/canonicalMomentFuncs")$
+load(stringproc)$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+
+/* ...... END OF USER INPUTS........ */
+
+bName        : ["ser"]$
+minPolyOrder : [minPolyOrder_Ser]$
+maxPolyOrder : [maxPolyOrder_Ser]$
+minCdim      : [minCdim_Ser]$
+maxCdim      : [maxCdim_Ser]$
+
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+
+    minPolyOrderB : minPolyOrder[bInd],
+    maxPolyOrderB : maxPolyOrder[bInd],
+    if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
+
+    /* Canonical-pb moment calculators. */
+    for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+      disp(printf(false,sconcat("Creating Canonical-pb Moments ~ax~av", bName[bInd]),c,c)),
+      fname : sconcat("~/max-out/mom_canonical_pb_", c, "x", c, "v_", bName[bInd], "_p", polyOrder, ".c"),
+      fh : openw(fname),
+      funcName : sconcat("canonical_pb"),
+      calcCanPBMoments(fh, funcName, c, c, bName[bInd], polyOrder),
+      close(fh)
+    )
+  )
+);

--- a/maxima/g0/canonical_pb/ms-canonical-pb-pressure-vars.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-pressure-vars.mac
@@ -31,17 +31,19 @@ maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 for bInd : 1 thru length(bName) do (
   for d : minCdim[bInd] thru maxCdim[bInd] do (
-    minPolyOrderB : minPolyOrder[bInd],
-    maxPolyOrderB : maxPolyOrder[bInd],
-    if (d>2 and bName[bInd] = "ser") then maxPolyOrderB : 1,
+    if not(d = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
+      minPolyOrderB : minPolyOrder[bInd],
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (d>2) then maxPolyOrderB : 1,
 
-    for polyOrder : minPolyOrderB thru maxPolyOrderB do (
-      disp(printf(false,sconcat("Creating canonical_pb vars funcs ",bName[bInd]," ~axp~a"),d,polyOrder)),
-      fname : sconcat("~/max-out/canonical_pb_vars_pressure_", d, "x_", bName[bInd], "_p", polyOrder, ".c"),
-      fh : openw(fname),
-      funcName : sconcat("canonical_pb_vars_pressure_",  d, "x_", bName[bInd], "_p", polyOrder),
-      calcCanonicalPbPressure(fh, funcName, d, bName[bInd], polyOrder),
-      close(fh)
+      for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+        disp(printf(false,sconcat("Creating canonical_pb vars funcs ",bName[bInd]," ~axp~a"),d,polyOrder)),
+        fname : sconcat("~/max-out/canonical_pb_vars_pressure_", d, "x_", bName[bInd], "_p", polyOrder, ".c"),
+        fh : openw(fname),
+        funcName : sconcat("canonical_pb_vars_pressure_",  d, "x_", bName[bInd], "_p", polyOrder),
+        calcCanonicalPbPressure(fh, funcName, d, "ser", polyOrder),
+        close(fh)
+      )
     )
   )
 );

--- a/maxima/g0/canonical_pb/ms-canonical-pb-pressure-vars.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-pressure-vars.mac
@@ -13,13 +13,21 @@ maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
+/* Tensor product basis. */
+/* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 3$
+
 /* ...... END OF USER INPUTS........ */
 
-bName        : ["ser"]$
-minPolyOrder : [minPolyOrder_Ser]$
-maxPolyOrder : [maxPolyOrder_Ser]$
-minCdim      : [minCdim_Ser]$
-maxCdim      : [maxCdim_Ser]$
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 for bInd : 1 thru length(bName) do (
   for d : minCdim[bInd] thru maxCdim[bInd] do (

--- a/maxima/g0/canonical_pb/ms-canonical-pb-surf.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-surf.mac
@@ -16,14 +16,21 @@ maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
+/* Tensor product basis. */
+/* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 3$
+
 /* ...... END OF USER INPUTS........ */
 
 /* To generate other bases, just add corresponding column to arrays below. */
-bName        : ["ser"]$
-minPolyOrder : [minPolyOrder_Ser]$
-maxPolyOrder : [maxPolyOrder_Ser]$
-minCdim      : [minCdim_Ser]$
-maxCdim      : [maxCdim_Ser]$
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$

--- a/maxima/g0/canonical_pb/ms-canonical-pb-surf.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-surf.mac
@@ -37,7 +37,12 @@ vlabels : ["vx","vy","vz"]$
 
 includeSurfHeaders(fhIn, bname, c, v, porder, dir) := block([],
   printf(fhIn, "#include <gkyl_canonical_pb_kernels.h>~%"),
-  printf(fhIn, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bname, c+v, porder)
+  if (polyOrder=1 and bname="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+    printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
+  ) 
+  else (
+    printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bname, c+v, porder)
+  )
 )$
 printf(fh, "~%"),
 
@@ -46,50 +51,53 @@ for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
     v : c, /* Canonical PB only supports equal cdim and vdim */
 
-    maxPolyOrderB : maxPolyOrder[bInd],
-    if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
-    for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-      for dir : 1 thru c do (
-        /* Advection in configuration space.*/
-        fname : sconcat("~/max-out/canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-        disp(printf(false,"Creating surface file: ~a",fname)),
+    /* Skip 3x3v ser (hyb) */
+    if not(c = 3 and bName[bInd] = "ser") then (
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x3v */
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        for dir : 1 thru c do (
+          /* Advection in configuration space.*/
+          fname : sconcat("~/max-out/canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+          disp(printf(false,"Creating surface file: ~a",fname)),
 
-        fh : openw(fname),
-        includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
-        funcName : sconcat("canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        calcCanonicalPBSurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
-        close(fh),
+          fh : openw(fname),
+          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
+          funcName : sconcat("canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          calcCanonicalPBSurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
+          close(fh),
 
-        /* Advection in configuration space in the skin cell (for boundary flux operations) .*/
-        fname : sconcat("~/max-out/canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-        disp(printf(false,"Creating surface file: ~a",fname)),
+          /* Advection in configuration space in the skin cell (for boundary flux operations) .*/
+          fname : sconcat("~/max-out/canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+          disp(printf(false,"Creating surface file: ~a",fname)),
 
-        fh : openw(fname),
-        includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
-        funcName : sconcat("canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        calcCanonicalPBBoundarySurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
-        close(fh)
-      ),
-      /* Index over advection in velocity space.*/
-      for v_sub_indx : 1 thru v do (
-        fname : sconcat("~/max-out/canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-        disp(printf(false,"Creating surface file: ~a",fname)),
+          fh : openw(fname),
+          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
+          funcName : sconcat("canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          calcCanonicalPBBoundarySurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
+          close(fh)
+        ),
+        /* Index over advection in velocity space.*/
+        for v_sub_indx : 1 thru v do (
+          fname : sconcat("~/max-out/canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+          disp(printf(false,"Creating surface file: ~a",fname)),
 
-        fh : openw(fname),
-        includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
-        funcName : sconcat("canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        calcCanonicalPBSurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
-        close(fh),
+          fh : openw(fname),
+          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
+          funcName : sconcat("canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          calcCanonicalPBSurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
+          close(fh),
 
-        /* Advection in velocity space in the skin cell along vpar (for zero-flux BCs).*/
-        fname : sconcat("~/max-out/canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-        disp(printf(false,"Creating surface file: ~a",fname)),
+          /* Advection in velocity space in the skin cell along vpar (for zero-flux BCs).*/
+          fname : sconcat("~/max-out/canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+          disp(printf(false,"Creating surface file: ~a",fname)),
 
-        fh : openw(fname),
-        includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
-        funcName : sconcat("canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        calcCanonicalPBBoundarySurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
-        close(fh)
+          fh : openw(fname),
+          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
+          funcName : sconcat("canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          calcCanonicalPBBoundarySurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
+          close(fh)
+        )
       )
     )
   )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-vol.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-vol.mac
@@ -37,18 +37,20 @@ vlabels : ["vx","vy","vz"]$
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
     v : c, /* Canonical PB only supports equal cdim and vdim */
+    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
 
-   maxPolyOrderB : maxPolyOrder[bInd],
-   if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
-   for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-      fname : sconcat("~/max-out/canonical_pb_vol_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
-      disp(printf(false,"Creating volume file: ~a",fname)),
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+          fname : sconcat("~/max-out/canonical_pb_vol_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          disp(printf(false,"Creating volume file: ~a",fname)),
 
-      fh : openw(fname),
-      printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+          fh : openw(fname),
+          printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
 
-      funcName : sconcat("canonical_pb_vol_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-      buildCanonicalPBVolKernel(fh, funcName, c, v, bName[bInd], polyOrder)
-   )
+          funcName : sconcat("canonical_pb_vol_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          buildCanonicalPBVolKernel(fh, funcName, c, v, bName[bInd], polyOrder)
+      )
+    )
   )
 )$

--- a/maxima/g0/canonical_pb/ms-canonical-pb-vol.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-vol.mac
@@ -14,14 +14,21 @@ maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
+/* Tensor product basis. */
+/* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 3$
+
 /* ...... END OF USER INPUTS........ */
 
 /* To generate other bases, just add corresponding column to arrays below. */
-bName        : ["ser"]$
-minPolyOrder : [minPolyOrder_Ser]$
-maxPolyOrder : [maxPolyOrder_Ser]$
-minCdim      : [minCdim_Ser]$
-maxCdim      : [maxCdim_Ser]$
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$


### PR DESCRIPTION
This is a combination of two PR's in G0 meant to add hybrid and tensor basis to the canonical bracket updater. As well as the computation of an energy moment for can-pb directly from the energy moment.

For hybrid/tensor basis see: [G0 PR#512](https://github.com/ammarhakim/gkylzero/pull/512)
For energy moment see: [G0 PR#491](https://github.com/ammarhakim/gkylzero/pull/491)