### PR TITLE
Kernels generator for the array_average updater in g0

### DIFF
--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -3,114 +3,114 @@ load("out-scripts")$
 load("utilities_gyrokinetic")$
 
 array_average(polyOrder,basisType,cfname,hfname) := block(
-    [headerf,fh,dims,single_elements,double_elements,triple_elements,
-     all_elements,intdims,dimNames,dimVars,b_full,outdimVars,outdimNames,
-     rdm_s,dm_s,funcName,fname,int_dim,b_remain,f_full,w_full,f_out],
-    headerf : openw(hfname),
-    /* write prologue of header file*/
-    printf(headerf,"#pragma once~%~%"),
-    printf(headerf,"#include <gkyl_util.h>~%"),
-    printf(headerf,"#include <math.h>~%~%"),
-    printf(headerf,"EXTERN_C_BEG~%~%"),
 
-    fh : openw(cfname),
-    /* write prologue of c file*/
-    printf(fh,"#include <gkyl_array_average_kernels.h>~%~%"),
+  [headerf,fh,dims,single_elements,double_elements,triple_elements,
+  all_elements,intdims,dimNames,vars,basis,outVars,outNames,
+  rdm_s,dm_s,funcName,int_dim,b_reduced,f_e,w_e,f_c],
 
-    for dim : 1 thru 3 do (
-        dims : makelist(k, k, 1, dim),
-        
-        /* Generate all single elements */
-        single_elements : dims,
-        
-        /* Generate all pairs (combinations of size 2) */
-        double_elements : if length(dims) > 1 then 
-            create_list([dims[i], dims[j]], i, 1, length(dims), j, i+1, length(dims)) 
-            else [],
-        
-        /* Generate all triplets (combinations of size 3) */
-        triple_elements : if length(dims) > 2 then 
-            create_list([dims[i], dims[j], dims[k]], i, 1, length(dims), j, i+1, length(dims), k, j+1, length(dims)) 
-            else [],
-        
-        /* Combine single, double, and triple elements */
-        all_elements : append(
-            append(create_list([x], x, single_elements), double_elements),
-            triple_elements
-        ),
+  headerf : openw(hfname),
+  /* write prologue of header file*/
+  printf(headerf,"#pragma once~%~%"),
+  printf(headerf,"#include <gkyl_util.h>~%"),
+  printf(headerf,"#include <math.h>~%~%"),
+  printf(headerf,"EXTERN_C_BEG~%~%"),
 
-        for i : 1 thru length(all_elements) do (
-            intdims : all_elements[i],
+  fh : openw(cfname),
+  /* write prologue of c file*/
+  printf(fh,"#include <gkyl_array_average_kernels.h>~%~%"),
 
-            if dim = 3 then (dimNames : ["x","y","z"]),
-            if dim = 2 then (dimNames : ["x","y"]),
-            if dim = 1 then (dimNames : ["x"]),
+  for dim : 1 thru 3 do (
+    dims : makelist(k, k, 1, dim),
 
-            /* Original basis */
-            [dimVars, b_full] : loadBasis(basisType, dim, polyOrder),
+    /* Generate all single elements */
+    single_elements : dims,
 
-            outdimVars : dimVars,
-            outdimNames : dimNames,
+    /* Generate all pairs (combinations of size 2) */
+    double_elements : if length(dims) > 1 then 
+    create_list([dims[i], dims[j]], i, 1, length(dims), j, i+1, length(dims)) 
+    else [],
 
-            for j : 1 thru length(intdims) do(
-                outdimNames : delete(dimNames[intdims[j]],outdimNames),
-                outdimVars  : delete(dimVars[intdims[j]],outdimVars)
-            ),
+    /* Generate all triplets (combinations of size 3) */
+    triple_elements : if length(dims) > 2 then 
+    create_list([dims[i], dims[j], dims[k]], i, 1, length(dims), j, i+1, length(dims), k, j+1, length(dims)) 
+    else [],
 
-            rdm_s : "",
-            for j : 1 thru length(outdimNames) do(
-            rdm_s : sconcat(rdm_s,outdimNames[j])
-            ),
-
-            if rdm_s # "" then rdm_s : sconcat(rdm_s,"_"), 
-
-            dm_s : "",
-            for j : 1 thru length(dimNames) do(
-            dm_s : sconcat(dm_s,dimNames[j])
-            ),
-
-            funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_", rdm_s, "ker"),
-            fname : sconcat("~/max-out/",funcName, ".c"),
-
-
-            /* integral dimensionality */
-            int_dim : dim - length(intdims),
-
-            /* Output sub basis */
-            b_remain : basisFromVars(basisType, outdimVars, polyOrder),
-
-            /* We expand our conf field on the full basis */
-            f_full : doExpand1(fin, b_full),
-            w_full : doExpand1(win, b_full),
-
-            /* We integrate it on our output basis over the complementary variables */
-            if length(b_remain) > 0 then(
-                f_out  : calcInnerProdList(dimVars, 1, b_remain, f_full)
-                /* f_out  : calcInnerProdList(dimVars, w_full, b_remain, f_full) */
-            ) else (
-                /* handle the full average case */
-                f_out  : [innerProd(dimVars, 1, 1, f_full)]
-                /* f_out  : [innerProd(dimVars, w_full, 1, f_full)] */
-            ),
-
-            /* write the .c file */
-            printf(fh, "GKYL_CU_DH void ~a( const double *win, const double *fin, double* GKYL_RESTRICT out, const double subvol) ~%{ ~%", funcName),
-
-            /* write down the average (this use fh globaly...)*/
-            writeCIncrExprsNoExpand1(out, subvol*expand(f_out)),
-
-            /* close accolade in .c file */
-            printf(fh, "} ~%"),
-
-            /* write the .h file */
-            printf(headerf, "GKYL_CU_DH void ~a( const double *win, const double *fin, double* GKYL_RESTRICT out,  const double subvol);~%", funcName),
-
-            print(funcName)
-        )
+    /* Combine single, double, and triple elements */
+    all_elements : append(
+      append(create_list([x], x, single_elements), double_elements),
+      triple_elements
     ),
-    
-    /* finalize header file*/
-    printf(headerf,"~%EXTERN_C_END"),
-    close(headerf),
-    close(fh)
+
+    for i : 1 thru length(all_elements) do (
+      intdims : all_elements[i],
+
+      if dim = 3 then (dimNames : ["x","y","z"]),
+      if dim = 2 then (dimNames : ["x","y"]),
+      if dim = 1 then (dimNames : ["x"]),
+
+      /* Original basis */
+      [vars, basis] : loadBasis(basisType, dim, polyOrder),
+
+      outVars  : vars,
+      outNames : dimNames,
+
+      for j : 1 thru length(intdims) do(
+        outNames : delete(dimNames[intdims[j]],outNames),
+        outVars  : delete(vars[intdims[j]],outVars)
+      ),
+
+      rdm_s : "",
+      for j : 1 thru length(outNames) do(
+        rdm_s : sconcat(rdm_s,outNames[j])
+      ),
+
+      if rdm_s # "" then rdm_s : sconcat(rdm_s,"_"), 
+
+      dm_s : "",
+      for j : 1 thru length(dimNames) do(
+        dm_s : sconcat(dm_s,dimNames[j])
+      ),
+
+      funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_", rdm_s, "ker"),
+
+      /* integral dimensionality */
+      int_dim : dim - length(intdims),
+
+      /* Output sub basis */
+      b_reduced : basisFromVars(basisType, outVars, polyOrder),
+
+      /* We expand our conf field on the full basis */
+      f_e : doExpand1(fin, basis),
+      w_e : doExpand1(win, basis),
+
+      /* We integrate it on our output basis over the complementary variables */
+      if length(b_reduced) > 0 then(
+        f_c  : calcInnerProdList(vars, 1, b_reduced, f_e)
+        /* f_c  : calcInnerProdList(vars, w_e, b_reduced, f_e) */
+      ) else (
+        /* handle the full average case */
+        f_c  : [innerProd(vars, 1, 1, f_e)]
+        /* f_c  : [innerProd(vars, w_e, 1, f_e)] */
+      ),
+
+      /* write the .c file */
+      printf(fh, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out) ~%{ ~%", funcName),
+
+      /* write down the average (this use fh globaly...)*/
+      writeCIncrExprsNoExpand1(out, subvol*expand(f_c)),
+
+      /* close accolade in .c file */
+      printf(fh, "} ~%"),
+
+      /* write the .h file */
+      printf(headerf, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out);~%", funcName),
+
+      print(funcName)
+    )
+  ),
+
+  /* finalize header file*/
+  printf(headerf,"~%EXTERN_C_END"),
+  close(headerf),
+  close(fh)
 )$

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -3,7 +3,9 @@ load("out-scripts")$
 load("utilities_gyrokinetic")$
 
 array_average(polyOrder,basisType,cfname,hfname) := block(
-
+    [headerf,fh,dims,single_elements,double_elements,triple_elements,
+     all_elements,intdims,dimNames,dimVars,b_full,outdimVars,outdimNames,
+     rdm_s,dm_s,funcName,fname,int_dim,b_remain,f_full,w_full,f_out],
     headerf : openw(hfname),
     /* write prologue of header file*/
     printf(headerf,"#pragma once~%~%"),

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -12,8 +12,8 @@ writeCIncrExprsNoExpand1atomicadd(lhs, rhs) := block([expr],
 array_average(polyOrder_max,basisType,cfname,hfname) := block(
 
   [headerf,fh,dims,single_elements,double_elements,triple_elements,
-  all_elements,intdims,dimNames,vars,basis,outVars,outNames,
-  intdim_s,dm_s,funcName,int_dim,b_reduced,f_e,w_e,f_c],
+  all_elements,intdims,dimNames,vars,basis,outVars,
+  intdim_s,funcName,int_dim,b_reduced,f_e,w_e,f_c],
 
   headerf : openw(hfname),
   /* write prologue of header file*/
@@ -25,57 +25,75 @@ array_average(polyOrder_max,basisType,cfname,hfname) := block(
   /* write prologue of c file*/
   printf(fh,"#include <gkyl_array_average_kernels.h>~%~%"),
 
-  for polyOrder : 1 thru polyOrder_max do(
-    for dim : 1 thru 3 do (
-      dims : makelist(k, k, 1, dim),
+  for dim : 1 thru 3 do (
 
-      /* Generate all single elements */
-      single_elements : dims,
+    /* add a mapping between dimensionality and symbols */
+    if dim = 3 then (dimNames : ["x","y","z"]),
+    if dim = 2 then (dimNames : ["x","y"]),
+    if dim = 1 then (dimNames : ["x"]),
 
-      /* Generate all pairs (combinations of size 2) */
-      double_elements : if length(dims) > 1 then 
-      create_list([dims[i], dims[j]], i, 1, length(dims), j, i+1, length(dims)) 
-      else [],
+    dims : makelist(k, k, 1, dim),
 
-      /* Generate all triplets (combinations of size 3) */
-      triple_elements : if length(dims) > 2 then 
-      create_list([dims[i], dims[j], dims[k]], i, 1, length(dims), j, i+1, length(dims), k, j+1, length(dims)) 
-      else [],
+    /* Generate all single elements */
+    single_elements : dims,
 
-      /* Combine single, double, and triple elements */
-      all_elements : append(
-        append(create_list([x], x, single_elements), double_elements),
-        triple_elements
+    /* Generate all pairs (combinations of size 2) */
+    double_elements : if length(dims) > 1 then 
+    create_list([dims[i], dims[j]], i, 1, length(dims), j, i+1, length(dims)) 
+    else [],
+
+    /* Generate all triplets (combinations of size 3) */
+    triple_elements : if length(dims) > 2 then 
+    create_list([dims[i], dims[j], dims[k]], i, 1, length(dims), j, i+1, length(dims), k, j+1, length(dims)) 
+    else [],
+
+    /* Combine single, double, and triple elements to create a list of type x,y,z,xy,xz,yz,xyz */
+    all_elements : append(
+      append(create_list([x], x, single_elements), double_elements),
+      triple_elements
+    ),
+    
+    /*  Example for dim = 3 (3x case):
+        -the single_element is [1,2,3]
+        -the double_element is [[1,2],[1,3],[2,3]]
+        -the triple_element is [[1,2,3]]
+        -the all_elements list is [[1],[2],[1,2],[1,3],[2,3],[1,2,3]] corresponding to average along first, second or both dimensions.
+    */
+    for i : 1 thru length(all_elements) do (
+      intdims : all_elements[i],
+
+      /* We build the name extension of the kernel to indicate the avg dimensions */
+      intdim_s : "",
+      for j : 1 thru length(all_elements[i]) do(
+        /* we add the corresponding symbol for each elements in the all_elements sublist */
+        intdim_s : sconcat(intdim_s,dimNames[intdims[j]])
       ),
 
-      for i : 1 thru length(all_elements) do (
-        intdims : all_elements[i],
+      /*  Example for dim = 3 and i = 5:
+          -the fifth element of all_element is [2,3]
+          -intdim_s is now "yz"
+      */
 
-        if dim = 3 then (dimNames : ["x","y","z"]),
-        if dim = 2 then (dimNames : ["x","y"]),
-        if dim = 1 then (dimNames : ["x"]),
+      for polyOrder : 1 thru polyOrder_max do(
 
         /* Original basis */
         [vars, basis] : loadBasis(basisType, dim, polyOrder),
 
+        /* Define strings that keep track of dimensions after averaging */
         outVars  : vars,
-        outNames : dimNames,
 
+        /* Remove the averaged dimensions symbols */
         for j : 1 thru length(intdims) do(
-          outNames : delete(dimNames[intdims[j]],outNames),
           outVars  : delete(vars[intdims[j]],outVars)
         ),
 
-        intdim_s : "",
-        for j : 1 thru length(all_elements[i]) do(
-          intdim_s : sconcat(intdim_s,dimNames[intdims[j]])
-        ),
+        /*  Example for dim = 3 and i = 5:
+            -the fifth element of all_element is [2,3]
+            -intdim_s is now "yz"
+            -outVars is just x
+        */
 
-        dm_s : "",
-        for j : 1 thru length(dimNames) do(
-          dm_s : sconcat(dm_s,dimNames[j])
-        ),
-
+        /* name of the kernel */
         funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_avg", intdim_s),
 
         /* integral dimensionality */
@@ -90,11 +108,9 @@ array_average(polyOrder_max,basisType,cfname,hfname) := block(
 
         /* We integrate it on our output basis over the complementary variables */
         if length(b_reduced) > 0 then(
-          /* f_c  : calcInnerProdList(vars, 1, b_reduced, f_e) */
           f_c  : calcInnerProdList(vars, w_e, b_reduced, f_e)
         ) else (
           /* handle the full average case */
-          /* f_c  : [innerProd(vars, 1, 1, f_e)] */
           f_c  : [innerProd(vars, w_e, 1, f_e)]
         ),
 
@@ -117,7 +133,6 @@ array_average(polyOrder_max,basisType,cfname,hfname) := block(
         printf(headerf, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out);~%", funcName),
 
         print("Kernel ",funcName," generated.")
-
       )
     )
   ),

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -78,18 +78,18 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
             b_remain : basisFromVars(basisType, outdimVars, polyOrder),
 
             /* We expand our conf field on the full basis */
-            f_full : doExpand1(in, b_full),
+            f_full : doExpand1(fin, b_full),
 
             /* We integrate it on our output basis over the complementary variables */
             if length(b_remain) > 0 then(
-                f_out : calcInnerProdList(dimVars, 1, b_remain, f_full)
+                f_out  : calcInnerProdList(dimVars, 1, b_remain, f_full)
             ) else (
                 /* handle the full average case */
-                f_out : [innerProd(dimVars, 1, 1, f_full)]
+                f_out  : [innerProd(dimVars, 1, 1, f_full)]
             ),
 
             /* write the .c file */
-            printf(fh, "GKYL_CU_DH void ~a( const double *in, double* GKYL_RESTRICT out, const double subvol) ~%{ ~%", funcName),
+            printf(fh, "GKYL_CU_DH void ~a( const double *fin, double* GKYL_RESTRICT out, const double subvol) ~%{ ~%", funcName),
 
             /* write down the average (this use fh globaly...)*/
             writeCIncrExprsNoExpand1(out, subvol*expand(f_out)),
@@ -98,7 +98,7 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
             printf(fh, "} ~%"),
 
             /* write the .h file */
-            printf(headerf, "GKYL_CU_DH void ~a( const double *in, double* GKYL_RESTRICT out,  const double subvol);~%", funcName),
+            printf(headerf, "GKYL_CU_DH void ~a( const double *fin, double* GKYL_RESTRICT out,  const double subvol);~%", funcName),
 
             print(funcName)
         )

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -2,7 +2,14 @@ load("modal-basis")$
 load("out-scripts")$
 load("utilities_gyrokinetic")$
 
-array_average(polyOrder,basisType,cfname,hfname) := block(
+writeCIncrExprsNoExpand1atomicadd(lhs, rhs) := block([expr],
+  expr : float(rhs),
+  for i : 1 thru length(expr) do (
+    if expr[i] # 0.0 then printf(fh, "  atomicAdd(&~a, ~a); ~%", lhs[i-1], expr[i])
+  )
+)$
+
+array_average(polyOrder_max,basisType,cfname,hfname) := block(
 
   [headerf,fh,dims,single_elements,double_elements,triple_elements,
   all_elements,intdims,dimNames,vars,basis,outVars,outNames,
@@ -12,99 +19,106 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
   /* write prologue of header file*/
   printf(headerf,"#pragma once~%~%"),
   printf(headerf,"#include <gkyl_util.h>~%"),
-  printf(headerf,"#include <math.h>~%~%"),
   printf(headerf,"EXTERN_C_BEG~%~%"),
 
   fh : openw(cfname),
   /* write prologue of c file*/
   printf(fh,"#include <gkyl_array_average_kernels.h>~%~%"),
 
-  for dim : 1 thru 3 do (
-    dims : makelist(k, k, 1, dim),
+  for polyOrder : 1 thru polyOrder_max do(
+    for dim : 1 thru 3 do (
+      dims : makelist(k, k, 1, dim),
 
-    /* Generate all single elements */
-    single_elements : dims,
+      /* Generate all single elements */
+      single_elements : dims,
 
-    /* Generate all pairs (combinations of size 2) */
-    double_elements : if length(dims) > 1 then 
-    create_list([dims[i], dims[j]], i, 1, length(dims), j, i+1, length(dims)) 
-    else [],
+      /* Generate all pairs (combinations of size 2) */
+      double_elements : if length(dims) > 1 then 
+      create_list([dims[i], dims[j]], i, 1, length(dims), j, i+1, length(dims)) 
+      else [],
 
-    /* Generate all triplets (combinations of size 3) */
-    triple_elements : if length(dims) > 2 then 
-    create_list([dims[i], dims[j], dims[k]], i, 1, length(dims), j, i+1, length(dims), k, j+1, length(dims)) 
-    else [],
+      /* Generate all triplets (combinations of size 3) */
+      triple_elements : if length(dims) > 2 then 
+      create_list([dims[i], dims[j], dims[k]], i, 1, length(dims), j, i+1, length(dims), k, j+1, length(dims)) 
+      else [],
 
-    /* Combine single, double, and triple elements */
-    all_elements : append(
-      append(create_list([x], x, single_elements), double_elements),
-      triple_elements
-    ),
-
-    for i : 1 thru length(all_elements) do (
-      intdims : all_elements[i],
-
-      if dim = 3 then (dimNames : ["x","y","z"]),
-      if dim = 2 then (dimNames : ["x","y"]),
-      if dim = 1 then (dimNames : ["x"]),
-
-      /* Original basis */
-      [vars, basis] : loadBasis(basisType, dim, polyOrder),
-
-      outVars  : vars,
-      outNames : dimNames,
-
-      for j : 1 thru length(intdims) do(
-        outNames : delete(dimNames[intdims[j]],outNames),
-        outVars  : delete(vars[intdims[j]],outVars)
+      /* Combine single, double, and triple elements */
+      all_elements : append(
+        append(create_list([x], x, single_elements), double_elements),
+        triple_elements
       ),
 
-      intdim_s : "",
-      for j : 1 thru length(all_elements[i]) do(
-        intdim_s : sconcat(intdim_s,dimNames[intdims[j]])
-      ),
+      for i : 1 thru length(all_elements) do (
+        intdims : all_elements[i],
 
-      dm_s : "",
-      for j : 1 thru length(dimNames) do(
-        dm_s : sconcat(dm_s,dimNames[j])
-      ),
+        if dim = 3 then (dimNames : ["x","y","z"]),
+        if dim = 2 then (dimNames : ["x","y"]),
+        if dim = 1 then (dimNames : ["x"]),
 
-      funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_avg", intdim_s, "_ker"),
+        /* Original basis */
+        [vars, basis] : loadBasis(basisType, dim, polyOrder),
 
-      /* integral dimensionality */
-      int_dim : dim - length(intdims),
+        outVars  : vars,
+        outNames : dimNames,
 
-      /* Output sub basis */
-      b_reduced : basisFromVars(basisType, outVars, polyOrder),
+        for j : 1 thru length(intdims) do(
+          outNames : delete(dimNames[intdims[j]],outNames),
+          outVars  : delete(vars[intdims[j]],outVars)
+        ),
 
-      /* We expand our conf field on the full basis */
-      f_e : doExpand1(fin, basis),
-      w_e : doExpand1(win, basis),
+        intdim_s : "",
+        for j : 1 thru length(all_elements[i]) do(
+          intdim_s : sconcat(intdim_s,dimNames[intdims[j]])
+        ),
 
-      /* We integrate it on our output basis over the complementary variables */
-      if length(b_reduced) > 0 then(
-        f_c  : calcInnerProdList(vars, 1, b_reduced, f_e)
-        /* f_c  : calcInnerProdList(vars, w_e, b_reduced, f_e) */
-      ) else (
-        /* handle the full average case */
-        f_c  : [innerProd(vars, 1, 1, f_e)]
-        /* f_c  : [innerProd(vars, w_e, 1, f_e)] */
-      ),
+        dm_s : "",
+        for j : 1 thru length(dimNames) do(
+          dm_s : sconcat(dm_s,dimNames[j])
+        ),
 
-      /* write the .c file */
-      printf(fh, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out) ~%{ ~%", funcName),
+        funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_avg", intdim_s, "_ker"),
 
-      /* write down the average (this use fh globaly...)*/
-      writeCIncrExprsNoExpand1(out, subvol*expand(f_c)),
+        /* integral dimensionality */
+        int_dim : dim - length(intdims),
 
-      /* close accolade in .c file */
-      printf(fh, "} ~%"),
+        /* Output sub basis */
+        b_reduced : basisFromVars(basisType, outVars, polyOrder),
 
-      /* write the .h file */
-      printf(headerf, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out);~%", funcName),
+        /* We expand our conf field on the full basis */
+        f_e : doExpand1(fin, basis),
+        w_e : doExpand1(win, basis),
 
-      print("Kernel ",funcName," generated.")
+        /* We integrate it on our output basis over the complementary variables */
+        if length(b_reduced) > 0 then(
+          /* f_c  : calcInnerProdList(vars, 1, b_reduced, f_e) */
+          f_c  : calcInnerProdList(vars, w_e, b_reduced, f_e)
+        ) else (
+          /* handle the full average case */
+          /* f_c  : [innerProd(vars, 1, 1, f_e)] */
+          f_c  : [innerProd(vars, w_e, 1, f_e)]
+        ),
 
+        /* write the .c file */
+        printf(fh, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out) ~%{ ~%", funcName),
+        
+        printf(fh, "#ifdef __CUDA_ARCH__~%"),
+        /* Version for GPU (to handle concurrent memory access) */
+        writeCIncrExprsNoExpand1atomicadd(out, subvol*expand(f_c)),
+
+        printf(fh, "#else~%"),
+        /* CPU sequential version*/
+        writeCIncrExprsNoExpand1(out, subvol*expand(f_c)),
+
+        /* close accolade and CUDA case */
+        printf(fh, "#endif~%"),
+        printf(fh, "} ~%"),
+
+        /* write the .h file */
+        printf(headerf, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out);~%", funcName),
+
+        print("Kernel ",funcName," generated.")
+
+      )
     )
   ),
 

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -1,0 +1,111 @@
+load("modal-basis")$
+load("out-scripts")$
+load("utilities_gyrokinetic")$
+
+array_average(polyOrder,basisType,cfname,hfname) := block(
+
+    headerf : openw(hfname),
+    /* write prologue of header file*/
+    printf(headerf,"#pragma once~%~%"),
+    printf(headerf,"#include <gkyl_util.h>~%"),
+    printf(headerf,"#include <math.h>~%~%"),
+    printf(headerf,"EXTERN_C_BEG~%~%"),
+
+    fh : openw(cfname),
+    /* write prologue of c file*/
+    printf(fh,"#include <gkyl_array_average_kernels.h>~%~%"),
+
+    for dim : 1 thru 3 do (
+        dims : makelist(k, k, 1, dim),
+        
+        /* Generate all single elements */
+        single_elements : dims,
+        
+        /* Generate all pairs (combinations of size 2) */
+        double_elements : if length(dims) > 1 then 
+            create_list([dims[i], dims[j]], i, 1, length(dims), j, i+1, length(dims)) 
+            else [],
+        
+        /* Generate all triplets (combinations of size 3) */
+        triple_elements : if length(dims) > 2 then 
+            create_list([dims[i], dims[j], dims[k]], i, 1, length(dims), j, i+1, length(dims), k, j+1, length(dims)) 
+            else [],
+        
+        /* Combine single, double, and triple elements */
+        all_elements : append(
+            append(create_list([x], x, single_elements), double_elements),
+            triple_elements
+        ),
+
+        for i : 1 thru length(all_elements) do (
+            intdims : all_elements[i],
+
+            if dim = 3 then (dimNames : ["x","y","z"]),
+            if dim = 2 then (dimNames : ["x","y"]),
+            if dim = 1 then (dimNames : ["x"]),
+
+            /* Original basis */
+            [dimVars, b_full] : loadBasis(basisType, dim, polyOrder),
+
+            outdimVars : dimVars,
+            outdimNames : dimNames,
+
+            for j : 1 thru length(intdims) do(
+                outdimNames : delete(dimNames[intdims[j]],outdimNames),
+                outdimVars  : delete(dimVars[intdims[j]],outdimVars)
+            ),
+
+            rdm_s : "",
+            for j : 1 thru length(outdimNames) do(
+            rdm_s : sconcat(rdm_s,outdimNames[j])
+            ),
+
+            if rdm_s # "" then rdm_s : sconcat(rdm_s,"_"), 
+
+            dm_s : "",
+            for j : 1 thru length(dimNames) do(
+            dm_s : sconcat(dm_s,dimNames[j])
+            ),
+
+            funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_", rdm_s, "ker"),
+            fname : sconcat("~/max-out/",funcName, ".c"),
+
+
+            /* integral dimensionality */
+            int_dim : dim - length(intdims),
+
+            /* Output sub basis */
+            b_remain : basisFromVars(basisType, outdimVars, polyOrder),
+
+            /* We expand our conf field on the full basis */
+            f_full : doExpand1(in, b_full),
+
+            /* We integrate it on our output basis over the complementary variables */
+            if length(b_remain) > 0 then(
+                f_out : calcInnerProdList(dimVars, 1, b_remain, f_full)
+            ) else (
+                /* handle the full average case */
+                f_out : [innerProd(dimVars, 1, 1, f_full)]
+            ),
+
+            /* write the .c file */
+            printf(fh, "GKYL_CU_DH void ~a( const double *in, double* GKYL_RESTRICT out, const double subvol) ~%{ ~%", funcName),
+
+            /* write down the average (this use fh globaly...)*/
+            writeCIncrExprsNoExpand1(out, subvol*expand(f_out)),
+
+            /* close accolade in .c file */
+            printf(fh, "} ~%"),
+
+            /* write the .h file */
+            printf(headerf, "GKYL_CU_DH void ~a( const double *in, double* GKYL_RESTRICT out,  const double subvol);~%", funcName),
+
+            print(funcName)
+        )
+    ),
+    
+    /* finalize header file*/
+    printf(headerf,"~%EXTERN_C_END"),
+    close(headerf),
+    close(fh)
+)$

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -6,7 +6,7 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
 
   [headerf,fh,dims,single_elements,double_elements,triple_elements,
   all_elements,intdims,dimNames,vars,basis,outVars,outNames,
-  rdm_s,dm_s,funcName,int_dim,b_reduced,f_e,w_e,f_c],
+  intdim_s,dm_s,funcName,int_dim,b_reduced,f_e,w_e,f_c],
 
   headerf : openw(hfname),
   /* write prologue of header file*/
@@ -59,19 +59,17 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
         outVars  : delete(vars[intdims[j]],outVars)
       ),
 
-      rdm_s : "",
-      for j : 1 thru length(outNames) do(
-        rdm_s : sconcat(rdm_s,outNames[j])
+      intdim_s : "",
+      for j : 1 thru length(all_elements[i]) do(
+        intdim_s : sconcat(intdim_s,dimNames[intdims[j]])
       ),
-
-      if rdm_s # "" then rdm_s : sconcat(rdm_s,"_"), 
 
       dm_s : "",
       for j : 1 thru length(dimNames) do(
         dm_s : sconcat(dm_s,dimNames[j])
       ),
 
-      funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_", rdm_s, "ker"),
+      funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_avg", intdim_s, "_ker"),
 
       /* integral dimensionality */
       int_dim : dim - length(intdims),
@@ -105,7 +103,8 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
       /* write the .h file */
       printf(headerf, "GKYL_CU_DH void ~a(const double subvol, const double *win, const double *fin, double* GKYL_RESTRICT out);~%", funcName),
 
-      print(funcName)
+      print("Kernel ",funcName," generated.")
+
     )
   ),
 

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -76,7 +76,7 @@ array_average(polyOrder_max,basisType,cfname,hfname) := block(
           dm_s : sconcat(dm_s,dimNames[j])
         ),
 
-        funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_avg", intdim_s, "_ker"),
+        funcName : sconcat("gkyl_array_average_",dim,"x_", basisType,"_p", polyOrder, "_avg", intdim_s),
 
         /* integral dimensionality */
         int_dim : dim - length(intdims),

--- a/maxima/g0/array_average/array_average.mac
+++ b/maxima/g0/array_average/array_average.mac
@@ -79,17 +79,20 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
 
             /* We expand our conf field on the full basis */
             f_full : doExpand1(fin, b_full),
+            w_full : doExpand1(win, b_full),
 
             /* We integrate it on our output basis over the complementary variables */
             if length(b_remain) > 0 then(
                 f_out  : calcInnerProdList(dimVars, 1, b_remain, f_full)
+                /* f_out  : calcInnerProdList(dimVars, w_full, b_remain, f_full) */
             ) else (
                 /* handle the full average case */
                 f_out  : [innerProd(dimVars, 1, 1, f_full)]
+                /* f_out  : [innerProd(dimVars, w_full, 1, f_full)] */
             ),
 
             /* write the .c file */
-            printf(fh, "GKYL_CU_DH void ~a( const double *fin, double* GKYL_RESTRICT out, const double subvol) ~%{ ~%", funcName),
+            printf(fh, "GKYL_CU_DH void ~a( const double *win, const double *fin, double* GKYL_RESTRICT out, const double subvol) ~%{ ~%", funcName),
 
             /* write down the average (this use fh globaly...)*/
             writeCIncrExprsNoExpand1(out, subvol*expand(f_out)),
@@ -98,7 +101,7 @@ array_average(polyOrder,basisType,cfname,hfname) := block(
             printf(fh, "} ~%"),
 
             /* write the .h file */
-            printf(headerf, "GKYL_CU_DH void ~a( const double *fin, double* GKYL_RESTRICT out,  const double subvol);~%", funcName),
+            printf(headerf, "GKYL_CU_DH void ~a( const double *win, const double *fin, double* GKYL_RESTRICT out,  const double subvol);~%", funcName),
 
             print(funcName)
         )

--- a/maxima/g0/array_average/ms-array_average.mac
+++ b/maxima/g0/array_average/ms-array_average.mac
@@ -1,0 +1,16 @@
+/* Generate kernels for updater averaging a gkyl_array in given dimensions .*/
+
+load("array_average/array_average")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+polyOrder : 1$
+basisType : "ser"$
+/* Out file names */
+cfname : "~/max-out/array_average_kernels.c"$
+hfname : "~/max-out/gkyl_array_average_kernels.h"$
+
+/* ...... END OF USER INPUTS........ */
+
+array_average(polyOrder,basisType,cfname,hfname)$


### PR DESCRIPTION
New Maxima script and function are designed to compute the kernel required for computing array average of `gkyl_array`.
The kernels are written for arrays from 1x to 3x and p=1,2. The race condition in GPU runs is handled by an atomicadd inside the kernel.

PR in gkylzero: https://github.com/ammarhakim/gkylzero/pull/558
DR in gkylzero: https://github.com/ammarhakim/gkylzero/issues/557