### PR TITLE
Add support for a weight on the RHS of the fem_parproj operator

### DIFF
--- a/maxima/g0/fem-parproj/fem-parproj-src_stencil.mac
+++ b/maxima/g0/fem-parproj/fem-parproj-src_stencil.mac
@@ -11,7 +11,7 @@ load("bvp_utilities/bvp-util");
 load("fem/fem-util");
 fpprec : 24$
 
-generate_fem_parproj_src_stencil(fh, funcNm, dim, basisFun, pMin, pMax) := block(
+generate_fem_parproj_src_stencil(fh, funcNm, dim, basisFun, pMin, pMax, isweighted) := block(
   [varsC,basis,coordVarS,stencilLoc,bcTypes,bcStrs,bcKey,sI,bcCombos,bcI,currBC,
    stencilStr,polyOrder,bN,numB,vars,nodes,numNodes,massM,mod2nod,massMod2nod,
    rho_c,src,src_c,insertVal,phiBC_m,phiBC_c,dir,dirichletNodesI,k,opStr],
@@ -62,8 +62,9 @@ generate_fem_parproj_src_stencil(fh, funcNm, dim, basisFun, pMin, pMax) := block
 
       for polyOrder : pMin thru pMax do (
     
-        printf(fh, "GKYL_CU_DH void ~a_p~a~a(const double *rho, const double *phiBC, long nodeOff, const long *globalIdxs, double *bsrc) ~%{ ~%", funcNm, polyOrder, stencilStr),
+        printf(fh, "GKYL_CU_DH void ~a_p~a~a(const double *weight, const double *rho, const double *phiBC, long nodeOff, const long *globalIdxs, double *bsrc) ~%{ ~%", funcNm, polyOrder, stencilStr),
         printf(fh, "  // rho: right side source.~%"),
+        printf(fh, "  // weight: Weight in the projection operation.~%"),
         printf(fh, "  // phiBC: Dirichlet boundary potential, given as a DG expansion in the ghost cell (volume).~%"),
         printf(fh, "  // nodeOff: node offset (prob idx * global number of nodes).~%"),
         printf(fh, "  // globalIdxs: global linear index of each basis function/node in current cell.~%"),
@@ -73,12 +74,22 @@ generate_fem_parproj_src_stencil(fh, funcNm, dim, basisFun, pMin, pMax) := block
         bN   : getNodalBasis(basisFun, dim, polyOrder),
         numB : length(bN),
         vars : listofvars(bN),
-    
+
         nodes    : args(getNodes(basisFun, dim, polyOrder)),
         numNodes : length(nodes),
     
-        massM   : calcMassUnweighted(dim, basisFun, polyOrder),
         mod2nod : calcModToNod(basisFun, dim, polyOrder),
+
+        if (isweighted) then (
+          wgt_c : makelist(weight[k-1],k,1,numB),
+          wgt_c : mod2nod . wgt_c,
+          wgt_c : makelist(fullratsimp(wgt_c[i][1]),i,1,numB),
+          wgt_e : doExpand(wgt_c, bN),
+      
+          massM : calcMassWeighted(dim, basisFun, polyOrder, wgt_e)
+        ) else (
+          massM : calcMassUnweighted(dim, basisFun, polyOrder)
+        ),
     
         massMod2nod : massM . mod2nod,
     

--- a/maxima/g0/fem-parproj/ms-fem-parproj-header.mac
+++ b/maxima/g0/fem-parproj/ms-fem-parproj-header.mac
@@ -140,7 +140,8 @@ for bInd : 1 thru length(bName) do (
       printf(fh, "~%"),
 
       /* Right side source stencil (mass matrix . modal_to_nodal matrix). */
-      findCombos(fh, "GKYL_CU_DH void", "fem_parproj_src_stencil", "const double *rho, const double *phiBC, long nodeOff, const long *globalIdxs, double *bsrc", bName[bInd], ci, polyOrder, bcKeyND, true, false),
+      findCombos(fh, "GKYL_CU_DH void", "fem_parproj_src_stencil_noweight", "const double *weight, const double *rho, const double *phiBC, long nodeOff, const long *globalIdxs, double *bsrc", bName[bInd], ci, polyOrder, bcKeyND, true, false),
+      findCombos(fh, "GKYL_CU_DH void", "fem_parproj_src_stencil_weighted", "const double *weight, const double *rho, const double *phiBC, long nodeOff, const long *globalIdxs, double *bsrc", bName[bInd], ci, polyOrder, bcKeyND, true, false),
       printf(fh, "~%"),
 
       /* Solution stencil kernels. */

--- a/maxima/g0/fem-parproj/ms-fem-parproj.mac
+++ b/maxima/g0/fem-parproj/ms-fem-parproj.mac
@@ -34,7 +34,6 @@ minDim       : [minDim_Ser, minDim_Tensor]$
 maxDim       : [maxDim_Ser, maxDim_Tensor]$
 
 /**
-**/
 /* Kernels computing the number of nodes in the global problem. */
 disp(printf(false,"Creating fem_parproj_num_nodes.c"))$
 fname : "~/max-out/fem_parproj_num_nodes.c"$
@@ -82,20 +81,30 @@ for bInd : 1 thru length(bName) do (
 )$
 close(fh)$
 
+**/
 /* RHS source stencil kernels. */
 disp(printf(false,"Creating fem_parproj_src_stencil.c"))$
 fname : "~/max-out/fem_parproj_src_stencil.c"$
 fh    : openw(fname)$
 printf(fh, "#include <gkyl_fem_parproj_kernels.h> ~%")$
 printf(fh, " ~%")$
+/* Stencils without a weight. */
 for bInd : 1 thru length(bName) do (
   for c : minDim[bInd] thru maxDim[bInd] do (
-    funcName : sconcat("fem_parproj_src_stencil_", c, "x_", bName[bInd]),
-    generate_fem_parproj_src_stencil(fh, funcName, c, bName[bInd], minPolyOrder[bInd], maxPolyOrder[bInd])
+    funcName : sconcat("fem_parproj_src_stencil_noweight_", c, "x_", bName[bInd]),
+    generate_fem_parproj_src_stencil(fh, funcName, c, bName[bInd], minPolyOrder[bInd], maxPolyOrder[bInd], false)
+  )
+)$
+/* Stencils with a weight. */
+for bInd : 1 thru length(bName) do (
+  for c : minDim[bInd] thru maxDim[bInd] do (
+    funcName : sconcat("fem_parproj_src_stencil_weighted_", c, "x_", bName[bInd]),
+    generate_fem_parproj_src_stencil(fh, funcName, c, bName[bInd], minPolyOrder[bInd], maxPolyOrder[bInd], true)
   )
 )$
 close(fh)$
 
+/**
 /* Solution nodal-to-modal kernels. */
 disp(printf(false,"Creating fem_parproj_sol_stencil.c"))$
 fname : "~/max-out/fem_parproj_sol_stencil.c"$
@@ -109,5 +118,4 @@ for bInd : 1 thru length(bName) do (
   )
 )$
 close(fh)$
-/**
 **/

--- a/maxima/g0/fem/fem-util.mac
+++ b/maxima/g0/fem/fem-util.mac
@@ -78,6 +78,15 @@ getStoredNodesWithBC(nodesIn,cellLoc,bcIn) := block(
   return(storedNodesBC)
 )$
 
+calcMassWeighted(dim, basisType, pOrder, weight) := block(
+  /* Calculate unweighted nodal mass matrix. */
+  [basis_n,vars,massMod],
+  basis_n : getNodalBasis(basisType, dim, pOrder),
+  vars    : listofvars(basis_n),
+  massNod : calcMassMatrix(vars, weight, basis_n),
+  return(massNod)
+)$
+
 calcMassUnweighted(dim, basisType, pOrder) := block(
   /* Calculate unweighted nodal mass matrix. */
   [basis_n,vars,massMod],


### PR DESCRIPTION
This allows us to add a Jacobian weight in 2x and 3x smoothing if desired. This goes with [PR 570](https://github.com/ammarhakim/gkylzero/pull/570) in gkylzero.