### PR TITLE
Maxima for the dg_interpolate operator

### DIFF
--- a/maxima/g0/bin_op/binOp-mul-cross.mac
+++ b/maxima/g0/bin_op/binOp-mul-cross.mac
@@ -126,15 +126,15 @@ calcBinOpCrossMultiplyHyb(fh, funcNm, cdim, vdim, basisFun, polyOrder, comp_par,
 
   if (basisFun = "hyb") then (
     [varsC,bC,varsP,bP] : loadPhaseBasis(basisFun, cdim, vdim, 1),
-    printf(fh, "#include <gkyl_binop_cross_mul_hyb.h> ~%"),      
+    printf(fh, "#include <gkyl_binop_cross_mul_hyb.h> ~%"),
     printf(fh, " ~%")
   ) 
   else if (basisFun = "gkhyb") then (
     [varsC,bC,varsP,bP,vsub] : loadGkBasis(basisFun, cdim, vdim, 1),
-    printf(fh, "#include <gkyl_binop_cross_mul_gkhyb.h> ~%"),      
+    printf(fh, "#include <gkyl_binop_cross_mul_gkhyb.h> ~%"),
     printf(fh, " ~%")
   ),
-  NP  : length(bP),
+  NP : length(bP),
 
   /* Function declaration with input/output variables. */
   printf(fh, "GKYL_CU_DH~%"),

--- a/maxima/g0/dg_interpolate/dg_interp.mac
+++ b/maxima/g0/dg_interpolate/dg_interp.mac
@@ -7,8 +7,8 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   /* Interpolation operator transfering a field defined on one grid to
      another grid. This kernel is called to compute contribution from a single
      origin-grid cell, to a single target-grid cell. */
-  [varsC,bC,varsP,bP,vSub,pdim,vars,basis,numB,interpDims,numInterpDims,intLimits,
-   dI,d,cFld_e,cFld_c,fFld_e,fFld_c,varMap,intLims,intLimsX,intLimsV,subList,subListX,
+  [varsC,bC,varsP,bP,vSub,pdim,vars,basis,numB,interpDims,numInterpDims,intLims,
+   dI,d,cFld_e,cFld_c,fFld_e,fFld_c,varMap,intLimsX,intLimsV,subList,subListX,
    subListV,IcFld_c,IcFld_cx,IcFld_cv,tempPowVars],
 
   pdim : cdim + vdim,
@@ -22,153 +22,145 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   numB  : length(basis),
   NC : length(bC),
 
-  interpDims    : makelist(i,i,1,pdim),
-  numInterpDims : length(interpDims),
+  /* Generate a kernel for interpolating along each direction. */
+  for dir : 1 thru pdim do (
 
-  /* Function declaration with input/output variables. */
-  printf(fh, "GKYL_CU_DH void ~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar) ~%{ ~%", funcNm),
-  printf(fh, "  // wDo: cell center of donor cell.~%"),
-  printf(fh, "  // wTar: cell center of target cell.~%"),
-  printf(fh, "  // dxDo: cell length of donor cell.~%"),
-  printf(fh, "  // dxTar: cell length of target cell.~%"),
-  printf(fh, "  // fldDo: donor field.~%"),
-  printf(fh, "  // fldTar: target field in cells pointed to by the stencil.~%"),
-  printf(fh, "~%"),
-
-  intLimits : makelist([-1,1], d, 1, pdim),
-  for dI : 1 thru numInterpDims do (
-    d : interpDims[dI],
-    intLimits[d] : [ 1-(2/dxTar[d-1])*(wTar[d-1]+dxTar[d-1]/2-(wDo[d-1]-dxDo[d-1]/2)),
-                    -1+(2/dxTar[d-1])*(wDo[d-1]+dxDo[d-1]/2-(wTar[d-1]-dxTar[d-1]/2)) ] 
-  ),
-  /* Create a variable saving limits of integration. */
-  printf(fh, "  double eLo[~a];~%", pdim),
-  printf(fh, "  double eUp[~a];~%", pdim),
-  for d : 0 thru pdim-1 do (
-    printf(fh, "  eLo[~a] = fmax(-1.0,~a);~%", d, float(intLimits[d+1][1])),
-    printf(fh, "  eUp[~a] = fmin( 1.0,~a);~%", d, float(intLimits[d+1][2]))
-  ),
-  printf(fh, "~%"),
+    /* Function declaration with input/output variables. */
+    printf(fh, "GKYL_CU_DH void ~a_~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar) ~%{ ~%", funcNm, vars[dir]),
+    printf(fh, "  // wDo: cell center of donor cell.~%"),
+    printf(fh, "  // wTar: cell center of target cell.~%"),
+    printf(fh, "  // dxDo: cell length of donor cell.~%"),
+    printf(fh, "  // dxTar: cell length of target cell.~%"),
+    printf(fh, "  // fldDo: donor field.~%"),
+    printf(fh, "  // fldTar: target field in cells pointed to by the stencil.~%"),
+    printf(fh, "~%"),
   
-  /* Field expansions and list of coefficients. */
-  cFld_c : makelist(fldDo[i],i,0,numB-1),
-  fFld_c : makelist(fldTar[i],i,0,numB-1),
-  cFld_e : doExpand(cFld_c,basis),
-  fFld_e : doExpand(fFld_c,basis),
-  
-  /* Create a table of the relationship between the logical coordinates
-     in each direction of the donor and target grids, that is, the linear map
-       xi_c = L(xi_f)
-     where xi_c and xi_f are the is the donor and target logical coordinates. */
-  varMap : makelist(vars[i],i,1,pdim),
-  for dI : 1 thru numInterpDims do (
-    d : interpDims[dI],
-    varMap[d] : (2/dxDo[d-1])*(wTar[d-1]-wDo[d-1]+(dxTar[d-1]/2)*vars[d])
-  ),
-  
-  /* Compute the inner product, on target grid of current cell,
-     of the donor field times the basis target-grid functions. */
-  intLims : makelist([eLo[d-1], eUp[d-1]],d,1,pdim),
-  /**
-    This approach produces extremely long lines.
-  subList : makelist(vars[i]=varMap[i],i,1,pdim),
-  IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,cFld_e))),
-  
-  /* In general these expressions are very complex. It would be beneficial to
-     perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
-  powVars : [],
-  powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
-  tempPowVars : [],
-  writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
-  printf(fh, "~%"),
-  **/
-
-  /**
-    This approach splits the inner product by splitting the expansion in cFld_e.
-    Unfortunately the lines are still very long.
-  **/
-  expTerms : args(cFld_e),
-  IcFld_c : makelist(0,i,1,numB),
-  tempPowVars : [],
-  powVars : [],
-  powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
-  for k : 1 thru numB do (
+    intLims : makelist([-1,1], d, 1, pdim),
+    intLims[dir] : [ 1-(2/dxTar[dir-1])*(wTar[dir-1]+dxTar[dir-1]/2-(wDo[dir-1]-dxDo[dir-1]/2)),
+                    -1+(2/dxTar[dir-1])*(wDo[dir-1]+dxDo[dir-1]/2-(wTar[dir-1]-dxTar[dir-1]/2)) ],
+    /* Create a variable saving limits of integration. */
+    printf(fh, "  double eLo = fmax(-1.0,~a);~%", float(intLims[dir][1])),
+    printf(fh, "  double eUp = fmin( 1.0,~a);~%", float(intLims[dir][2])),
+    printf(fh, "~%"),
+    
+    /* Field expansions and list of coefficients. */
+    cFld_c : makelist(fldDo[i],i,0,numB-1),
+    fFld_c : makelist(fldTar[i],i,0,numB-1),
+    cFld_e : doExpand(cFld_c,basis),
+    fFld_e : doExpand(fFld_c,basis),
+    
+    /* Create a table of the relationship between the logical coordinates
+       in each direction of the donor and target grids, that is, the linear map
+         xi_c = L(xi_f)
+       where xi_c and xi_f are the is the donor and target logical coordinates. */
+    varMap : makelist(vars[i],i,1,pdim),
+    varMap[dir] : (2/dxDo[dir-1])*(wTar[dir-1]-wDo[dir-1]+(dxTar[dir-1]/2)*vars[dir]),
+    
+    /* Compute the inner product, on target grid of current cell,
+       of the donor field times the basis target-grid functions. */
+    intLims : makelist([-1, 1],d,1,pdim),
+    intLims[dir] : [eLo, eUp],
+    /**
+      This approach produces extremely long lines.
+    **/
     subList : makelist(vars[i]=varMap[i],i,1,pdim),
-    IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,expTerms[k]))),
-
+    IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,cFld_e))),
+    
     /* In general these expressions are very complex. It would be beneficial to
        perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
-    tempPowVars : writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
-    printf(fh, "~%")
-  ),
+    powVars : [],
+    powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
+    powVars : endcons(eLo,powVars),
+    powVars : endcons(eUp,powVars),
+    tempPowVars : [],
+    writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
+    printf(fh, "~%"),
   
-  /**
-    This approach splits the inner product by splitting the expansion in cFld_e, and 
-    (for p=1 or Tensor only) split the x- and v- integrals (MF 2024/11/10: doesn't work).
-  printf(fh, "  double tmp[~a]; ~%", NC),
-  tmp_c : makelist(0,i,1,NC),
-  expTerms : args(cFld_e),
-  IcFld_c : makelist(0,i,1,numB),
-  tempPowVars : [],
-  powVars : [],
-  powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
-  powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
-  for k : 1 thru numB do (
-    /* Do v-space integrals. */
-    intLimsV : makelist(intLims[i],i,cdim+1,pdim),
-    subListV : makelist(vars[i]=varMap[i],i,cdim+1,pdim),
-    IcFld_cv : fullratsimp(calcInnerProdListGen(varsV,intLimsV,1.0,basis,subst(subListV,expTerms[k]))),
-
-    for j : 1 thru numB do (
-      if (IcFld_cv[j] # 0) then (
-        /* Store the result of v-space integrals in a projection on x-basis. */
-        IcFld_cx : calcInnerProdList(varsC,1,bC,IcFld_cv[j]),
-        /*
-        writeCExprs1(tmp, IcFld_cx),
-        */
-        printf(fh, "~%"),
-        printf(fh, "  for (int k=0; k<~a; k++) tmp[k] = 0.0; ~%", NC),
-        printf(fh, "~%"),
-
-        tempPowVars : writeCExprs1noPowers(tmp, IcFld_cx, powVars, tempPowVars),
-        tmp_c : makelistNoZeros1(IcFld_cx, tmp),
-        tmp_e : doExpand(tmp_c,bC),
-        printf(fh, "~%"),
-
-        /* Now do the x-integrals and write the result. */
-        intLimsX : makelist(intLims[i],i,1,cdim),
-        subListX : makelist(vars[i]=varMap[i],i,1,cdim),
-        IcFld_c : float(expand(fullratsimp(innerProdGen(varsC,intLimsX,1.0,1.0,subst(subListX,tmp_e))))),
-
-/*
-       [subList,tempPowVars] : findReplacePowers(IcFld_c, powVars, 1, tempPowVars),
-
-        printf(fh, "  ~a += ~a; ~%", fldTar[j-1], IcFld_c)
-       */
-       tempPowVars : writeCIncrExprsCollectnoPowers([fldTar[j-1]], [IcFld_c], [dxDo,dxTar], powVars, tempPowVars)
-
-      )
+    /**
+      This approach splits the inner product by splitting the expansion in cFld_e.
+      Unfortunately the lines are still very long.
+    expTerms : args(cFld_e),
+    IcFld_c : makelist(0,i,1,numB),
+    tempPowVars : [],
+    powVars : [],
+    powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
+    for k : 1 thru numB do (
+      subList : makelist(vars[i]=varMap[i],i,1,pdim),
+      IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,expTerms[k]))),
+  
+      /* In general these expressions are very complex. It would be beneficial to
+         perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
+      tempPowVars : writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
+      printf(fh, "~%")
     ),
-    printf(fh, "~%")
-  ),
-  **/
+    **/
+    
+    /**
+      This approach splits the inner product by splitting the expansion in cFld_e, and 
+      (for p=1 or Tensor only) split the x- and v- integrals (MF 2024/11/10: doesn't work).
+    printf(fh, "  double tmp[~a]; ~%", NC),
+    tmp_c : makelist(0,i,1,NC),
+    expTerms : args(cFld_e),
+    IcFld_c : makelist(0,i,1,numB),
+    tempPowVars : [],
+    powVars : [],
+    powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
+    for k : 1 thru numB do (
+      /* Do v-space integrals. */
+      intLimsV : makelist(intLims[i],i,cdim+1,pdim),
+      subListV : makelist(vars[i]=varMap[i],i,cdim+1,pdim),
+      IcFld_cv : fullratsimp(calcInnerProdListGen(varsV,intLimsV,1.0,basis,subst(subListV,expTerms[k]))),
   
-  printf(fh, "}~%"),
-  printf(fh, "~%")
+      for j : 1 thru numB do (
+        if (IcFld_cv[j] # 0) then (
+          /* Store the result of v-space integrals in a projection on x-basis. */
+          IcFld_cx : calcInnerProdList(varsC,1,bC,IcFld_cv[j]),
+          /*
+          writeCExprs1(tmp, IcFld_cx),
+          */
+          printf(fh, "~%"),
+          printf(fh, "  for (int k=0; k<~a; k++) tmp[k] = 0.0; ~%", NC),
+          printf(fh, "~%"),
+  
+          tempPowVars : writeCExprs1noPowers(tmp, IcFld_cx, powVars, tempPowVars),
+          tmp_c : makelistNoZeros1(IcFld_cx, tmp),
+          tmp_e : doExpand(tmp_c,bC),
+          printf(fh, "~%"),
+  
+          /* Now do the x-integrals and write the result. */
+          intLimsX : makelist(intLims[i],i,1,cdim),
+          subListX : makelist(vars[i]=varMap[i],i,1,cdim),
+          IcFld_c : float(expand(fullratsimp(innerProdGen(varsC,intLimsX,1.0,1.0,subst(subListX,tmp_e))))),
+  
+  /*
+         [subList,tempPowVars] : findReplacePowers(IcFld_c, powVars, 1, tempPowVars),
+  
+          printf(fh, "  ~a += ~a; ~%", fldTar[j-1], IcFld_c)
+         */
+         tempPowVars : writeCIncrExprsCollectnoPowers([fldTar[j-1]], [IcFld_c], [dxDo,dxTar], powVars, tempPowVars)
+  
+        )
+      ),
+      printf(fh, "~%")
+    ),
+    **/
+    
+    printf(fh, "}~%"),
+    printf(fh, "~%")
+  )
   
 )$
 

