### PR TITLE
Skin surf from ghost Maxima

### DIFF
--- a/maxima/g0/skin_surf_from_ghost/ms-ssfg-header.mac
+++ b/maxima/g0/skin_surf_from_ghost/ms-ssfg-header.mac
@@ -7,7 +7,7 @@
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 1$
-minCdim_Ser : 2$
+minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
 /* Tensor order basis. No need to generate p=1. */
@@ -28,8 +28,9 @@ maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
-printPrototypes(fh) := block([],
+printPrototypes(fh) := block([varsCall, boundaryStr, bInd,c,polyOrder,bS],
 
+  varsCall : [x, y, z],
   boundaryStr : ["lower","upper"],
 
   for bInd : 1 thru length(bName) do (
@@ -39,8 +40,10 @@ printPrototypes(fh) := block([],
     for c : minCdim[bInd] thru maxCdim[bInd] do (
       /* Conf-space functions. */
       for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-        for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-          printf(fh, sconcat("GKYL_CU_DH void skin_surf_from_ghost_", boundaryStr[bS], "_", c, "x_", bName[bInd], "_p", polyOrder, "(const double *fghost, double *fskin);~%"))
+        for dir : 1 thru c do (
+          for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
+            printf(fh, sconcat("GKYL_CU_DH void skin_surf_from_ghost_", boundaryStr[bS], varsCall[dir], "_", c, "x_", bName[bInd], "_p", polyOrder, "(const double *fghost, double *fskin);~%"))
+          )
         )
       ),
       printf(fh, "~%")

--- a/maxima/g0/skin_surf_from_ghost/ms-ssfg-header.mac
+++ b/maxima/g0/skin_surf_from_ghost/ms-ssfg-header.mac
@@ -1,0 +1,61 @@
+/*
+  Generate the header file for the updater that forces the skin cell
+  to match the ghost cell at the surface.
+*/
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* Vdim possibilities for each of Cdim=[1,2,3]. */
+gkVdims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+printPrototypes(fh) := block([],
+
+  boundaryStr : ["lower","upper"],
+
+  for bInd : 1 thru length(bName) do (
+    maxPolyOrderB : maxPolyOrder[bInd],
+    if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+
+    for c : minCdim[bInd] thru maxCdim[bInd] do (
+      /* Conf-space functions. */
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
+          printf(fh, sconcat("GKYL_CU_DH void skin_surf_from_ghost_", boundaryStr[bS], "_", c, "x_", bName[bInd], "_p", polyOrder, "(const double *fghost, double *fskin);~%"))
+        )
+      ),
+      printf(fh, "~%")
+    )
+  )
+)$
+
+fh : openw("~/max-out/gkyl_skin_surf_from_ghost_kernels.h")$
+printf(fh, "#pragma once~%")$
+printf(fh, "~%")$
+printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_BEG~%")$
+printf(fh, "~%")$
+printPrototypes(fh)$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_END~%")$
+close(fh)$

--- a/maxima/g0/skin_surf_from_ghost/ms-ssfg.mac
+++ b/maxima/g0/skin_surf_from_ghost/ms-ssfg.mac
@@ -9,7 +9,7 @@ load("skin_surf_from_ghost/ssfg.mac")$
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 1$
-minCdim_Ser : 2$
+minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
 /* Tensor order basis. No need to generate p=1. */

--- a/maxima/g0/skin_surf_from_ghost/ms-ssfg.mac
+++ b/maxima/g0/skin_surf_from_ghost/ms-ssfg.mac
@@ -1,0 +1,55 @@
+/*
+  Generate kernels for an updater that forces the skin
+  surface to match the corresponding ghost surface.
+*/
+load("skin_surf_from_ghost/ssfg.mac")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* Vdim possibilities for each of Cdim=[1,2,3]. */
+gkVdims : [[1,2], [2], [2]]$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+/* Generate kernels of selected types. */
+for bInd : 1 thru length(bName) do (
+  maxPolyOrderB : maxPolyOrder[bInd],
+  if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+
+    /* Generate conf space kernels. */
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+      fname : sconcat("~/max-out/skin_surf_from_ghost_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating conf-space file: ~a",fname)),
+
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_skin_surf_from_ghost_kernels.h> ~%"),
+      printf(fh, "~%"),
+
+      funcName : sconcat("skin_surf_from_ghost_~a_", c, "x_", bName[bInd], "_p", polyOrder),
+      genSSFGkernel(fh, funcName, c, bName[bInd], polyOrder),
+      close(fh)
+    )
+
+  )
+)$

