### PR TITLE
GK boundary flux kernels

### DIFF
--- a/maxima/g0/gyrokinetic/gkFuncs-surf.mac
+++ b/maxima/g0/gyrokinetic/gkFuncs-surf.mac
@@ -359,3 +359,210 @@ calcGKBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrd
 
 )$
 
+calcGKBoundaryFluxUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder, varsInB, no_by) := block(
+  [pDim,varsC,bC,varsP,bP,vSub,surfVar,varLabel,dirLabel,
+   surfIntVars,surf_cvars,surf_vvars,surfNodes,bSurf,basisStr,NSurf,numNodes,surfIntVarsC,bSurfC,
+   tempVars,tempBasis,NSurfIndexing,numNodesIndexing,
+   rdx2vec,rdv2vec,rdSurfVar2,bmagBasis,ignoreVars,inFlds_e,cmag_e,b_x_e,b_y_e,b_z_e,jacobTotInv_e,
+   BstarXdBmag_e,BstarYdBmag_e,BstarZdBmag_e,BstardBmag_e,
+   hamil_e,alphaUpL_e,alphaSurfL_e,alphaUpSurfL_e,alphaUpR_e,alphaSurfR_e,alphaUpSurfR_e,
+   fEdge_e,fSkin_e,fluxDir,dualmag_c,dualmag_e,dualmagSurf_c,dualmagSurf_e,
+   fUpL_e,fUpR_e,GhatL_c,GhatR_c,GhatL_e,GhatR_e,incrL_c,incrR_c,pOrderCFL],
+
+  kill(varsC,varsP,bC,bP),
+  pDim : cdim+vdim,
+
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+  numC : length(bC),  numP : length(bP), 
+
+  surfVar  : varsP[surfDir],         /* Surface variable. */
+  varLabel : makelist(string(varsP[d]),d,1,pDim),
+  dirLabel : varLabel[surfDir],
+
+  surfIntVars : delete(surfVar,varsP), 
+  surf_cvars  : delete(surfVar, makelist(varsP[i],i,1,cdim)),
+  surf_vvars  : delete(surfVar, makelist(varsP[cdim+i],i,1,vdim)),
+  if polyOrder = 1 then (  /* Force p=1 to use hybrid basis. */
+    surfNodes : gaussOrdGkHyb(1+1, surf_cvars, surf_vvars),
+    bSurf     : basisFromVars("gkhyb",surfIntVars,polyOrder),
+    basisStr  : sconcat("gkhyb_", cdim, "x", vdim, "v", "_p", polyOrder)
+  ) else (
+    surfNodes : gaussOrd(polyOrder+1, pDim-1),
+    bSurf     : basisFromVars(basisFun,surfIntVars,polyOrder),
+    basisStr  : sconcat(basisFun, "_", cdim+vdim, "x", "_p", polyOrder) 
+  ),
+  NSurf    : length(bSurf),
+  numNodes : length(surfNodes),
+
+  surfIntVarsC : delete(surfVar,varsC), 
+  bSurfC : basisFromVars(basisFun,surfIntVarsC,polyOrder),
+
+  /* if polyOrder = 1 and we're doing the vpar update, we need to be careful about
+     indexing input arrays since the surface hybrid basis has a different size at the
+     vparallel surfaces */
+  if (surfDir = cdim+1 and polyOrder = 1) then (
+    tempVars         : delete(x,varsP), 
+    tempBasis        : basisFromVars("gkhyb",tempVars,polyOrder),
+    NSurfIndexing    : length(tempBasis),
+    numNodesIndexing : length(tempBasis)
+  ) else (
+    NSurfIndexing    : NSurf,
+    numNodesIndexing : numNodes
+  ),
+
+  print("Working on ", funcNm),
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv,
+    const double *vmap_prime_edge, const double *vmap_prime_skin,
+    const double *alpha_surf_edge, const double *alpha_surf_skin, 
+    const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
+    const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, const double *dualmag,
+    const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[NDIM]: cell-center.~%"),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // vmap_prime_edge,vmap_prime_skin: velocity space mapping derivative in edge and skin cells.~%"),
+  printf(fh, "  // alpha_surf_edge: Surface expansion of phase space flux on the lower edges of the edge cell.~%"),
+  printf(fh, "  // alpha_surf_skin: Surface expansion of phase space flux on the lower edges of the skin cell.~%"),
+  printf(fh, "  // sgn_alpha_surf_edge: sign(alpha_surf_edge) at quadrature points.~%"),
+  printf(fh, "  // sgn_alpha_surf_skin: sign(alpha_surf_skin) at quadrature points.~%"),
+  printf(fh, "  // const_sgn_alpha_edge: Boolean array true if sign(alpha_surf_edge) is only one sign, either +1 or -1.~%"),
+  printf(fh, "  // const_sgn_alpha_skin: Boolean array true if sign(alpha_surf_skin) is only one sign, either +1 or -1.~%"),
+  printf(fh, "  // dualmag_edge: magnitude of the dual vectors (assumed continuous).~%"),
+  printf(fh, "  // edge: determines if the update is for the left edge (-1) or right edge (+1).~%"),
+  printf(fh, "  // fskin,fedge: distribution function in skin cell/last edge cell.~%"),
+  printf(fh, "  // out: output increment in center cell.~%"),
+  printf(fh, "~%"),
+
+  /* Declare cell spacing for evaluating surface integrals. */
+  rdx2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,1,cdim),
+  rdv2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,cdim+1,pDim),
+
+  rdSurfVar2 : eval_string(sconcat("rd",dirLabel,"2")),
+  printf(fh, "  double ~a = 2.0/dxv[~a];~%", rdSurfVar2, surfDir-1),
+  printf(fh, "~%"),
+
+  /* Axisymmetric basis (independent of y). */
+  bmagBasis : getAxisymmetricConfBasis(bC),
+
+  inFlds_e : expandInputFields(bC,bP,dxv,bmagBasis),
+
+  cmag_e : inFlds_e[2],
+  b_x_e  : inFlds_e[7],  b_y_e : inFlds_e[8],  b_z_e : inFlds_e[9],
+  jacobTotInv_e : inFlds_e[10],  vmap_e : inFlds_e[11],  vmap_prime_e : inFlds_e[13],
+  /* Expand BstarX/Bmag, BstarY/Bmag, BstarZ/Bmag on basis. */
+  if (no_by or cdim = 1) then (b_y_e : 0),
+  BstardBmag_e : [(-((m_/q_)*vmap_e[1])*rdz2*diff(b_y_e,z))*jacobTotInv_e,
+                  (-((m_/q_)*vmap_e[1])*(rdx2*diff(b_z_e,x) - rdz2*diff(b_x_e,z)))*jacobTotInv_e,
+                  (cmag_e + ((m_/q_)*vmap_e[1])*rdx2*diff(b_y_e,x))*jacobTotInv_e],
+  BstardBmag_e : append(makelist(BstardBmag_e[i],i,1,cdim-1),[BstardBmag_e[3]]),
+
+  /* Compute electrostatic Hamiltonian (used to determine sparsity of pre-computed phase space flux alpha). */
+  hamil_e : calc_HamilES_no_write(q_,m_,[wvpar,wmu],rdv2vec,bP,inFlds_e),
+
+  /* Compute the surface alpha but do *not* write it out; we already computed it
+     We just need to re-compute it here in Maxima to get the right sparsity pattern 
+     Further, for boundary surface kernels we will only use one of the surface alphas
+     for computing the update (but pre-compute both for convenience here). */
+  alphaSurfL_e : calc_alpha_no_write(fh,surfDir,bP,polyOrder,basisFun,
+    m_,q_,rdx2vec,rdv2vec,inFlds_e,hamil_e,BstardBmag_e,"L",no_by,false),
+  alphaSurfR_e :  calc_alpha_no_write(fh,surfDir,bP,polyOrder,basisFun,
+    m_,q_,rdx2vec,rdv2vec,inFlds_e,hamil_e,BstardBmag_e,"R",no_by,false),
+
+  vmap_prime_fac_edge : 1,  vmap_prime_fac_skin : 1,
+  if (surfDir > cdim) then (
+    vmap_prime_fac_edge : subst(vmap_prime=vmap_prime_edge, vmap_prime_e[surfDir-cdim]),
+    vmap_prime_fac_skin : subst(vmap_prime=vmap_prime_skin, vmap_prime_e[surfDir-cdim])
+  ),
+  /* When we need the surface alpha at +1, we use alpha_edge 
+     (which stores the next interior edge surface alpha at -1 and alpha is continuous)
+     When we need the surface alpha at -1, we use alpha_skin 
+     (which stores the skin cell surface alpha at -1 and alpha is continuous) */
+  printf(fh, "  const double *alphaL = &alpha_surf_skin[~a];~%", (surfDir-1)*NSurfIndexing),
+  printf(fh, "  const double *alphaR = &alpha_surf_edge[~a];~%", (surfDir-1)*NSurfIndexing),
+  printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_skin[~a];~%", (surfDir-1)*numNodesIndexing),
+  printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_edge[~a];~%", (surfDir-1)*numNodesIndexing),
+  printf(fh, "  const int *const_sgn_alphaL = &const_sgn_alpha_skin[~a];~%", surfDir-1),
+  printf(fh, "  const int *const_sgn_alphaR = &const_sgn_alpha_edge[~a];~%", surfDir-1),
+  printf(fh, "~%"),
+  fEdge_e : doExpand1(fedge, bP)/vmap_prime_fac_edge,
+  fSkin_e : doExpand1(fskin, bP)/vmap_prime_fac_skin,
+
+  fluxDir : surfDir,
+  if (cdim = 2 and surfDir=2) then (fluxDir : 3),
+  dualmag_c : makelist(dualmag[(surfDir-1)*numC+i-1],i,1,numC),
+  dualmag_e : doExpand(dualmag_c, bC),
+
+  /* if edge == -1, we are doing the left edge boundary and the skin cell needs to be evaluated at +1 */
+  printf(fh, "  if (edge == -1) { ~%~%"),
+
+  /* Evaluate the magnitude of the dual at the boundary
+     and project onto the surface basis. */
+  dualmagSurf_c : calcInnerProdList(surfIntVarsC, 1, bSurfC, subst(surfVar=-1, dualmag_e)),
+  dualmagSurf_e : doExpand(dualmagSurf_c, bSurfC),
+
+  calcAndWrite_GKfUpwind(fh,cdim,surfDir,surfVar,surfIntVars,bSurf,fSkin_e,fEdge_e,basisStr,"R",no_by),
+  fUpR_e : doExpand1(fUpR, bSurf), 
+  printf(fh, "  double GhatR[~a] = {0.};~%", NSurf), 
+  GhatR_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfR_e*dualmagSurf_e*fUpR_e), 
+  writeCExprsNoExpand1(GhatR, gcfac(float(expand(GhatR_c)))),  
+  printf(fh, "~%"),
+  flush_output(fh), 
+  GhatR_e : doExpand1(GhatR, bSurf), 
+
+  incrR_c : calcInnerProdList(surfIntVars, -1.0, subst(surfVar=1, bP), GhatR_e),
+
+  /* Write the actual increments to the cell, which are
+     built with incr, dxv factors and some sign changes. */
+  writeCIncrExprsNoExpand1(out, rdSurfVar2*incrR_c),
+  printf(fh, "~%"),
+  flush_output(fh),
+
+  /* Otherwise, edge == 1, and we are doing the right edge boundary and the skin cell needs to be evaluated at -1 */
+  printf(fh, "  } else { ~%~%"), 
+
+  /* Evaluate the magnitude of the dual at the boundary
+     and project onto the surface basis. */
+  dualmagSurf_c : calcInnerProdList(surfIntVarsC, 1, bSurfC, subst(surfVar=1, dualmag_e)),
+  dualmagSurf_e : doExpand(dualmagSurf_c, bSurfC),
+
+  calcAndWrite_GKfUpwind(fh,cdim,surfDir,surfVar,surfIntVars,bSurf,fEdge_e,fSkin_e,basisStr,"L",no_by),
+  fUpL_e : doExpand1(fUpL, bSurf), 
+  printf(fh, "  double GhatL[~a] = {0.};~%", NSurf),
+  GhatL_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfL_e*dualmagSurf_e*fUpL_e), 
+  writeCExprsNoExpand1(GhatL, gcfac(float(expand(GhatL_c)))),
+  printf(fh, "~%"),
+  flush_output(fh),
+  GhatL_e : doExpand1(GhatL, bSurf), 
+
+  incrL_c : calcInnerProdList(surfIntVars, 1.0, subst(surfVar=-1, bP), GhatL_e),
+
+  /* Write the actual increments to the left and right cells, which are
+     built with incr, dxv factors and some sign changes. */
+  writeCIncrExprsNoExpand1(out, rdSurfVar2*incrL_c),
+  printf(fh, "~%"),
+  flush_output(fh),
+  printf(fh, "  } ~%~%"), 
+
+  /* Identify polyOrder in velocity space as p=2 for p=1 since we force p=1 to
+     mean gkhybrid basis. */
+  pOrderCFL : polyOrder,
+  if polyOrder=1 and surfDir=cdim+1 then ( pOrderCFL : 2 ),
+
+  vprimeStr : "",
+  if (surfDir > cdim) then (
+    printf(fh, "  double vmap_prime_min = fmin(fabs(~a),fabs(~a));~%",vmap_prime_edge[surfDir-cdim-1],vmap_prime_skin[surfDir-cdim-1]),
+    vprimeStr : "/vmap_prime_min"
+  ),
+  /* Extra 1/2 factor is because we are multiplying by 2/dx and we only need 1/dx 
+     Also need to divide out 1/sqrt(2^(pDim-1)) to convert 0th component of surface alpha
+     expansion to cell average (so we take the surface averaged alpha as our estimate of the
+     maximum velocity to compute the largest frequency) */
+  printf(fh, "  double cflFreq = fmax(fabs(alphaL[0]~a), fabs(alphaR[0]~a)); ~%", vprimeStr, vprimeStr),
+  printf(fh, "  return ~a*cflFreq; ~%",float(0.5*(2*pOrderCFL+1)*rdSurfVar2*2.0^(-0.5*(pDim-1)))),
+  printf(fh, "~%"),
+
+  printf(fh, "} ~%"),
+  flush_output(fh)
+
+)$
+
+