--- a/maxima/g0/dg_interpolate/dg_interp.mac
+++ b/maxima/g0/dg_interpolate/dg_interp.mac
@@ -27,27 +27,31 @@ writeCIncrExprsCollect1noPowersAtomicAdd(lhs, rhs, clst, qPow, alreadyDecl) := b
   return(alreadyDecl)
 )$
 
-gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder, isGK) := block(
   /* Interpolation operator transfering a field defined on one grid to
      another grid. This kernel is called to compute contribution from a single
      origin-grid cell, to a single target-grid cell. */
-  [varsC,bC,varsP,bP,vSub,pdim,vars,basis,numB,interpDims,numInterpDims,intLims,
+  [varsC,bC,vars,basis,vSub,ndim,numB,interpDims,numInterpDims,intLims,
    dI,d,cFld_e,cFld_c,fFld_e,fFld_c,varMap,intLimsX,intLimsV,subList,subListX,
    subListV,IcFld_c,IcFld_cx,IcFld_cv,tempPowVars],
 
-  pdim : cdim + vdim,
-
+  ndim : cdim + vdim,
+ 
   /* Get desired basis. */
-  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
-  varsV : makelist(varsP[i],i,cdim+1,pdim),
-
-  vars : varsP,
-  basis : bP,
-  numB  : length(basis),
-  NC : length(bC),
+  if (vdim = 0) then (
+    [vars, basis] : loadBasis(basisFun, cdim, polyOrder)
+  ) else (
+    if (isGK) then (
+      [varsC,bC,vars,basis,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder)
+    )
+    else (
+      [varsC,bC,vars,basis] : loadPhaseBasis(basisFun, cdim, vdim, polyOrder)
+    )
+  ),
+  numB : length(basis),
 
   /* Generate a kernel for interpolating along each direction. */
-  for dir : 1 thru pdim do (
+  for dir : 1 thru ndim do (
 
     /* Function declaration with input/output variables. */
     printf(fh, "GKYL_CU_DH void ~a_~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar) ~%{ ~%", funcNm, vars[dir]),
@@ -59,7 +63,7 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
     printf(fh, "  // fldTar: target field in cells pointed to by the stencil.~%"),
     printf(fh, "~%"),
   
-    intLims : makelist([-1,1], d, 1, pdim),
+    intLims : makelist([-1,1], d, 1, ndim),
     intLims[dir] : [ 1-(2/dxTar[dir-1])*(wTar[dir-1]+dxTar[dir-1]/2-(wDo[dir-1]-dxDo[dir-1]/2)),
                     -1+(2/dxTar[dir-1])*(wDo[dir-1]+dxDo[dir-1]/2-(wTar[dir-1]-dxTar[dir-1]/2)) ],
     /* Create a variable saving limits of integration. */
@@ -77,23 +81,23 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
        in each direction of the donor and target grids, that is, the linear map
          xi_c = L(xi_f)
        where xi_c and xi_f are the is the donor and target logical coordinates. */
-    varMap : makelist(vars[i],i,1,pdim),
+    varMap : makelist(vars[i],i,1,ndim),
     varMap[dir] : (2/dxDo[dir-1])*(wTar[dir-1]-wDo[dir-1]+(dxTar[dir-1]/2)*vars[dir]),
     
     /* Compute the inner product, on target grid of current cell,
        of the donor field times the basis target-grid functions. */
-    intLims : makelist([-1, 1],d,1,pdim),
+    intLims : makelist([-1, 1],d,1,ndim),
     intLims[dir] : [eLo, eUp],
-    subList : makelist(vars[i]=varMap[i],i,1,pdim),
+    subList : makelist(vars[i]=varMap[i],i,1,ndim),
     IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,cFld_e))),
     
     /* In general these expressions are very complex. It would be beneficial to
        perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
     powVars : [],
-    powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
+    powVars : endcons(makelist( wDo[i-1],i,1,ndim),powVars),
+    powVars : endcons(makelist( wTar[i-1],i,1,ndim),powVars),
+    powVars : endcons(makelist(dxDo[i-1],i,1,ndim),powVars),
+    powVars : endcons(makelist(dxTar[i-1],i,1,ndim),powVars),
     powVars : endcons(eLo,powVars),
     powVars : endcons(eUp,powVars),
     printf(fh, "#ifdef __CUDA_ARCH__~%"),

--- a/maxima/g0/dg_interpolate/dg_interp.mac
+++ b/maxima/g0/dg_interpolate/dg_interp.mac
@@ -3,6 +3,30 @@ load("modal-basis");
 load("out-scripts");
 fpprec : 24$
 
+writeCIncrExprsCollect1noPowersAtomicAdd(lhs, rhs, clst, qPow, alreadyDecl) := block(
+  [i,subList,expr,ep,outStr],
+
+  [subList,alreadyDecl] : findReplacePowers(rhs, qPow, 1, alreadyDecl),
+
+  expr : float(expand(rhs)),
+  for i : 1 thru length(rhs) do (
+    if expr[i] # 0.0 then (
+      expr[i] : apply(collectterms, cons(expr[i], clst)),
+      ep : string(expr[i]),
+      if (length(subList) > 0) then (
+        outStr : ssubst(subList[1][2],subList[1][1],ep),
+        for s : 2 thru length(subList) do (
+          outStr : ssubst(subList[s][2],subList[s][1],outStr)
+        )
+      ) else (
+        outStr : ep
+      ),
+      printf(fh, "  atomicAdd(&~a, ~a); ~%", lhs[i-1], outStr)
+    )
+  ),
+  return(alreadyDecl)
+)$
+
 gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   /* Interpolation operator transfering a field defined on one grid to
      another grid. This kernel is called to compute contribution from a single
@@ -60,9 +84,6 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
        of the donor field times the basis target-grid functions. */
     intLims : makelist([-1, 1],d,1,pdim),
     intLims[dir] : [eLo, eUp],
-    /**
-      This approach produces extremely long lines.
-    **/
     subList : makelist(vars[i]=varMap[i],i,1,pdim),
     IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,cFld_e))),
     
