### PR TITLE
Added 1x2v, 1x3v, 2x3v kernels to the can-pb species

### DIFF
--- a/maxima/g0/canonical_pb/canonical-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/canonical-alpha-surf.mac
@@ -154,7 +154,7 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
       printf(fh, "  double *alphaR = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
       printf(fh, "  double *sgn_alpha_surfR = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing)
     ),
-    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
+    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R",cdim,vdim,pDim),
     calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"R")
   )
   else (
@@ -171,7 +171,7 @@ buildCanonicalPBAlphaKernel(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOrder
       printf(fh, "  double *alphaL = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
       printf(fh, "  double *sgn_alpha_surfL = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing)
     ),
-    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
+    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L",cdim,vdim,pDim),
     calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"L")
   ),
   printf(fh, "  return const_sgn_alpha_surf; ~%"),

--- a/maxima/g0/canonical_pb/canonical-pressure-vars.mac
+++ b/maxima/g0/canonical_pb/canonical-pressure-vars.mac
@@ -2,7 +2,9 @@
     pressure tensor and metric
 
     // Solve for d*P*Jv: d*P*Jv = h^{ij}*M2_{ij} - n*h^{ij}*u_i*u_j 
-    //                     = h^{ij}*M2_{ij} - h^{ij}*M1i*V_drift_j 
+    //                          = h^{ij}*M2_{ij} - h^{ij}*M1i*V_drift_j
+    //                          = 2E - h^{ij}*M1i*V_drift_j (ENERGY CONS.)
+    // P = nT
     */
 
 load("modal-basis")$

--- a/maxima/g0/canonical_pb/canonical-pressure-vars.mac
+++ b/maxima/g0/canonical_pb/canonical-pressure-vars.mac
@@ -13,7 +13,7 @@ load(stringproc)$
 load("scifac")$
 fpprec : 24$
 
-calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
+calcCanonicalPbPressure(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC, bC, NC],
 
   kill(varsC, bC),
@@ -42,20 +42,20 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
 
  
   printf(fh, "  const double *NVx = &nv_i[~a]; ~%", 0*NC),
-  if (cdim > 1) then (
+  if (vdim > 1) then (
     printf(fh, "  const double *NVy = &nv_i[~a]; ~%", 1*NC)
   ),
-  if (cdim > 2) then (
+  if (vdim > 2) then (
     printf(fh, "  const double *NVz = &nv_i[~a]; ~%", 2*NC)
   ),
   printf(fh, "~%"),
 
 
   printf(fh, "  const double *Vx = &v_j[~a]; ~%", 0*NC),
-  if (cdim > 1) then (
+  if (vdim > 1) then (
     printf(fh, "  const double *Vy = &v_j[~a]; ~%", 1*NC)
   ),
-  if (cdim > 2) then (
+  if (vdim > 2) then (
   printf(fh, "  const double *Vz = &v_j[~a]; ~%", 2*NC)
   ),
   printf(fh, "~%"),
@@ -64,15 +64,15 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
   printf(fh, "  const double *energy = &MEnergy[~a]; ~%", 0*NC),
   printf(fh, "~%"),
 
-  if (cdim = 1) then (
+  if (vdim = 1) then (
     printf(fh, "  const double *Hxx = &h_ij_inv[~a]; ~%", 0*NC)
   ),
-  if (cdim = 2) then (
+  if (vdim = 2) then (
     printf(fh, "  const double *Hxx = &h_ij_inv[~a]; ~%", 0*NC),
     printf(fh, "  const double *Hxy = &h_ij_inv[~a]; ~%", 1*NC),
     printf(fh, "  const double *Hyy = &h_ij_inv[~a]; ~%", 2*NC)
   ),
-  if (cdim = 3) then (
+  if (vdim = 3) then (
     printf(fh, "  const double *Hxx = &h_ij_inv[~a]; ~%", 0*NC),
     printf(fh, "  const double *Hxy = &h_ij_inv[~a]; ~%", 1*NC),
     printf(fh, "  const double *Hxz = &h_ij_inv[~a]; ~%", 2*NC),
@@ -94,7 +94,7 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
   printf(fh, "  binop_mul_~ad_~a_p~a(Hxx_M1x, Vx, Hxx_M1x_Vx); ~%", cdim, basisFun, polyOrder),
   printf(fh, " ~%"),
 
-  if (cdim > 1) then (
+  if (vdim > 1) then (
     printf(fh, "  double Hxy_M1x[~a] = {0.0}; ~%", NC),
     printf(fh, "  double Hxy_M1x_Vy[~a] = {0.0}; ~%", NC),
     printf(fh, "  binop_mul_~ad_~a_p~a(Hxy, NVx, Hxy_M1x); ~%", cdim, basisFun, polyOrder),
@@ -108,7 +108,7 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
     printf(fh, " ~%")
   ),
 
-  if (cdim > 2) then (
+  if (vdim > 2) then (
     printf(fh, "  double Hxz_M1x[~a] = {0.0}; ~%", NC),
     printf(fh, "  double Hxz_M1x_Vz[~a] = {0.0}; ~%", NC),
     printf(fh, "  binop_mul_~ad_~a_p~a(Hxz, NVx, Hxz_M1x); ~%", cdim, basisFun, polyOrder),
@@ -131,11 +131,11 @@ calcCanonicalPbPressure(fh, funcNm, cdim, basisFun, polyOrder) := block(
   for i : 1 thru NC do (
     printf(fh, "  d_Jv_P[~a] = 2.0*energy[~a]; ~%", i-1, i-1),
     printf(fh, "  d_Jv_P[~a] += - Hxx_M1x_Vx[~a]; ~%", i-1, i-1),
-    if (cdim > 1) then (
+    if (vdim > 1) then (
     printf(fh, "  d_Jv_P[~a] += (- Hxy_M1x_Vy[~a])*2.0; ~%", i-1, i-1),
     printf(fh, "  d_Jv_P[~a] +=  - Hyy_M1y_Vy[~a]; ~%", i-1, i-1)
     ),
-    if (cdim > 2) then (
+    if (vdim > 2) then (
       printf(fh, "  d_Jv_P[~a] += (- Hxz_M1x_Vz[~a])*2.0; ~%", i-1, i-1),
       printf(fh, "  d_Jv_P[~a] += (- Hyz_M1y_Vz[~a])*2.0; ~%", i-1, i-1),
       printf(fh, "  d_Jv_P[~a] +=  - Hzz_M1z_Vz[~a]; ~%", i-1, i-1)

--- a/maxima/g0/canonical_pb/canonical-vol.mac
+++ b/maxima/g0/canonical_pb/canonical-vol.mac
@@ -68,7 +68,6 @@ buildCanonicalPBVolKernel(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   for dir : 1 thru cdim do (
     pbfac[dir] : 4*dxdvInv[dir]
   ),
-  volfac : 1,
   for dir : 1 thru cdim do (
     printf(fh, "  double dxdvInv~a = 1.0/(dxv[~a]*dxv[~a]); ~%", dir-1, cid[dir], vid[dir])
   ),
@@ -80,9 +79,14 @@ buildCanonicalPBVolKernel(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   ),
   fl : doExpand1(f, bP),
   Hl : doExpand1(hamil, bP),
+  /* For cdim /= vdim, we assume the ignorable coordinates are the last pairs.
+  For instance if we have varsC = [x,y,z] with:
+  - 1 ignorable coordinate: [x,y, \dot{x},\dot{y}] are all that show up in {f,H} 
+  - 2 ignorable coordinates: [x, \dot{x},] are all that show up in {f,H} 
+  It's assumed that H does not depend on these ignorable coordinates */
   pb : (pb : 0, for dir : 1 thru cdim do (
      pbBasis : pbfac[dir]*(PB_vol(bP,Hl,varsC[dir],varsV[dir])),
-     pb : pb + fullratsimp(volfac*calcInnerProdList(varsP, 1, pbBasis, fl))
+     pb : pb + fullratsimp(calcInnerProdList(varsP, 1, pbBasis, fl))
      ),
   pb),
   writeCIncrExprsNoExpand(facsum(fullratsimp(pb),dxv)),

--- a/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
+++ b/maxima/g0/canonical_pb/canonicalFuncs-surf.mac
@@ -119,8 +119,8 @@ calcCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun, polyOr
 
   /* Compute the surface alpha but do *not* write it out; we already computed it
      We just need to re-compute it here in Maxima to get the right sparsity pattern */
-  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
-  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
+  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L",cdim,vdim,pDim),
+  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R",cdim,vdim,pDim),
 
   if (polyOrder=1 and basisFun="ser" and surfDir > cdim) then (
    surfIntVars_hyb_conf : delete(varsP[1],varsP),
@@ -289,8 +289,8 @@ calcCanonicalPBBoundarySurfUpdateInDir(surfDir, fh, funcNm, cdim, vdim, basisFun
      We just need to re-compute it here in Maxima to get the right sparsity pattern 
      Further, for boundary surface kernels we will only use one of the surface alphas
      for computing the update (but pre-compute both for convenience here). */
-  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L"),
-  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R"),
+  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"L",cdim,vdim,pDim),
+  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bP,varsP,bSurf,basisFun,rdx2vec,rdv2vec,hamil,"R",cdim,vdim,pDim),
 
   /* When we need the surface alpha at +1, we use alpha_edge 
      (which stores the next interior edge surface alpha at -1 and alpha is continuous)

--- a/maxima/g0/canonical_pb/canonicalUtils.mac
+++ b/maxima/g0/canonical_pb/canonicalUtils.mac
@@ -20,7 +20,7 @@ PB(f, g, x_vec, y_vec, dx_vec, dy_vec) :=
     i, 1, length(x_vec)
   )$
 
-calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,hamil,sideStr) := block(
+calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,hamil,sideStr,cdim,vdim,pDim) := block(
   [varsC, varsV, varLabel, dirLabel, wSurf, rdSurfVar2, surfVar, surfIntVars, rdx2vec, rdv2vec,
    z, q, p, dq, dp, alpha, alphaUp, numSurf, evPoint, replaceList, alpha_c, printf, alphaCvar,
    alphaNoZero_c, alphaSurf, alphaUpSurf], 
@@ -30,7 +30,7 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,h
      determine upwind direction. */
 
   varsC : slcn(varsP, cdim),
-  varsV : slcn_v(varsP, cdim),
+  varsV : slcn_v(varsP, cdim), /* cdim offset */
   varLabel : makelist(string(varsP[d]),d,1,pDim),
   dirLabel : varLabel[surfDir],
 
@@ -39,6 +39,10 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,h
 
   surfVar     : varsP[surfDir],         /* Surface variable. */
   surfIntVars : delete(surfVar,varsP),  /* Surface integral variables. */
+
+  /* print("varsC ",varsC),
+  print("varsV ",varsV),
+  print("varsR ",varsR), */
 
   /* Calculate phase space velocity alpha_d = {z[d], H} = dz[d]/dt. */
   rdx2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,1,cdim),
@@ -53,7 +57,7 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,h
   numSurf : length(bSurf),
 
   if sideStr="L" then (evPoint : -1)
-  elseif sideStr="R" then (evPoint : 1),
+  else if sideStr="R" then (evPoint : 1),
 
   /* Project full alpha expression evaluated at interior surface
      onto surface basis and print to C variable alpha. */
@@ -72,7 +76,7 @@ calcAndWrite_CanonicalPB_alpha(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,h
 
 
 calc_canonical_pb_alpha_no_write(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V,
-                   hamil,sideStr) := block(
+                   hamil,sideStr,cdim,vdim,pDim) := block(
   [varsC, varsV, varLabel, dirLabel, wSurf, rdSurfVar2, surfVar, surfIntVars, rdx2vec, rdv2vec,
    z, q, p, dq, dp, alpha, alphaUp, numSurf, evPoint, replaceList, alpha_c, printf, alphaCvar,
    alphaNoZero_c, alphaSurf, alphaUpSurf],
@@ -106,7 +110,7 @@ calc_canonical_pb_alpha_no_write(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V
   numSurf : length(bSurf),
 
   if sideStr="L" then (evPoint : -1)
-  elseif sideStr="R" then (evPoint : 1),
+  else if sideStr="R" then (evPoint : 1),
 
   /* Project full alpha expression evaluated at interior surface
      onto surface basis and print to C variable alpha. */

--- a/maxima/g0/canonical_pb/ms-canonical-pb-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-alpha-surf.mac
@@ -11,6 +11,7 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
@@ -18,6 +19,7 @@ minPolyOrder_Tensor : 1$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 3$
+maxVdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
@@ -27,6 +29,7 @@ minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$
@@ -34,70 +37,71 @@ vlabels : ["vx","vy","vz"]$
 /* Generate kernels of selected types. */
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
-    v : c, /* Canonical PB only supports equal cdim and vdim */
-    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
-
+    for v : c thru maxVdim[bInd] do (
       maxPolyOrderB : maxPolyOrder[bInd],
       if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x3v */
       for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-        /* Surface alpha in direction dir in configuration space.*/
-        for dir : 1 thru c do (
-          fname : sconcat("~/max-out/canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
-          disp(printf(false,"Creating alpha surf~a file: ~a",clabels[dir],fname)),
-    
-          fh : openw(fname),
-          printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
-          if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
-            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+dir),
-            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
-          ) 
-          else (
-            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+dir),
-            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
+        if not(c = 3 and bName[bInd] = "ser") and not(c = 2 and v = 3 and bName[bInd] = "tensor" and polyOrder = 2) then ( /* SKIP hybrid in 3d */
+
+          /* Surface alpha in direction dir in configuration space.*/
+          for dir : 1 thru c do (
+            fname : sconcat("~/max-out/canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+            disp(printf(false,"Creating alpha surf~a file: ~a",clabels[dir],fname)),
+      
+            fh : openw(fname),
+            printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+            if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+              printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+dir),
+              printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
+            ) 
+            else (
+              printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+dir),
+              printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
+            ),
+
+            funcName : sconcat("canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
+            close(fh),
+
+            fname : sconcat("~/max-out/canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+            disp(printf(false,"Creating alpha edge surf~a file: ~a",clabels[dir],fname)),
+      
+            fh : openw(fname),
+            printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+            if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+              printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+dir),
+              printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
+            ) 
+            else (
+              printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+dir),
+              printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
+            ),
+
+            funcName : sconcat("canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, true), /* An edge */
+            close(fh)
           ),
 
-          funcName : sconcat("canonical_pb_alpha_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-          buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
-          close(fh),
+          /* Surface alpha in v direction.*/
+          for v_sub_indx : 1 thru v do (
+            fname : sconcat("~/max-out/canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+            disp(printf(false,"Creating alpha surfvx file: ~a",fname)),
 
-          fname : sconcat("~/max-out/canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
-          disp(printf(false,"Creating alpha edge surf~a file: ~a",clabels[dir],fname)),
-    
-          fh : openw(fname),
-          printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
-          if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
-            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+dir),
-            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
-          ) 
-          else (
-            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+dir),
-            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
-          ),
+            fh : openw(fname),
+            printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+            if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+              printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+v_sub_indx),
+              printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
+            ) 
+            else (
+              printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+v_sub_indx),
+              printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
+            ),
 
-          funcName : sconcat("canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-          buildCanonicalPBAlphaKernel(dir, fh, funcName, c, v, bName[bInd], polyOrder, true), /* An edge */
-          close(fh)
-        ),
-
-        /* Surface alpha in v direction.*/
-        for v_sub_indx : 1 thru v do (
-          fname : sconcat("~/max-out/canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
-          disp(printf(false,"Creating alpha surfvx file: ~a",fname)),
-
-          fh : openw(fname),
-          printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
-          if (polyOrder=1 and bName[bInd]="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
-            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_surfx~a_eval_quad.h> ~%", c, v, c+v_sub_indx),
-            printf(fh, "#include <gkyl_basis_hyb_~ax~av_p1_upwind_quad_to_modal.h> ~%", c, v)
-          ) 
-          else (
-            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_surfx~a_eval_quad.h> ~%", bName[bInd], c+v, polyOrder, c+v_sub_indx),
-            printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bName[bInd], c+v, polyOrder)
-          ),
-
-          funcName : sconcat("canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-          buildCanonicalPBAlphaKernel(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
-          close(fh)
+            funcName : sconcat("canonical_pb_alpha_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            buildCanonicalPBAlphaKernel(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder, false), /* Not an edge */
+            close(fh)
+          )
         )
       )
     )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
@@ -43,11 +43,9 @@ printPrototypes() := block([],
               const double *fin, double* GKYL_RESTRICT out); ~%", c, v, bName[bInd], polyOrder),
 
             /* Only make one pressure kernel header line */
-            if (v = c) then (
-              funcNm : sconcat("canonical_pb_vars_pressure_",  c, "x_", bName[bInd], "_p", polyOrder),
-              printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *MEnergy, const double *v_j, 
-              const double *nv_i, double* GKYL_RESTRICT d_Jv_P);~%", funcNm, polyOrder)
-            ),
+            funcNm : sconcat("canonical_pb_vars_pressure_",  c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *MEnergy, const double *v_j, 
+            const double *nv_i, double* GKYL_RESTRICT d_Jv_P);~%", funcNm, polyOrder),
             
             for surfDir : 1 thru c+v do ( /* Iterate over each phase space coordinate */
               if surfDir<=c then (dirlabel : clabels[surfDir]) else (dirlabel : vlabels[surfDir-c]),

--- a/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
@@ -7,6 +7,7 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
@@ -14,6 +15,7 @@ minPolyOrder_Tensor : 1$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 3$
+maxVdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
@@ -23,6 +25,7 @@ minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$
@@ -30,38 +33,43 @@ vlabels : ["vx","vy","vz"]$
 printPrototypes() := block([],
   for bInd : 1 thru length(bName) do (
     for c : minCdim[bInd] thru maxCdim[bInd] do (
-      v : c, /* Canonical PB only supports equal cdim and vdim */
-      if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
-
+      for v : c thru maxVdim[bInd] do (
         maxPolyOrderB : maxPolyOrder[bInd],
         if (c=3) then maxPolyOrderB : 1, /* Only declare p=1 kernels for 3x3v */
         for polyOrder : 1 thru maxPolyOrderB do (
-          printf(fh, "GKYL_CU_DH double canonical_pb_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,  
-            const double *fin, double* GKYL_RESTRICT out); ~%", c, v, bName[bInd], polyOrder),
-          funcNm : sconcat("canonical_pb_vars_pressure_",  c, "x_", bName[bInd], "_p", polyOrder),
-          printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *M2_ij, const double *v_j, 
-          const double *nv_i, double* GKYL_RESTRICT d_Jv_P);~%", funcNm, polyOrder),
-          
-          for surfDir : 1 thru c+v do ( /* Iterate over each phase space coordinate */
-            if surfDir<=c then (dirlabel : clabels[surfDir]) else (dirlabel : vlabels[surfDir-c]),
-            printf(fh, "GKYL_CU_DH int canonical_pb_alpha_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
-              double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder),
-            if (surfDir < c+1) then ( /* Only for configuration space */
-              printf(fh, "GKYL_CU_DH int canonical_pb_alpha_edge_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
-                double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder)
+          if not(c = 3 and bName[bInd] = "ser") and not(c = 2 and v = 3 and bName[bInd] = "tensor" and polyOrder = 2) then ( /* SKIP hybrid in 3d */
+
+            printf(fh, "GKYL_CU_DH double canonical_pb_vol_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,  
+              const double *fin, double* GKYL_RESTRICT out); ~%", c, v, bName[bInd], polyOrder),
+
+            /* Only make one pressure kernel header line */
+            if (v = c) then (
+              funcNm : sconcat("canonical_pb_vars_pressure_",  c, "x_", bName[bInd], "_p", polyOrder),
+              printf(fh, "GKYL_CU_DH void ~a(const double *h_ij_inv, const double *MEnergy, const double *v_j, 
+              const double *nv_i, double* GKYL_RESTRICT d_Jv_P);~%", funcNm, polyOrder)
             ),
-            printf(fh, "GKYL_CU_DH double canonical_pb_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
-            const double *alpha_surf_l, const double *alpha_surf_r, 
-            const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
-            const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
-            const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder),
-            printf(fh, "GKYL_CU_DH double canonical_pb_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
-            const double *alpha_surf_edge, const double *alpha_surf_skin, 
-            const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
-            const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, 
-            const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder)
-          ), 
-          printf(fh, "~%")
+            
+            for surfDir : 1 thru c+v do ( /* Iterate over each phase space coordinate */
+              if surfDir<=c then (dirlabel : clabels[surfDir]) else (dirlabel : vlabels[surfDir-c]),
+              printf(fh, "GKYL_CU_DH int canonical_pb_alpha_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
+                double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder),
+              if (surfDir < c+1) then ( /* Only for configuration space */
+                printf(fh, "GKYL_CU_DH int canonical_pb_alpha_edge_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
+                  double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, v, bName[bInd], polyOrder)
+              ),
+              printf(fh, "GKYL_CU_DH double canonical_pb_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil, 
+              const double *alpha_surf_l, const double *alpha_surf_r, 
+              const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
+              const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
+              const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder),
+              printf(fh, "GKYL_CU_DH double canonical_pb_boundary_surf~a_~ax~av_~a_p~a(const double *w, const double *dxv, const double *hamil,
+              const double *alpha_surf_edge, const double *alpha_surf_skin, 
+              const double *sgn_alpha_surf_edge, const double *sgn_alpha_surf_skin, 
+              const int *const_sgn_alpha_edge, const int *const_sgn_alpha_skin, 
+              const int edge, const double *fedge, const double *fskin, double* GKYL_RESTRICT out); ~%", dirlabel, c, v, bName[bInd], polyOrder)
+            ), 
+            printf(fh, "~%")
+          )
         )
       )
     )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moment-header.mac
@@ -7,6 +7,7 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
@@ -14,6 +15,7 @@ minPolyOrder_Tensor : 1$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 3$
+maxVdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
@@ -23,6 +25,7 @@ minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 printPrototype(deco, ci, vi, bStr, pi) := block([si],
   printf(fh, "~avoid canonical_pb_MEnergy_~ax~av_~a_p~a(const double *dxv, const double *hamil, const double *f, double* GKYL_RESTRICT out); ~%", deco, ci, vi, bStr, pi),
@@ -40,14 +43,15 @@ printf(fh, "~%")$
 decorator : "GKYL_CU_DH "$
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
-    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
-
+    for v : c thru maxVdim[bInd] do (
       minPolyOrderB : minPolyOrder[bInd],
       maxPolyOrderB : maxPolyOrder[bInd],
-      if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
+      if (c+v>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
 
       for polyOrder : minPolyOrderB thru maxPolyOrderB do (
-      printPrototype(decorator, c, c, bName[bInd], polyOrder)
+        if not(c = 3 and bName[bInd] = "ser") and not(c = 2 and v = 3 and bName[bInd] = "tensor" and polyOrder = 2) then ( /* SKIP hybrid in 3d */
+          printPrototype(decorator, c, v, bName[bInd], polyOrder)
+        )
       )
     )
   )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-moments.mac
@@ -10,6 +10,7 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
@@ -17,6 +18,7 @@ minPolyOrder_Tensor : 1$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 3$
+maxVdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
@@ -26,23 +28,25 @@ minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
-    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
-
+    for v : c thru maxVdim[bInd] do (
       minPolyOrderB : minPolyOrder[bInd],
       maxPolyOrderB : maxPolyOrder[bInd],
-      if (c+c>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
+      if (c+v>5 and maxPolyOrderB > 1) then maxPolyOrderB : 1,
 
       /* Canonical-pb moment calculators. */
       for polyOrder : minPolyOrderB thru maxPolyOrderB do (
-        disp(printf(false,sconcat("Creating Canonical-pb Moments ~ax~av", bName[bInd]),c,c)),
-        fname : sconcat("~/max-out/mom_canonical_pb_", c, "x", c, "v_", bName[bInd], "_p", polyOrder, ".c"),
-        fh : openw(fname),
-        funcName : sconcat("canonical_pb"),
-        calcCanPBMoments(fh, funcName, c, c, bName[bInd], polyOrder),
-        close(fh)
+        if not(c = 3 and bName[bInd] = "ser") and not(c = 2 and v = 3 and bName[bInd] = "tensor" and polyOrder = 2) then ( /* SKIP hybrid in 3d */
+          disp(printf(false,sconcat("Creating Canonical-pb Moments ~ax~av", bName[bInd]),c,v)),
+          fname : sconcat("~/max-out/mom_canonical_pb_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          fh : openw(fname),
+          funcName : sconcat("canonical_pb"),
+          calcCanPBMoments(fh, funcName, c, v, bName[bInd], polyOrder),
+          close(fh)
+        )
       )
     )
   )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-pressure-vars.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-pressure-vars.mac
@@ -12,6 +12,7 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
@@ -19,6 +20,7 @@ minPolyOrder_Tensor : 1$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 3$
+maxVdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
@@ -28,21 +30,24 @@ minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 for bInd : 1 thru length(bName) do (
-  for d : minCdim[bInd] thru maxCdim[bInd] do (
-    if not(d = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
-      minPolyOrderB : minPolyOrder[bInd],
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for v : c thru maxVdim[bInd] do (
       maxPolyOrderB : maxPolyOrder[bInd],
-      if (d>2) then maxPolyOrderB : 1,
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x3v */
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        if not(c = 3 and bName[bInd] = "ser") and not(c = 2 and v = 3 and bName[bInd] = "tensor" and polyOrder = 2) then ( /* SKIP hybrid in 3d */
 
-      for polyOrder : minPolyOrderB thru maxPolyOrderB do (
-        disp(printf(false,sconcat("Creating canonical_pb vars funcs ",bName[bInd]," ~axp~a"),d,polyOrder)),
-        fname : sconcat("~/max-out/canonical_pb_vars_pressure_", d, "x_", bName[bInd], "_p", polyOrder, ".c"),
-        fh : openw(fname),
-        funcName : sconcat("canonical_pb_vars_pressure_",  d, "x_", bName[bInd], "_p", polyOrder),
-        calcCanonicalPbPressure(fh, funcName, d, "ser", polyOrder),
-        close(fh)
+          disp(printf(false,sconcat("Creating canonical_pb vars funcs ",bName[bInd]," ~ax~avp~a"),c,v,polyOrder)),
+          fname : sconcat("~/max-out/canonical_pb_vars_pressure_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          fh : openw(fname),
+          funcName : sconcat("canonical_pb_vars_pressure_",  c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+          calcCanonicalPbPressure(fh, funcName, c, v, "ser", polyOrder),
+          close(fh)
+
+        )
       )
     )
   )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-surf.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-surf.mac
@@ -15,6 +15,7 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
@@ -22,6 +23,7 @@ minPolyOrder_Tensor : 1$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 3$
+maxVdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
@@ -31,6 +33,7 @@ minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$
@@ -49,54 +52,53 @@ printf(fh, "~%"),
 /* Generate kernels of selected types. */
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
-    v : c, /* Canonical PB only supports equal cdim and vdim */
-
-    /* Skip 3x3v ser (hyb) */
-    if not(c = 3 and bName[bInd] = "ser") then (
+    for v : c thru maxVdim[bInd] do (
       maxPolyOrderB : maxPolyOrder[bInd],
       if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x3v */
       for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-        for dir : 1 thru c do (
-          /* Advection in configuration space.*/
-          fname : sconcat("~/max-out/canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-          disp(printf(false,"Creating surface file: ~a",fname)),
+        if not(c = 3 and bName[bInd] = "ser") and not(c = 2 and v = 3 and bName[bInd] = "tensor" and polyOrder = 2) then ( /* SKIP hybrid in 3d */
+          for dir : 1 thru c do (
+            /* Advection in configuration space.*/
+            fname : sconcat("~/max-out/canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+            disp(printf(false,"Creating surface file: ~a",fname)),
 
-          fh : openw(fname),
-          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
-          funcName : sconcat("canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-          calcCanonicalPBSurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
-          close(fh),
+            fh : openw(fname),
+            includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
+            funcName : sconcat("canonical_pb_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            calcCanonicalPBSurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
+            close(fh),
 
-          /* Advection in configuration space in the skin cell (for boundary flux operations) .*/
-          fname : sconcat("~/max-out/canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-          disp(printf(false,"Creating surface file: ~a",fname)),
+            /* Advection in configuration space in the skin cell (for boundary flux operations) .*/
+            fname : sconcat("~/max-out/canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+            disp(printf(false,"Creating surface file: ~a",fname)),
 
-          fh : openw(fname),
-          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
-          funcName : sconcat("canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-          calcCanonicalPBBoundarySurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
-          close(fh)
-        ),
-        /* Index over advection in velocity space.*/
-        for v_sub_indx : 1 thru v do (
-          fname : sconcat("~/max-out/canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-          disp(printf(false,"Creating surface file: ~a",fname)),
+            fh : openw(fname),
+            includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, dir),
+            funcName : sconcat("canonical_pb_boundary_surf",clabels[dir],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            calcCanonicalPBBoundarySurfUpdateInDir(dir, fh, funcName, c, v, bName[bInd], polyOrder),
+            close(fh)
+          ),
+          /* Index over advection in velocity space.*/
+          for v_sub_indx : 1 thru v do (
+            fname : sconcat("~/max-out/canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+            disp(printf(false,"Creating surface file: ~a",fname)),
 
-          fh : openw(fname),
-          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
-          funcName : sconcat("canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-          calcCanonicalPBSurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
-          close(fh),
+            fh : openw(fname),
+            includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
+            funcName : sconcat("canonical_pb_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            calcCanonicalPBSurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
+            close(fh),
 
-          /* Advection in velocity space in the skin cell along vpar (for zero-flux BCs).*/
-          fname : sconcat("~/max-out/canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
-          disp(printf(false,"Creating surface file: ~a",fname)),
+            /* Advection in velocity space in the skin cell along vpar (for zero-flux BCs).*/
+            fname : sconcat("~/max-out/canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p",polyOrder, ".c"),
+            disp(printf(false,"Creating surface file: ~a",fname)),
 
-          fh : openw(fname),
-          includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
-          funcName : sconcat("canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
-          calcCanonicalPBBoundarySurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
-          close(fh)
+            fh : openw(fname),
+            includeSurfHeaders(fh, bName[bInd], c, v, polyOrder, c+v_sub_indx),
+            funcName : sconcat("canonical_pb_boundary_surf",vlabels[v_sub_indx],"_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+            calcCanonicalPBBoundarySurfUpdateInDir(c+v_sub_indx, fh, funcName, c, v, bName[bInd], polyOrder),
+            close(fh)
+          )
         )
       )
     )

--- a/maxima/g0/canonical_pb/ms-canonical-pb-vol.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-vol.mac
@@ -13,6 +13,7 @@ minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
 minCdim_Ser : 1$
 maxCdim_Ser : 3$
+maxVdim_Ser : 3$
 
 /* Tensor product basis. */
 /* Note that Serendipity, p=1, is hybrid and p=1 Tensor is *pure* p=1 */
@@ -20,6 +21,7 @@ minPolyOrder_Tensor : 1$
 maxPolyOrder_Tensor : 2$
 minCdim_Tensor : 1$
 maxCdim_Tensor : 3$
+maxVdim_Tensor : 3$
 
 /* ...... END OF USER INPUTS........ */
 
@@ -29,6 +31,7 @@ minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 clabels : ["x","y","z"]$
 vlabels : ["vx","vy","vz"]$
@@ -36,12 +39,12 @@ vlabels : ["vx","vy","vz"]$
 /* Generate kernels of selected types. */
 for bInd : 1 thru length(bName) do (
   for c : minCdim[bInd] thru maxCdim[bInd] do (
-    v : c, /* Canonical PB only supports equal cdim and vdim */
-    if not(c = 3 and bName[bInd] = "ser") then ( /* SKIP hybrid in 3d */
-
+    for v : c thru maxVdim[bInd] do (
       maxPolyOrderB : maxPolyOrder[bInd],
-      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+      if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x3v */
       for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        if not(c = 3 and bName[bInd] = "ser") and not(c = 2 and v = 3 and bName[bInd] = "tensor" and polyOrder = 2) then ( /* SKIP hybrid in 3d */
+
           fname : sconcat("~/max-out/canonical_pb_vol_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
           disp(printf(false,"Creating volume file: ~a",fname)),
 
@@ -50,6 +53,7 @@ for bInd : 1 thru length(bName) do (
 
           funcName : sconcat("canonical_pb_vol_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
           buildCanonicalPBVolKernel(fh, funcName, c, v, bName[bInd], polyOrder)
+        )
       )
     )
   )


### PR DESCRIPTION
Generates the kernels to allow for ignorable coordinates in the can-pb species.
See [G0 PR](https://github.com/ammarhakim/gkylzero/pull/536) and associated DR for more details.