--- a/maxima/g0/gyrokinetic/ms-gyrokinetic-header.mac
+++ b/maxima/g0/gyrokinetic/ms-gyrokinetic-header.mac
@@ -98,7 +98,21 @@ printPrototypes() := block([],
               const double *alpha_surf_edge, const double *alpha_surf_skin, 
               const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
               const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, 
-              const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder)
+              const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder),
+            if (surfDir < c+1) then (
+              printf(fh, "GKYL_CU_DH double gyrokinetic_boundary_flux~a_~ax~av_~a_p~a(const double *w, const double *dxv,
+                const double *vmap_prime_edge, const double *vmap_prime_skin, 
+                const double *alpha_surf_edge, const double *alpha_surf_skin, 
+                const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
+                const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, const double *dualmag_edge,
+                const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder),
+              printf(fh, "GKYL_CU_DH double gyrokinetic_no_by_boundary_flux~a_~ax~av_~a_p~a(const double *w, const double *dxv,
+                const double *vmap_prime_edge, const double *vmap_prime_skin, 
+                const double *alpha_surf_edge, const double *alpha_surf_skin, 
+                const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
+                const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, const double *dualmag_edge, 
+                const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder)
+            )
           ),
           printf(fh, "~%")
         )

--- a/maxima/g0/gyrokinetic/ms-gyrokinetic-surf.mac
+++ b/maxima/g0/gyrokinetic/ms-gyrokinetic-surf.mac
@@ -59,6 +59,7 @@ for bInd : 1 thru length(bName) do (
       if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
       for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
         for dir : 1 thru c do (
+/**
           /* Advection in configuration space.*/
           fname : sconcat("~/max-out/gyrokinetic_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
           disp(printf(false,"Creating surface file: ~a",fname)),
@@ -68,6 +69,7 @@ for bInd : 1 thru length(bName) do (
           funcName : sconcat("gyrokinetic_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
           calcGKSurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder, bVarsList, false),
           close(fh),
+**/
 
           /* Advection in configuration space in the skin cell (for boundary flux operations) .*/
           fname : sconcat("~/max-out/gyrokinetic_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
@@ -79,8 +81,18 @@ for bInd : 1 thru length(bName) do (
           calcGKBoundarySurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder, bVarsList, false),
           close(fh),
 
+          fname : sconcat("~/max-out/gyrokinetic_boundary_flux",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+          disp(printf(false,"Creating surface flux file: ~a",fname)),
+
+          fh : openw(fname),
+          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
+          funcName : sconcat("gyrokinetic_boundary_flux",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          calcGKBoundaryFluxUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder, bVarsList, false),
+          close(fh),
+
           /* if cdim > 1, also generate a set of kernels for the case where there is no toroidal field (by = 0) */
           if (c > 1) then (
+/**
             fname : sconcat("~/max-out/gyrokinetic_no_by_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
             disp(printf(false,"Creating surface file (no by): ~a",fname)),
     
@@ -89,6 +101,7 @@ for bInd : 1 thru length(bName) do (
             funcName : sconcat("gyrokinetic_no_by_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
             calcGKSurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder, bVarsList, true),
             close(fh),
+**/
 
             /* Advection in configuration space in the skin cell (for boundary flux operations).*/
             fname : sconcat("~/max-out/gyrokinetic_no_by_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
@@ -98,9 +111,19 @@ for bInd : 1 thru length(bName) do (
             includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
             funcName : sconcat("gyrokinetic_no_by_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
             calcGKBoundarySurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder, bVarsList, true),
+            close(fh),
+
+            fname : sconcat("~/max-out/gyrokinetic_no_by_boundary_flux",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+            disp(printf(false,"Creating surface flux file (no by): ~a",fname)),
+
+            fh : openw(fname),
+            includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
+            funcName : sconcat("gyrokinetic_no_by_boundary_flux",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            calcGKBoundaryFluxUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder, bVarsList, true),
             close(fh)
           )
-        ),
+        )
+/**
         /* Advection in velocity space.*/
         fname : sconcat("~/max-out/gyrokinetic_surf",vlabels[1],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
         disp(printf(false,"Creating surface file: ~a",fname)),
@@ -142,6 +165,7 @@ for bInd : 1 thru length(bName) do (
           calcGKBoundarySurfUpdateInDir(c+1, fh, funcName, c, v, bName[bInd], polyOrder, bVarsList, true),
           close(fh)
         )
+**/
       )
     )
   )


### PR DESCRIPTION
These are similar to GK boundary surf kernels except that they include a factor of |e^i| where e^i is the dual vector of the i-th boundary surface.

Because they are derived from boundary surf kernels they contain a factor of 2/dx that is inconvenient and we could consider removing.