@@ -75,89 +96,15 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
     powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
     powVars : endcons(eLo,powVars),
     powVars : endcons(eUp,powVars),
+    printf(fh, "#ifdef __CUDA_ARCH__~%"),
+    tempPowVars : [],
+    writeCIncrExprsCollect1noPowersAtomicAdd(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
+    printf(fh, "#else~%"),
     tempPowVars : [],
     writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
+    printf(fh, "#endif~%"),
     printf(fh, "~%"),
   
-    /**
-      This approach splits the inner product by splitting the expansion in cFld_e.
-      Unfortunately the lines are still very long.
-    expTerms : args(cFld_e),
-    IcFld_c : makelist(0,i,1,numB),
-    tempPowVars : [],
-    powVars : [],
-    powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
-    for k : 1 thru numB do (
-      subList : makelist(vars[i]=varMap[i],i,1,pdim),
-      IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,expTerms[k]))),
-  
-      /* In general these expressions are very complex. It would be beneficial to
-         perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
-      tempPowVars : writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
-      printf(fh, "~%")
-    ),
-    **/
-    
-    /**
-      This approach splits the inner product by splitting the expansion in cFld_e, and 
-      (for p=1 or Tensor only) split the x- and v- integrals (MF 2024/11/10: doesn't work).
-    printf(fh, "  double tmp[~a]; ~%", NC),
-    tmp_c : makelist(0,i,1,NC),
-    expTerms : args(cFld_e),
-    IcFld_c : makelist(0,i,1,numB),
-    tempPowVars : [],
-    powVars : [],
-    powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
-    powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
-    for k : 1 thru numB do (
-      /* Do v-space integrals. */
-      intLimsV : makelist(intLims[i],i,cdim+1,pdim),
-      subListV : makelist(vars[i]=varMap[i],i,cdim+1,pdim),
-      IcFld_cv : fullratsimp(calcInnerProdListGen(varsV,intLimsV,1.0,basis,subst(subListV,expTerms[k]))),
-  
-      for j : 1 thru numB do (
-        if (IcFld_cv[j] # 0) then (
-          /* Store the result of v-space integrals in a projection on x-basis. */
-          IcFld_cx : calcInnerProdList(varsC,1,bC,IcFld_cv[j]),
-          /*
-          writeCExprs1(tmp, IcFld_cx),
-          */
-          printf(fh, "~%"),
-          printf(fh, "  for (int k=0; k<~a; k++) tmp[k] = 0.0; ~%", NC),
-          printf(fh, "~%"),
-  
-          tempPowVars : writeCExprs1noPowers(tmp, IcFld_cx, powVars, tempPowVars),
-          tmp_c : makelistNoZeros1(IcFld_cx, tmp),
-          tmp_e : doExpand(tmp_c,bC),
-          printf(fh, "~%"),
-  
-          /* Now do the x-integrals and write the result. */
-          intLimsX : makelist(intLims[i],i,1,cdim),
-          subListX : makelist(vars[i]=varMap[i],i,1,cdim),
-          IcFld_c : float(expand(fullratsimp(innerProdGen(varsC,intLimsX,1.0,1.0,subst(subListX,tmp_e))))),
-  
-  /*
-         [subList,tempPowVars] : findReplacePowers(IcFld_c, powVars, 1, tempPowVars),
-  
-          printf(fh, "  ~a += ~a; ~%", fldTar[j-1], IcFld_c)
-         */
-         tempPowVars : writeCIncrExprsCollectnoPowers([fldTar[j-1]], [IcFld_c], [dxDo,dxTar], powVars, tempPowVars)
-  
-        )
-      ),
-      printf(fh, "~%")
-    ),
-    **/
-    
     printf(fh, "}~%"),
     printf(fh, "~%")
   )