--- a/maxima/g0/skin_surf_from_ghost/ssfg.mac
+++ b/maxima/g0/skin_surf_from_ghost/ssfg.mac
@@ -9,75 +9,78 @@ load(stringproc)$
 load("nodal_operations/nodal_functions")$
 fpprec : 24$
 
-genSSFGkernel(fh, funcNm, dim, basisNm, polyOrder) := block(
-  [vars,basis,numB,surfDir,surfVar,surfPerpVars,perpDirs,basisLowD,varsLowD,subList,numBLowD,
-   nodes,numNodes,nodesLowD,numNodesLowD,boundaryStr,ghostEvSign,bS,fghost_e,fghostSurf_c,
+genSSFGkernelInDir(fh, funcNm, dim, surfDir, basisNm, polyOrder) := block(
+  [vars,basis,numB,surfVar,perpVars,perpDirs,perpBasis,subList,numBperp,
+   nodes,numNodes,perpNodes,numNodesPerp,boundaryStr,ghostEvSign,bS,fghost_e,fghostSurf_c,
    fghostSurf_noZero_c,fghostSurf_e,fghostSurf_n,fskin_e,fskin_n,i,curr_node,surf_node_idx,j,
    found_node,d,nodToMod,fskin_c],
 
   [vars, basis] : loadBasis(basisNm, dim, polyOrder),
   numB : length(basis),
 
-  surfDir : dim,  /* Assume the last dimension is the boundary direction. */
   surfVar : vars[surfDir],
-  surfPerpVars : delete(surfVar, vars),
+  perpVars : delete(surfVar, vars),
   perpDirs : delete(surfDir, makelist(i,i,1,dim)),
 
- /* Load a basis of one fewer dimension for projecting onto surface. */
-  if dim>1 then (
-    basisLowD : basisFromVars(basisNm, surfPerpVars, polyOrder),
-    varsLowD : listofvars(basisLowD)
-  ) else (
-    varsLowD : [x],  basisLowD : [1/innerProd(varsLowD,1,1,1)]
-  ),
-  numBLowD : length(basisLowD),
-
-  /* Get the nodes at requested dimension. */
+  /* Get the nodes at requested dimension, and the nodal-to-modal matrix. */
   nodes : getNodes(basisNm, dim, polyOrder),
   numNodes : length(nodes),
+  nodToMod : calcNodToModWithNodes(basisNm, dim, polyOrder, nodes),
+
+  /* Load a basis of one fewer dimension for projecting onto surface. */
+  if dim>1 then (
+    perpBasis : basisFromVars(basisNm, perpVars, polyOrder)
+  ) else (
+    perpBasis : [1/innerProd(perpVars,1,1,1)]
+  ),
+  numBperp : length(perpBasis),
 
   /* Get the nodes in one dimension lower. */
   if dim>1 then (
-    nodesLowD : getNodes(basisNm, dim-1, polyOrder),
-    numNodesLowD : length(nodesLowD)
+    perpNodes : getNodes(basisNm, dim-1, polyOrder)
+  ) else (
+    perpNodes : getNodes(basisNm, dim, polyOrder)
   ),
+  numNodesPerp : length(perpNodes),
 
-  /* Evaluate the ghost cell at the boundary and project it onto a surface basis. */
+  /* Expand skin and ghost cell in volume basis. */
+  fskin_e : doExpand1(fskin, basis),
   fghost_e : doExpand1(fghost, basis),
 
   boundaryStr : ["lower","upper"],
   ghostEvSign : [1, -1],  skinEvSign  : [-1, 1],
 
   for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(const double *fghost, double *fskin) ~%{ ~%"), boundaryStr[bS]),
+    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(const double *fghost, double *fskin) ~%{ ~%"), sconcat(boundaryStr[bS],surfVar)),
     printf(fh,"  // fghost: field in the ghost cell.~%"),
     printf(fh,"  // fskin: field in the skin cell.~%"),
     printf(fh,"~%"),
 
     /* Evaluate the (ghost cell) flux at the boundary surface. */
-    fghostSurf_c : calcInnerProdList(varsLowD,1,basisLowD,subst(surfVar=ghostEvSign[bS], fghost_e)),
+    fghostSurf_c : calcInnerProdList(perpVars,1,perpBasis,subst(surfVar=ghostEvSign[bS], fghost_e)),
     fghostSurf_noZero_c : makelistNoZeros1(fghostSurf_c, fghostSurf),
-    fghostSurf_e : doExpand(fghostSurf_noZero_c,basisLowD),
-    printf(fh,"  double fghostSurf[~a];~%", numBLowD),
+    fghostSurf_e : doExpand(fghostSurf_noZero_c,perpBasis),
+    printf(fh,"  double fghostSurf[~a];~%", numBperp),
     writeCExprs1(fghostSurf, fghostSurf_c),
     printf(fh,"~%"),
 
     /* Evaluate the surface expansion at nodes. */
-    fghostSurf_n : evAtNodes(fghostSurf_e, nodesLowD, surfPerpVars),
+    fghostSurf_n : evAtNodes(fghostSurf_e, perpNodes, perpVars),
 
     /* Evaluate skin cell at volume nodes. */
-    fskin_e : doExpand1(fskin, basis),
     fskin_n : evAtNodes(fskin_e, nodes, vars),
 
-    /* Replace nodal values of fskin with nodal values of fghostSurf. */
+    /* Replace values of fskin at nodes on boundary surface with nodal values of fghostSurf. */
     for i : 1 thru numNodes do (
       curr_node : nodes[i],
+      /* Only nodes on the boundary surface. */
       if curr_node[surfDir] = skinEvSign[bS] then (
+
         surf_node_idx : -1,
-        for j : 1 thru numNodesLowD do (
+        for j : 1 thru numNodesPerp do (
           found_node : true,
           for d : 1 thru dim-1 do (
-            if nodesLowD[j][d] = curr_node[perpDirs[d]] then (
+            if perpNodes[j][d] = curr_node[perpDirs[d]] then (
               found_node : found_node and true
             ) else (
               found_node : found_node and false
@@ -91,7 +94,6 @@ genSSFGkernel(fh, funcNm, dim, basisNm, polyOrder) := block(
     ),
 
     /* Perform a nodal to modal transformation of the skin. */
-    nodToMod : calcNodToModWithNodes(basisNm, dim, polyOrder, nodes),
     fskin_c : nodToMod . fskin_n,
     fskin_c : makelist(fullratsimp(fskin_c[i][1]),i,1,numB),
 
@@ -99,5 +101,11 @@ genSSFGkernel(fh, funcNm, dim, basisNm, polyOrder) := block(
     printf(fh, "~%"),
 
     printf(fh, "}~%~%")
+  )
+)$
+
+genSSFGkernel(fh, funcNm, dim, basisNm, polyOrder) := block([],
+  for d : 1 thru dim do (
+    genSSFGkernelInDir(fh, funcNm, dim, d, basisNm, polyOrder)
   )
 )$

--- a/maxima/g0/skin_surf_from_ghost/ssfg.mac
+++ b/maxima/g0/skin_surf_from_ghost/ssfg.mac
@@ -1,0 +1,103 @@
+/*
+  Functions to generate kernels that force the skin cell
+  to equal the ghost cell at the boundary surface.
+*/
+
+load("modal-basis");
+load("out-scripts");
+load(stringproc)$
+load("nodal_operations/nodal_functions")$
+fpprec : 24$
+
+genSSFGkernel(fh, funcNm, dim, basisNm, polyOrder) := block(
+  [vars,basis,numB,surfDir,surfVar,surfPerpVars,perpDirs,basisLowD,varsLowD,subList,numBLowD,
+   nodes,numNodes,nodesLowD,numNodesLowD,boundaryStr,ghostEvSign,bS,fghost_e,fghostSurf_c,
+   fghostSurf_noZero_c,fghostSurf_e,fghostSurf_n,fskin_e,fskin_n,i,curr_node,surf_node_idx,j,
+   found_node,d,nodToMod,fskin_c],
+
+  [vars, basis] : loadBasis(basisNm, dim, polyOrder),
+  numB : length(basis),
+
+  surfDir : dim,  /* Assume the last dimension is the boundary direction. */
+  surfVar : vars[surfDir],
+  surfPerpVars : delete(surfVar, vars),
+  perpDirs : delete(surfDir, makelist(i,i,1,dim)),
+
+ /* Load a basis of one fewer dimension for projecting onto surface. */
+  if dim>1 then (
+    basisLowD : basisFromVars(basisNm, surfPerpVars, polyOrder),
+    varsLowD : listofvars(basisLowD)
+  ) else (
+    varsLowD : [x],  basisLowD : [1/innerProd(varsLowD,1,1,1)]
+  ),
+  numBLowD : length(basisLowD),
+
+  /* Get the nodes at requested dimension. */
+  nodes : getNodes(basisNm, dim, polyOrder),
+  numNodes : length(nodes),
+
+  /* Get the nodes in one dimension lower. */
+  if dim>1 then (
+    nodesLowD : getNodes(basisNm, dim-1, polyOrder),
+    numNodesLowD : length(nodesLowD)
+  ),
+
+  /* Evaluate the ghost cell at the boundary and project it onto a surface basis. */
+  fghost_e : doExpand1(fghost, basis),
+
+  boundaryStr : ["lower","upper"],
+  ghostEvSign : [1, -1],  skinEvSign  : [-1, 1],
+
+  for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
+    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(const double *fghost, double *fskin) ~%{ ~%"), boundaryStr[bS]),
+    printf(fh,"  // fghost: field in the ghost cell.~%"),
+    printf(fh,"  // fskin: field in the skin cell.~%"),
+    printf(fh,"~%"),
+
+    /* Evaluate the (ghost cell) flux at the boundary surface. */
+    fghostSurf_c : calcInnerProdList(varsLowD,1,basisLowD,subst(surfVar=ghostEvSign[bS], fghost_e)),
+    fghostSurf_noZero_c : makelistNoZeros1(fghostSurf_c, fghostSurf),
+    fghostSurf_e : doExpand(fghostSurf_noZero_c,basisLowD),
+    printf(fh,"  double fghostSurf[~a];~%", numBLowD),
+    writeCExprs1(fghostSurf, fghostSurf_c),
+    printf(fh,"~%"),
+
+    /* Evaluate the surface expansion at nodes. */
+    fghostSurf_n : evAtNodes(fghostSurf_e, nodesLowD, surfPerpVars),
+
+    /* Evaluate skin cell at volume nodes. */
+    fskin_e : doExpand1(fskin, basis),
+    fskin_n : evAtNodes(fskin_e, nodes, vars),
+
+    /* Replace nodal values of fskin with nodal values of fghostSurf. */
+    for i : 1 thru numNodes do (
+      curr_node : nodes[i],
+      if curr_node[surfDir] = skinEvSign[bS] then (
+        surf_node_idx : -1,
+        for j : 1 thru numNodesLowD do (
+          found_node : true,
+          for d : 1 thru dim-1 do (
+            if nodesLowD[j][d] = curr_node[perpDirs[d]] then (
+              found_node : found_node and true
+            ) else (
+              found_node : found_node and false
+            )
+          ),
+          if found_node then (surf_node_idx : j)
+        ),
+
+        fskin_n[i] : fghostSurf_n[surf_node_idx]
+      )
+    ),
+
+    /* Perform a nodal to modal transformation of the skin. */
+    nodToMod : calcNodToModWithNodes(basisNm, dim, polyOrder, nodes),
+    fskin_c : nodToMod . fskin_n,
+    fskin_c : makelist(fullratsimp(fskin_c[i][1]),i,1,numB),
+
+    writeCExprs1(fskin, fskin_c),
+    printf(fh, "~%"),
+
+    printf(fh, "}~%~%")
+  )
+)$

--- a/maxima/g0/skin_surf_from_ghost/ssfg.mac
+++ b/maxima/g0/skin_surf_from_ghost/ssfg.mac
@@ -96,8 +96,12 @@ genSSFGkernelInDir(fh, funcNm, dim, surfDir, basisNm, polyOrder) := block(
     /* Perform a nodal to modal transformation of the skin. */
     fskin_c : nodToMod . fskin_n,
     fskin_c : makelist(fullratsimp(fskin_c[i][1]),i,1,numB),
+    /* Write these coefficients to avoid wrongful use of new coefficients. */
+    printf(fh,"  double fskinNew[~a];~%", numB),
+    writeCExprs1(fskinNew, fskin_c),
+    printf(fh,"~%"),
 
-    writeCExprs1(fskin, fskin_c),
+    writeCExprs1(fskin, makelist(fskinNew[i-1],i,1,numB)),
     printf(fh, "~%"),
 
     printf(fh, "}~%~%")


### PR DESCRIPTION
Maxima for the skin_surf_from_ghost updater in gkylzero. This updater:
1. Evaluates the ghost at the "basis" nodes on the skin-ghost boundary.
2. Sets the value of the skin at the "basis" nodes on the skin-ghost boundary to equal the ghost at these same locations. Leaves the value at the nodes not on the "basis" nodes fn the skin-ghost boundary untouched.
3. Performs a nodal to modal transformation to reconstruct the skin's modal representation.

This meant to be used for enforcing the TS BC of phi on the boundary surface after we use the TS updater to fill the ghost cell ([PR 576 in gkylzero](https://github.com/ammarhakim/gkylzero/pull/576)).