--- a/maxima/g0/dg_interpolate/dg_interp.mac
+++ b/maxima/g0/dg_interpolate/dg_interp.mac
@@ -27,7 +27,7 @@ writeCIncrExprsCollect1noPowersAtomicAdd(lhs, rhs, clst, qPow, alreadyDecl) := b
   return(alreadyDecl)
 )$
 
-gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder, isGK) := block(
+gen_dg_interp_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder, isGK) := block(
   /* Interpolation operator transfering a field defined on one grid to
      another grid. This kernel is called to compute contribution from a single
      origin-grid cell, to a single target-grid cell. */

--- a/maxima/g0/dg_interpolate/dg_interp.mac
+++ b/maxima/g0/dg_interpolate/dg_interp.mac
@@ -7,18 +7,22 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   /* Interpolation operator transfering a field defined on one grid to
      another grid. This kernel is called to compute contribution from a single
      origin-grid cell, to a single target-grid cell. */
-  [varsC,bC,varsP,bP,vSub,dim,vars,basis,numB,interpDims,numInterpDims,intLimits,
-   dI,d,cFld_e,cFld_c,fFld_e,fFld_c,varMap,intLims,IcFld,tempPowVars],
+  [varsC,bC,varsP,bP,vSub,pdim,vars,basis,numB,interpDims,numInterpDims,intLimits,
+   dI,d,cFld_e,cFld_c,fFld_e,fFld_c,varMap,intLims,intLimsX,intLimsV,subList,subListX,
+   subListV,IcFld_c,IcFld_cx,IcFld_cv,tempPowVars],
+
+  pdim : cdim + vdim,
 
   /* Get desired basis. */
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+  varsV : makelist(varsP[i],i,cdim+1,pdim),
 
-  dim : cdim + vdim,
   vars : varsP,
   basis : bP,
   numB  : length(basis),
+  NC : length(bC),
 
-  interpDims    : makelist(i,i,1,dim),
+  interpDims    : makelist(i,i,1,pdim),
   numInterpDims : length(interpDims),
 
   /* Function declaration with input/output variables. */
@@ -31,16 +35,16 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   printf(fh, "  // fldTar: target field in cells pointed to by the stencil.~%"),
   printf(fh, "~%"),
 
-  intLimits : makelist([-1,1], d, 1, dim),
+  intLimits : makelist([-1,1], d, 1, pdim),
   for dI : 1 thru numInterpDims do (
     d : interpDims[dI],
     intLimits[d] : [ 1-(2/dxTar[d-1])*(wTar[d-1]+dxTar[d-1]/2-(wDo[d-1]-dxDo[d-1]/2)),
                     -1+(2/dxTar[d-1])*(wDo[d-1]+dxDo[d-1]/2-(wTar[d-1]-dxTar[d-1]/2)) ] 
   ),
   /* Create a variable saving limits of integration. */
-  printf(fh, "  double eLo[~a];~%", dim),
-  printf(fh, "  double eUp[~a];~%", dim),
-  for d : 0 thru dim-1 do (
+  printf(fh, "  double eLo[~a];~%", pdim),
+  printf(fh, "  double eUp[~a];~%", pdim),
+  for d : 0 thru pdim-1 do (
     printf(fh, "  eLo[~a] = fmax(-1.0,~a);~%", d, float(intLimits[d+1][1])),
     printf(fh, "  eUp[~a] = fmin( 1.0,~a);~%", d, float(intLimits[d+1][2]))
   ),
@@ -56,7 +60,7 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
      in each direction of the donor and target grids, that is, the linear map
        xi_c = L(xi_f)
      where xi_c and xi_f are the is the donor and target logical coordinates. */
-  varMap : makelist(vars[i],i,1,dim),
+  varMap : makelist(vars[i],i,1,pdim),
   for dI : 1 thru numInterpDims do (
     d : interpDims[dI],
     varMap[d] : (2/dxDo[d-1])*(wTar[d-1]-wDo[d-1]+(dxTar[d-1]/2)*vars[d])
@@ -64,20 +68,21 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   
   /* Compute the inner product, on target grid of current cell,
      of the donor field times the basis target-grid functions. */
-  intLims : makelist([eLo[d-1], eUp[d-1]],d,1,dim),
+  intLims : makelist([eLo[d-1], eUp[d-1]],d,1,pdim),
   /**
     This approach produces extremely long lines.
-  IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(makelist(vars[i]=varMap[i],i,1,dim),cFld_e))),
+  subList : makelist(vars[i]=varMap[i],i,1,pdim),
+  IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,cFld_e))),
   
   /* In general these expressions are very complex. It would be beneficial to
      perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
   powVars : [],
-  powVars : endcons(makelist( wDo[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist( wTar[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(dxDo[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(dxTar[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(eLo[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(eUp[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
   tempPowVars : [],
   writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
   printf(fh, "~%"),
@@ -91,14 +96,15 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   IcFld_c : makelist(0,i,1,numB),
   tempPowVars : [],
   powVars : [],
-  powVars : endcons(makelist( wDo[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist( wTar[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(dxDo[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(dxTar[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(eLo[i-1],i,1,dim),powVars),
-  powVars : endcons(makelist(eUp[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
   for k : 1 thru numB do (
-    IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(makelist(vars[i]=varMap[i],i,1,dim),expTerms[k]))),
+    subList : makelist(vars[i]=varMap[i],i,1,pdim),
+    IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(subList,expTerms[k]))),
 
     /* In general these expressions are very complex. It would be beneficial to
        perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
@@ -108,7 +114,57 @@ gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   
   /**
     This approach splits the inner product by splitting the expansion in cFld_e, and 
-    (for p=1 or Tensor only) split the integration by recursively projecting onto a lower dimensional space.
+    (for p=1 or Tensor only) split the x- and v- integrals (MF 2024/11/10: doesn't work).
+  printf(fh, "  double tmp[~a]; ~%", NC),
+  tmp_c : makelist(0,i,1,NC),
+  expTerms : args(cFld_e),
+  IcFld_c : makelist(0,i,1,numB),
+  tempPowVars : [],
+  powVars : [],
+  powVars : endcons(makelist( wDo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist( wTar[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(dxDo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(dxTar[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(eLo[i-1],i,1,pdim),powVars),
+  powVars : endcons(makelist(eUp[i-1],i,1,pdim),powVars),
+  for k : 1 thru numB do (
+    /* Do v-space integrals. */
+    intLimsV : makelist(intLims[i],i,cdim+1,pdim),
+    subListV : makelist(vars[i]=varMap[i],i,cdim+1,pdim),
+    IcFld_cv : fullratsimp(calcInnerProdListGen(varsV,intLimsV,1.0,basis,subst(subListV,expTerms[k]))),
+
+    for j : 1 thru numB do (
+      if (IcFld_cv[j] # 0) then (
+        /* Store the result of v-space integrals in a projection on x-basis. */
+        IcFld_cx : calcInnerProdList(varsC,1,bC,IcFld_cv[j]),
+        /*
+        writeCExprs1(tmp, IcFld_cx),
+        */
+        printf(fh, "~%"),
+        printf(fh, "  for (int k=0; k<~a; k++) tmp[k] = 0.0; ~%", NC),
+        printf(fh, "~%"),
+
+        tempPowVars : writeCExprs1noPowers(tmp, IcFld_cx, powVars, tempPowVars),
+        tmp_c : makelistNoZeros1(IcFld_cx, tmp),
+        tmp_e : doExpand(tmp_c,bC),
+        printf(fh, "~%"),
+
+        /* Now do the x-integrals and write the result. */
+        intLimsX : makelist(intLims[i],i,1,cdim),
+        subListX : makelist(vars[i]=varMap[i],i,1,cdim),
+        IcFld_c : float(expand(fullratsimp(innerProdGen(varsC,intLimsX,1.0,1.0,subst(subListX,tmp_e))))),
+
+/*
+       [subList,tempPowVars] : findReplacePowers(IcFld_c, powVars, 1, tempPowVars),
+
+        printf(fh, "  ~a += ~a; ~%", fldTar[j-1], IcFld_c)
+       */
+       tempPowVars : writeCIncrExprsCollectnoPowers([fldTar[j-1]], [IcFld_c], [dxDo,dxTar], powVars, tempPowVars)
+
+      )
+    ),
+    printf(fh, "~%")
+  ),
   **/
   
   printf(fh, "}~%"),

--- a/maxima/g0/dg_interpolate/dg_interp.mac
+++ b/maxima/g0/dg_interpolate/dg_interp.mac
@@ -1,0 +1,118 @@
+/* Generate kernels for dg_interpolate updater. */
+load("modal-basis");
+load("out-scripts");
+fpprec : 24$
+
+gen_dg_interp_gk_kern(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  /* Interpolation operator transfering a field defined on one grid to
+     another grid. This kernel is called to compute contribution from a single
+     origin-grid cell, to a single target-grid cell. */
+  [varsC,bC,varsP,bP,vSub,dim,vars,basis,numB,interpDims,numInterpDims,intLimits,
+   dI,d,cFld_e,cFld_c,fFld_e,fFld_c,varMap,intLims,IcFld,tempPowVars],
+
+  /* Get desired basis. */
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  dim : cdim + vdim,
+  vars : varsP,
+  basis : bP,
+  numB  : length(basis),
+
+  interpDims    : makelist(i,i,1,dim),
+  numInterpDims : length(interpDims),
+
+  /* Function declaration with input/output variables. */
+  printf(fh, "GKYL_CU_DH void ~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar) ~%{ ~%", funcNm),
+  printf(fh, "  // wDo: cell center of donor cell.~%"),
+  printf(fh, "  // wTar: cell center of target cell.~%"),
+  printf(fh, "  // dxDo: cell length of donor cell.~%"),
+  printf(fh, "  // dxTar: cell length of target cell.~%"),
+  printf(fh, "  // fldDo: donor field.~%"),
+  printf(fh, "  // fldTar: target field in cells pointed to by the stencil.~%"),
+  printf(fh, "~%"),
+
+  intLimits : makelist([-1,1], d, 1, dim),
+  for dI : 1 thru numInterpDims do (
+    d : interpDims[dI],
+    intLimits[d] : [ 1-(2/dxTar[d-1])*(wTar[d-1]+dxTar[d-1]/2-(wDo[d-1]-dxDo[d-1]/2)),
+                    -1+(2/dxTar[d-1])*(wDo[d-1]+dxDo[d-1]/2-(wTar[d-1]-dxTar[d-1]/2)) ] 
+  ),
+  /* Create a variable saving limits of integration. */
+  printf(fh, "  double eLo[~a];~%", dim),
+  printf(fh, "  double eUp[~a];~%", dim),
+  for d : 0 thru dim-1 do (
+    printf(fh, "  eLo[~a] = fmax(-1.0,~a);~%", d, float(intLimits[d+1][1])),
+    printf(fh, "  eUp[~a] = fmin( 1.0,~a);~%", d, float(intLimits[d+1][2]))
+  ),
+  printf(fh, "~%"),
+  
+  /* Field expansions and list of coefficients. */
+  cFld_c : makelist(fldDo[i],i,0,numB-1),
+  fFld_c : makelist(fldTar[i],i,0,numB-1),
+  cFld_e : doExpand(cFld_c,basis),
+  fFld_e : doExpand(fFld_c,basis),
+  
+  /* Create a table of the relationship between the logical coordinates
+     in each direction of the donor and target grids, that is, the linear map
+       xi_c = L(xi_f)
+     where xi_c and xi_f are the is the donor and target logical coordinates. */
+  varMap : makelist(vars[i],i,1,dim),
+  for dI : 1 thru numInterpDims do (
+    d : interpDims[dI],
+    varMap[d] : (2/dxDo[d-1])*(wTar[d-1]-wDo[d-1]+(dxTar[d-1]/2)*vars[d])
+  ),
+  
+  /* Compute the inner product, on target grid of current cell,
+     of the donor field times the basis target-grid functions. */
+  intLims : makelist([eLo[d-1], eUp[d-1]],d,1,dim),
+  /**
+    This approach produces extremely long lines.
+  IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(makelist(vars[i]=varMap[i],i,1,dim),cFld_e))),
+  
+  /* In general these expressions are very complex. It would be beneficial to
+     perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
+  powVars : [],
+  powVars : endcons(makelist( wDo[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist( wTar[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(dxDo[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(dxTar[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(eLo[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(eUp[i-1],i,1,dim),powVars),
+  tempPowVars : [],
+  writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
+  printf(fh, "~%"),
+  **/
+
+  /**
+    This approach splits the inner product by splitting the expansion in cFld_e.
+    Unfortunately the lines are still very long.
+  **/
+  expTerms : args(cFld_e),
+  IcFld_c : makelist(0,i,1,numB),
+  tempPowVars : [],
+  powVars : [],
+  powVars : endcons(makelist( wDo[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist( wTar[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(dxDo[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(dxTar[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(eLo[i-1],i,1,dim),powVars),
+  powVars : endcons(makelist(eUp[i-1],i,1,dim),powVars),
+  for k : 1 thru numB do (
+    IcFld_c : fullratsimp(calcInnerProdListGen(vars,intLims,1.0,basis,subst(makelist(vars[i]=varMap[i],i,1,dim),expTerms[k]))),
+
+    /* In general these expressions are very complex. It would be beneficial to
+       perform some kind of common subexpression elimination. For now we'll just eliminate the exponents. */
+    tempPowVars : writeCIncrExprsCollect1noPowers(fldTar, IcFld_c, [dxDo,dxTar], powVars, tempPowVars),
+    printf(fh, "~%")
+  ),
+  
+  /**
+    This approach splits the inner product by splitting the expansion in cFld_e, and 
+    (for p=1 or Tensor only) split the integration by recursively projecting onto a lower dimensional space.
+  **/
+  
+  printf(fh, "}~%"),
+  printf(fh, "~%")
+  
+)$
+

--- a/maxima/g0/dg_interpolate/ms-dg_interp-header.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp-header.mac
@@ -1,0 +1,65 @@
+/*
+  Generate the kernels header file for the updater which interpolates
+  a DG field from one grid to another (dimensionality of the grids is
+  the same, only resolution varies).
+*/
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* Vdim possibilities for each of Cdim=[1,2,3]. */
+gkVdims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+printPrototypes(fh) := block(
+  [bInd,c,gkV,v,maxPolyOrderB,polyOrder],
+
+  for bInd : 1 thru length(bName) do (
+    for c : minCdim[bInd] thru maxCdim[bInd] do (
+      for gkV : 1 thru length(gkVdims[c]) do (
+        v : gkVdims[c][gkV],
+
+        maxPolyOrderB : maxPolyOrder[bInd],
+        if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+        for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+
+          printf(fh, "GKYL_CU_DH void dg_interpolate_gyrokinetic_~ax~av_~a_p~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar);~%", c, v, bName[bInd], polyOrder)
+
+        )
+      )
+    ),
+    printf(fh, "~%")
+  )
+
+)$
+
+fh : openw("~/max-out/gkyl_dg_interpolate_kernels.h")$
+printf(fh, "#pragma once~%")$
+printf(fh, "~%")$
+printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "#include <math.h>~%")$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_BEG~%")$
+printf(fh, "~%")$
+printPrototypes(fh)$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_END~%")$
+close(fh)$

--- a/maxima/g0/dg_interpolate/ms-dg_interp-header.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp-header.mac
@@ -22,6 +22,7 @@ maxCdim_Tensor : 0$
 /* ...... END OF USER INPUTS........ */
 
 /* Vdim possibilities for each of Cdim=[1,2,3]. */
+vlasovVdims : [[1,2,3],[2,3],[3]]$
 gkVdims : [[1,2], [2], [2]]$
 
 /* To generate other bases, just add corresponding column to arrays below. */
@@ -32,9 +33,48 @@ minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 printPrototypes(fh) := block(
-  [bInd,c,gkV,v,maxPolyOrderB,polyOrder],
+  [bInd,c,gkV,v,vI,maxPolyOrderB,polyOrder],
 
   for bInd : 1 thru length(bName) do (
+
+    /* Conf-space kernels. */
+    for c : minCdim[bInd] thru maxCdim[bInd] do (
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+
+        [varsP,jnk] : loadBasis(bName[bInd], c, polyOrder),
+
+        /* Generate a kernel for interpolating along each direction. */
+        for dir : 1 thru c do (
+          printf(fh, "GKYL_CU_DH void dg_interpolate_~ax_~a_p~a_~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar);~%", c, bName[bInd], polyOrder, varsP[dir])
+        ),
+        printf(fh, "~%")
+      )
+    ),
+    printf(fh, "~%"),
+
+    /* Vlasov kernels. */
+    for c : minCdim[bInd] thru maxCdim[bInd] do (
+      for vI : 1 thru length(vlasovVdims[c]) do (
+        v : vlasovVdims[c][vI],
+
+        maxPolyOrderB : maxPolyOrder[bInd],
+        if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+        for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+
+          [jnk,jnk,varsP,jnk] : loadPhaseBasis(bName[bInd], c, v, polyOrder),
+
+          /* Generate a kernel for interpolating along each direction. */
+          for dir : 1 thru c+v do (
+            printf(fh, "GKYL_CU_DH void dg_interpolate_vlasov_~ax~av_~a_p~a_~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar);~%", c, v, bName[bInd], polyOrder, varsP[dir])
+          ),
+          printf(fh, "~%")
+
+        )
+      )
+    ),
+    printf(fh, "~%"),
+
+    /* Gyrokinetic kernels. */
     for c : minCdim[bInd] thru maxCdim[bInd] do (
       for gkV : 1 thru length(gkVdims[c]) do (
         v : gkVdims[c][gkV],
@@ -56,7 +96,6 @@ printPrototypes(fh) := block(
     ),
     printf(fh, "~%")
   )
-
 )$
 
 fh : openw("~/max-out/gkyl_dg_interpolate_kernels.h")$

--- a/maxima/g0/dg_interpolate/ms-dg_interp-header.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp-header.mac
@@ -3,11 +3,13 @@
   a DG field from one grid to another (dimensionality of the grids is
   the same, only resolution varies).
 */
+load("modal-basis")$
+
 /* ...... USER INPUTS........ */
 
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
-maxPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
@@ -41,7 +43,13 @@ printPrototypes(fh) := block(
         if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
         for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
 
-          printf(fh, "GKYL_CU_DH void dg_interpolate_gyrokinetic_~ax~av_~a_p~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar);~%", c, v, bName[bInd], polyOrder)
+          [jnk,jnk,varsP,jnk,jnk] : loadGkBasis(bName[bInd], c, v, polyOrder),
+
+          /* Generate a kernel for interpolating along each direction. */
+          for dir : 1 thru c+v do (
+            printf(fh, "GKYL_CU_DH void dg_interpolate_gyrokinetic_~ax~av_~a_p~a_~a(const double *wDo, const double *wTar, const double *dxDo, const double *dxTar, const double *fldDo, double *fldTar);~%", c, v, bName[bInd], polyOrder, varsP[dir])
+          ),
+          printf(fh, "~%")
 
         )
       )

--- a/maxima/g0/dg_interpolate/ms-dg_interp.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp.mac
@@ -8,9 +8,9 @@ load(stringproc)$
 
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
-maxPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
-maxCdim_Ser : 1$
+maxCdim_Ser : 2$
 
 /* Tensor order basis. No need to generate p=1. */
 minPolyOrder_Tensor : 2$

--- a/maxima/g0/dg_interpolate/ms-dg_interp.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp.mac
@@ -1,0 +1,58 @@
+/* Generate kernels for the dg_interpolate updater
+   which interpolates a DG field from one grid to another. */
+
+load("dg_interpolate/dg_interp.mac")$
+load(stringproc)$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 1$
+maxCdim_Ser : 1$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* Vdim possibilities for each of Cdim=[1,2,3]. */
+gkVdims : [[1], [2], [2]]$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+/* Generate kernels of selected types. */
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for gkV : 1 thru length(gkVdims[c]) do (
+      v : gkVdims[c][gkV],
+
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        fname : sconcat("~/max-out/dg_interpolate_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+      
+        disp(printf(false,"Creating file: ~a",fname)),
+      
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_dg_interpolate_kernels.h> ~%"),
+        printf(fh, " ~%"),
+        
+        funcName : sconcat("dg_interpolate_gyrokinetic_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+        gen_dg_interp_gk_kern(fh, funcName, c, v, bName[bInd], polyOrder),
+        close(fh)
+      )
+    )
+  )
+)$
+

--- a/maxima/g0/dg_interpolate/ms-dg_interp.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp.mac
@@ -44,7 +44,7 @@ for bInd : 1 thru length(bName) do (
       printf(fh, " ~%"),
       
       funcName : sconcat("dg_interpolate_", c, "x_", bName[bInd], "_p", polyOrder),
-      gen_dg_interp_gk_kern(fh, funcName, c, 0, bName[bInd], polyOrder, false),
+      gen_dg_interp_kern(fh, funcName, c, 0, bName[bInd], polyOrder, false),
       close(fh)
     )
   )
@@ -69,7 +69,7 @@ for bInd : 1 thru length(bName) do (
         printf(fh, " ~%"),
         
         funcName : sconcat("dg_interpolate_vlasov_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        gen_dg_interp_gk_kern(fh, funcName, c, v, bName[bInd], polyOrder, false),
+        gen_dg_interp_kern(fh, funcName, c, v, bName[bInd], polyOrder, false),
         close(fh)
       )
     )
@@ -95,7 +95,7 @@ for bInd : 1 thru length(bName) do (
         printf(fh, " ~%"),
         
         funcName : sconcat("dg_interpolate_gyrokinetic_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        gen_dg_interp_gk_kern(fh, funcName, c, v, bName[bInd], polyOrder, true),
+        gen_dg_interp_kern(fh, funcName, c, v, bName[bInd], polyOrder, true),
         close(fh)
       )
     )

--- a/maxima/g0/dg_interpolate/ms-dg_interp.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp.mac
@@ -18,10 +18,10 @@ maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 0$
 
-/* Vdim possibilities for each of Cdim=[1,2,3]. */
-gkVdims : [[1], [2], [2]]$
-
 /* ...... END OF USER INPUTS........ */
+
+/* Vdim possibilities for each of Cdim=[1,2,3]. */
+gkVdims : [[1,2], [2], [2]]$
 
 /* To generate other bases, just add corresponding column to arrays below. */
 bName        : ["ser", "tensor"]$

--- a/maxima/g0/dg_interpolate/ms-dg_interp.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp.mac
@@ -21,6 +21,7 @@ maxCdim_Tensor : 0$
 /* ...... END OF USER INPUTS........ */
 
 /* Vdim possibilities for each of Cdim=[1,2,3]. */
+vlasovVdims : [[1,2,3],[2,3],[3]]$
 gkVdims : [[1,2], [2], [2]]$
 
 /* To generate other bases, just add corresponding column to arrays below. */
@@ -30,7 +31,52 @@ maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
-/* Generate kernels of selected types. */
+/* Generate configuration-space kernels. */
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+      fname : sconcat("~/max-out/dg_interpolate_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+    
+      disp(printf(false,"Creating file: ~a",fname)),
+    
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_dg_interpolate_kernels.h> ~%"),
+      printf(fh, " ~%"),
+      
+      funcName : sconcat("dg_interpolate_", c, "x_", bName[bInd], "_p", polyOrder),
+      gen_dg_interp_gk_kern(fh, funcName, c, 0, bName[bInd], polyOrder, false),
+      close(fh)
+    )
+  )
+)$
+
+/* Generate Vlasov kernels. */
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for vI : 1 thru length(vlasovVdims[c]) do (
+      v : vlasovVdims[c][vI],
+
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        fname : sconcat("~/max-out/dg_interpolate_vlasov_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+      
+        disp(printf(false,"Creating file: ~a",fname)),
+      
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_dg_interpolate_kernels.h> ~%"),
+        printf(fh, " ~%"),
+        
+        funcName : sconcat("dg_interpolate_vlasov_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+        gen_dg_interp_gk_kern(fh, funcName, c, v, bName[bInd], polyOrder, false),
+        close(fh)
+      )
+    )
+  )
+)$
+
+/* Generate gyrokinetic kernels. */
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
     for gkV : 1 thru length(gkVdims[c]) do (
@@ -40,7 +86,7 @@ for bInd : 1 thru length(bName) do (
       if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
 
       for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-        fname : sconcat("~/max-out/dg_interpolate_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        fname : sconcat("~/max-out/dg_interpolate_gyrokinetic_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
       
         disp(printf(false,"Creating file: ~a",fname)),
       
@@ -49,7 +95,7 @@ for bInd : 1 thru length(bName) do (
         printf(fh, " ~%"),
         
         funcName : sconcat("dg_interpolate_gyrokinetic_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-        gen_dg_interp_gk_kern(fh, funcName, c, v, bName[bInd], polyOrder),
+        gen_dg_interp_gk_kern(fh, funcName, c, v, bName[bInd], polyOrder, true),
         close(fh)
       )
     )

--- a/maxima/g0/dg_interpolate/ms-dg_interp.mac
+++ b/maxima/g0/dg_interpolate/ms-dg_interp.mac
@@ -10,7 +10,7 @@ load(stringproc)$
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
-maxCdim_Ser : 2$
+maxCdim_Ser : 3$
 
 /* Tensor order basis. No need to generate p=1. */
 minPolyOrder_Tensor : 2$

--- a/maxima/g0/gk-sheath/sheath-1x1v.mac
+++ b/maxima/g0/gk-sheath/sheath-1x1v.mac
@@ -4,7 +4,7 @@
 load("modal-basis");
 load("out-scripts");
 load("nodal_operations/nodal_functions")$
-load("gk-sheath/sheath_util.mac")$
+load("utilities_gyrokinetic")$
 load(stringproc)$
 fpprec : 24$
 

--- a/maxima/g0/out-scripts.mac
+++ b/maxima/g0/out-scripts.mac
@@ -303,7 +303,7 @@ writeCExprs1noPowers(lhs, rhs, qPow, alreadyDecl) := block(
      redefining the same variables.
   */
 
-  [subList,alreadyDecl] : findReplacePowers(rhs, qPow, 0, alreadyDecl), 
+  [subList,alreadyDecl] : findReplacePowers(rhs, qPow, 1, alreadyDecl), 
 
   expr : float(rhs),
   for i : 1 thru length(rhs) do (
@@ -389,7 +389,7 @@ writeCIncrExprsCollectnoPowers(lhs, rhs, clst, qPow, alreadyDecl) := block(
       ) else (
         outStr : ep
       ),
-      printf(fh, "  ~a += ~a; ~%", lhs[i-1], outStr)
+      printf(fh, "  ~a += ~a; ~%", lhs[i], outStr)
     )
   ),
   return(alreadyDecl)

--- a/maxima/g0/prim_moments/CrossPrimMomsLBO-vlasov-with-fluid.mac
+++ b/maxima/g0/prim_moments/CrossPrimMomsLBO-vlasov-with-fluid.mac
@@ -341,7 +341,7 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block([udim
   ),
   tempVars : [],
   sqCoeffs : [makelist(u_self[a0+k-1],k,1,NC),makelist(u_other[a0+k-1],k,1,NC)],
-  tempVars : writeCIncrExprsCollectnoPowers(uSumSq, uSumSq_c, [dx], sqCoeffs, tempVars),
+  tempVars : writeCIncrExprsCollect1noPowers(uSumSq, uSumSq_c, [dx], sqCoeffs, tempVars),
   printf(fh, "  } ~%"),
   printf(fh, " ~%"),
 

--- a/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
+++ b/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
@@ -294,7 +294,7 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   ),
   tempVars : [],
   sqCoeffs : [makelist(u_self[a0+k-1],k,1,numB),makelist(u_other[a0+k-1],k,1,numB)],
-  tempVars : writeCIncrExprsCollectnoPowers(uSumSq, uSumSq_c, [dx], sqCoeffs, tempVars),
+  tempVars : writeCIncrExprsCollect1noPowers(uSumSq, uSumSq_c, [dx], sqCoeffs, tempVars),
   printf(fh, "  } ~%"),
   printf(fh, " ~%"),
 


### PR DESCRIPTION
These kernels are meant to be used in interpolating a DG field onto another grid with the same extents but different number of cells. It assumes that one is going to do 1D interpolation at a time. General multi-D interpolation kernels are in principle possible but the Maxima kernels that come out of that are too big; see earlier commits, commits to the g2 Maxima or the g2 repo for attempts at multi-D interpolation kernels.

This goes with PR 574 in gkylzero: https://github.com/ammarhakim/gkylzero/pull/574