### PR TITLE
Corresponding Maxima for the extension of Vlasov fluid species to simulate canonical Poisson bracket fluid equations

### DIFF
--- a/maxima/g0/canonical_pb/canonicalUtils.mac
+++ b/maxima/g0/canonical_pb/canonicalUtils.mac
@@ -96,7 +96,6 @@ calc_canonical_pb_alpha_no_write(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V
   surfVar     : varsP[surfDir],         /* Surface variable. */
   surfIntVars : delete(surfVar,varsP),  /* Surface integral variables. */
 
-
   /* Calculate phase space velocity alpha_d = {z[d], H} = dz[d]/dt. */
   rdx2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,1,cdim),
   rdv2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,cdim+1,pDim),
@@ -125,7 +124,7 @@ calc_canonical_pb_alpha_no_write(fH,surfDir,bP,varsP,bSurf,basisType,rdx2V,rdv2V
 
 /* Determine the upwinded distribution function in canonical pb */
 calcAndWrite_CanonicalPBfUpwind(file_handle,surfDir,surfVar,surfIntVars,bSurf,NSurf,fl_e,fr_e,basisStr,sideStr,
-                    cdim, vdim, polyOrder,basisFun) := block(
+                    cdim, vdim, polyOrder, basisFun, conf_only) := block(
   [fstrL, fstrR, fLNm, fRNm, fUpNm, sgn_alpha_surfNm, sgn_alphaUpNm, fSurfl_c, fSurfr_c, 
    fSurfl_e, fSurfr_e, sgn_alphaUp_e, fUp_c],
    
@@ -172,7 +171,8 @@ calcAndWrite_CanonicalPBfUpwind(file_handle,surfDir,surfVar,surfIntVars,bSurf,NS
     
     /*printf(file_handle, "  ~a_upwind_quad_to_modal(~a, ~a); ~%", basisStr, sgn_alpha_surfNm, sgn_alphaUpNm),*/
     printf(file_handle, "  // Project tensor nodal quadrature basis back onto modal basis. ~%"),
-    if (polyOrder=1 and basisFun="ser") then (  /* Force p=1 Serendipity to use hybrid basis. */
+    if (polyOrder=1 and basisFun="ser" and (not conf_only)) then ( 
+      /* Force p=1 Serendipity for kinetic equations to use hybrid basis. */
       if (surfDir - cdim > 0) then ( 
         /* Velocity space */
         printf(file_handle, "  hyb_~ax~av_p1_vdir_upwind_quad_to_modal(~a, ~a); ~%", cdim, vdim, sgn_alpha_surfNm, sgn_alphaUpNm)

--- a/maxima/g0/canonical_pb/fluid-canonical-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/fluid-canonical-alpha-surf.mac
@@ -1,0 +1,113 @@
+/*
+   Create kernels for the surface expansions of the flux alpha 
+   for a canonical Poisson bracket fluid system, e.g., incomressible Euler or Hasegawa-Wakatani.
+   Evaluates the Poisson bracket alpha = dz/dt = {z, phi} at the corresponding surface
+   and then projects the resulting evaluation onto a surface basis in each direction
+   of the update. Each cell owns the *lower* surface expansion in that direction.
+
+   Note that dz/dt = {z, phi} is a higher order expansion and this order of operations
+   1. Expand alpha = dz/dt = {z, phi}
+   2. Evaluate alpha at desired surface
+   3. Project alpha onto surface basis
+   *must* be respected to insure alpha is continuous at phase space interfaces like 
+   we require it to be (if we create lower order intermediate variables or pre-project
+   alpha in the volume and then evaluate it at surfaces, we may destroy the continuity
+   of the surface alpha).
+
+   *hamil* is assumed to be written in canonical coordinates
+*/
+
+load("modal-basis")$
+load("out-scripts")$
+load(stringproc)$
+load("scifac")$
+load("canonical_pb/canonicalUtils.mac")$
+/*load("nodal_operations/nodal_functions")$*/
+fpprec : 24$
+
+buildCanonicalPBFluidAlphaKernel(surfDir, fh, funcNm, cdim, basisFun, polyOrder, edge) := block(
+  [bC, varsC, numC, surfVar, varLabel, dirLabel, surfIntVars, surf_cvars, 
+  surfNodes, nodeVars, bSurf,  NSurf, numNodes, NSurfIndexing, numNodesIndexing, 
+  rdx2vec, phi_e, alphaSurf],
+
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+
+  numC : length(bC), 
+
+  surfVar : varsC[surfDir],         /* Surface variable. */
+  varLabel : makelist(string(varsC[d]),d,1,cdim),
+  dirLabel : varLabel[surfDir],
+
+  surfIntVars : delete(surfVar,varsC), 
+  surf_cvars : delete(surfVar, makelist(varsC[i],i,1,cdim)),
+  nodeVars : surfIntVars,
+
+  /* Generate surface basis. this produces the ndim-1 orthogonal basis with no surfVar dependence. */
+  /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
+  bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
+
+  surfNodes : gaussOrd(polyOrder+1, cdim-1),
+
+  basisStr : sconcat(basisFun, "_", cdim, "x", "_p", polyOrder),
+
+  NSurf : length(bSurf),
+  numNodes  : length(surfNodes),
+
+  NSurfIndexing : NSurf,
+  numNodesIndexing : numNodes,
+
+  print("Working on ", funcNm),
+  printf(fh, "GKYL_CU_DH int ~a(const double *w, const double *dxv, const double *phi,
+   double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf) ~%{ ~%", funcNm),
+  printf(fh, "  // w[NDIM]: cell-center.~%"),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // phi: Potential in fluid system given by grad^2 phi = f where f is (one of) the evolved quantities.~%"),
+  printf(fh, "  // alpha_surf: output surface phase space flux in each direction (cdim + 1 components).~%"),
+  printf(fh, "  //             Note: Each cell owns their *lower* edge surface evaluation.~%"),
+  printf(fh, "  // sgn_alpha_surf: output sign(alpha_surf) in each direction at quadrature points (cdim + 1 components).~%"),
+  printf(fh, "  //                 Note: Each cell owns their *lower* edge sign(alpha_surf).~%"),
+  printf(fh, "  // returns int const_sgn_alpha (true if sign(alpha_surf) is only one sign, either +1 or -1).~%"),
+  printf(fh, "~%"),
+
+  /* Declare cell-center variables and variables multiplying gradients. */
+  for d : 1 thru cdim do (
+    printf(fh, "  double w~a = w[~a];~%", varLabel[d], d-1),
+    printf(fh, "  double rd~a2 = 2.0/dxv[~a];~%", varLabel[d], d-1)
+  ),
+  printf(fh, "~%"),
+  rdx2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,1,cdim),
+  /* Initiate variables for canonical PB calculation 
+     This creates the appropriate variable pair for fluids 
+     so we can re-use all the same infrastructure we used for the 
+     kinetic canonical PB computation. */
+  varsP : [varsC[1], varsC[2]],
+
+  /* Expand potential in the configuration basis. */
+  phi_e : doExpand1(phi,bC),
+
+  /* Calculate and write phase space velocity alpha in direction surfDir. */
+  /* We assume alpha.n is continuous across boundary, although phi may not be. */
+  if (edge = true) then (
+    /* alpha_surf owns the *lower* edge surface expansion, so write out a separate
+       set of kernels if we are on the edge so we also can evaluate the correct 
+       alpha_surf at the upper configuration space boundary without evaluating
+       quantities such as geometry in the ghost cells where they are not defined */
+    printf(fh, "  double *alphaR = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
+    printf(fh, "  double *sgn_alpha_surfR = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing),
+    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bC,varsP,bSurf,basisFun,rdx2vec,rdx2vec2,phi_e,"R",1,1,2),
+    calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"R")
+  )
+  else (
+    printf(fh, "  double *alphaL = &alpha_surf[~a];~%", (surfDir-1)*NSurfIndexing),
+    printf(fh, "  double *sgn_alpha_surfL = &sgn_alpha_surf[~a];~%", (surfDir-1)*numNodesIndexing),
+    alphaSurf : calcAndWrite_CanonicalPB_alpha(fh,surfDir,bC,varsP,bSurf,basisFun,rdx2vec,rdx2vec2,phi_e,"L",1,1,2),
+    calcAndWrite_sgn_CanonicalPB_alpha(fh,nodeVars,surfNodes,numNodes,alphaSurf,"L")
+  ),
+  printf(fh, "  return const_sgn_alpha_surf; ~%"),
+  printf(fh, "~%"),
+  flush_output(fh),
+  printf(fh, "} ~%")
+)$  

--- a/maxima/g0/canonical_pb/fluid-canonical-funcs-surf.mac
+++ b/maxima/g0/canonical_pb/fluid-canonical-funcs-surf.mac
@@ -1,0 +1,307 @@
+/* 
+   Create kernels for the surface term of the specified 
+   hamiltonian in canonical coordinates for a fluid
+   canonical system such as incompressible Euler or
+   Hasegawa-Wakatani.
+
+   *hamil* is assumed to be written in canonical coordinates
+   and for fluid systems is simply phi, the potential given by
+   grad^2 phi = f, where f is (one of) the evolved quantities
+   (vorticity in incompressible Euler and Hasegawa-Wakatani)
+*/
+load("modal-basis")$
+load("out-scripts")$
+load(stringproc)$
+load("scifac")$
+load("canonical_pb/canonicalUtils.mac")$
+fpprec : 24$
+
+calcFluidCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [varsC, bC, numC, surfVar, varLabel, dirLabel, surfIntVars, surf_cvars, 
+   surfNodes, bSurf, basisStr, NSurf, numNodes, NSurfIndexing, numNodesIndexing, rdSurfVar2, rdx2vec, 
+   phi_e, alphaSurfL_e, alphaSurfR_e, fl_e, fc_e, fr_e, fUpL_e, fUpR_e, GhatL_c, GhatR_c, GhatL_e, GhatR_e, 
+   incrL_c, incrR_c],
+
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+
+  numC : length(bC), 
+
+  surfVar : varsC[surfDir],         /* Surface variable. */
+  varLabel : makelist(string(varsC[d]),d,1,cdim),
+  dirLabel : varLabel[surfDir],
+
+  surfIntVars : delete(surfVar,varsC), 
+  surf_cvars : delete(surfVar, makelist(varsC[i],i,1,cdim)),
+  nodeVars : surfIntVars,
+
+  /* Generate surface basis. this produces the ndim-1 orthogonal basis with no surfVar dependence. */
+  /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
+  bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
+
+  surfNodes : gaussOrd(polyOrder+1, cdim-1),
+
+  basisStr : sconcat(basisFun, "_", cdim, "x", "_p", polyOrder),
+
+  NSurf : length(bSurf),
+  numNodes  : length(surfNodes),
+
+  NSurfIndexing : NSurf,
+  numNodesIndexing : numNodes,
+
+  print("Working on ", funcNm),
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double *phi, 
+  const double *alpha_surf_l, const double *alpha_surf_r, 
+  const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
+  const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
+  const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[NDIM]: cell-center.~%"),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // phi: Potential in fluid system given by grad^2 phi = f where f is (one of) the evolved quantities.~%"),
+  printf(fh, "  // alpha_surf_l: Surface expansion of phase space flux on the left.~%"),
+  printf(fh, "  // alpha_surf_r: Surface expansion of phase space flux on the right.~%"),
+  printf(fh, "  // sgn_alpha_surf_l: sign(alpha_surf_l) at quadrature points.~%"),
+  printf(fh, "  // sgn_alpha_surf_r: sign(alpha_surf_r) at quadrature points.~%"),
+  printf(fh, "  // const_sgn_alpha_l: Boolean array true if sign(alpha_surf_l) is only one sign, either +1 or -1.~%"),
+  printf(fh, "  // const_sgn_alpha_r: Boolean array true if sign(alpha_surf_r) is only one sign, either +1 or -1.~%"),
+  printf(fh, "  // fl,fc,fr: input state vector in left, center and right cells.~%"),
+  printf(fh, "  // out: output increment in center cell.~%"),
+  printf(fh, "~%"),
+
+  /* Declare cell spacing for evaluating surface integrals. */
+  rdx2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,1,cdim),
+  /* Initiate variables for canonical PB calculation 
+     This creates the appropriate variable pair for fluids 
+     so we can re-use all the same infrastructure we used for the 
+     kinetic canonical PB computation. */
+  varsP : [varsC[1], varsC[2]],
+
+  rdSurfVar2 : eval_string(sconcat("rd",dirLabel,"2")),
+  printf(fh, "  double ~a = 2.0/dxv[~a];~%", rdSurfVar2, surfDir-1),
+  printf(fh, "~%"),
+
+  /* Expand potential in the configuration basis. */
+  phi_e : doExpand1(phi,bC),
+
+  /* Compute the surface alpha but do *not* write it out; we already computed it
+     We just need to re-compute it here in Maxima to get the right sparsity pattern */
+  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bC,varsP,bSurf,basisFun,rdx2vec,rdx2vec2,phi_e,"L",1,1,2),
+  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bC,varsP,bSurf,basisFun,rdx2vec,rdx2vec2,phi_e,"R",1,1,2),
+  printf(fh, "  const double *alphaL = &alpha_surf_l[~a];~%", (surfDir-1)*NSurfIndexing),
+  printf(fh, "  const double *alphaR = &alpha_surf_r[~a];~%", (surfDir-1)*NSurfIndexing),
+  printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_l[~a];~%", (surfDir-1)*numNodesIndexing),
+  printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_r[~a];~%", (surfDir-1)*numNodesIndexing),
+
+  printf(fh, "  const int *const_sgn_alphaL = &const_sgn_alpha_l[~a];~%", surfDir-1),
+  printf(fh, "  const int *const_sgn_alphaR = &const_sgn_alpha_r[~a];~%", surfDir-1),
+  printf(fh, "~%"),
+  fl_e : doExpand1(fl, bC),
+  fc_e : doExpand1(fc, bC),
+  fr_e : doExpand1(fr, bC),
+
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fl_e,fc_e,basisStr,"L",cdim, vdim, polyOrder,basisFun,true),
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,fc_e,fr_e,basisStr,"R",cdim, vdim, polyOrder,basisFun,true),
+
+  fUpL_e : doExpand1(fUpL, bSurf), 
+  fUpR_e : doExpand1(fUpR, bSurf), 
+  printf(fh, "  double GhatL[~a] = {0.};~%", NSurf),
+  printf(fh, "  double GhatR[~a] = {0.};~%", NSurf), 
+  GhatL_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfL_e*fUpL_e), 
+  GhatR_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfR_e*fUpR_e), 
+  writeCExprsNoExpand1(GhatL, gcfac(float(expand(GhatL_c)))),
+  printf(fh, "~%"),
+  flush_output(fh),
+  writeCExprsNoExpand1(GhatR, gcfac(float(expand(GhatR_c)))),  
+  printf(fh, "~%"),
+  flush_output(fh),
+  GhatL_e : doExpand1(GhatL, bSurf), 
+  GhatR_e : doExpand1(GhatR, bSurf), 
+
+  incrL_c : calcInnerProdList(surfIntVars, 1.0, subst(surfVar=-1, bC), GhatL_e),
+  incrR_c : calcInnerProdList(surfIntVars, -1.0, subst(surfVar=1, bC), GhatR_e),
+
+  /* Write the actual increments to the left and right cells, which are
+     built with incr, dxv factors and some sign changes. */
+  writeCIncrExprsNoExpand1(out, rdSurfVar2*(incrL_c+incrR_c)),
+  printf(fh, "~%"),
+  flush_output(fh),
+
+  /* Extra 1/2 factor is because we are multiplying by 2/dx and we only need 1/dx 
+     Also need to divide out 1/sqrt(2^(pDim-1)) to convert 0th component of surface alpha
+     expansion to cell average (so we take the surface averaged alpha as our estimate of the
+     maximum velocity to compute the largest frequency) */
+  printf(fh, "  double cflFreq = fmax(fabs(alphaL[0]), fabs(alphaR[0])); ~%"),
+  printf(fh, "  return ~a*cflFreq; ~%",float(0.5*(2*polyOrder+1)*rdSurfVar2*2.0^(-0.5*(cdim-1)))),
+  printf(fh, "~%"),
+
+  printf(fh, "} ~%"),
+  flush_output(fh)
+
+)$
+
+calcTwoFluidCanonicalPBSurfUpdateInDir(surfDir, fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [varsC, bC, numC, surfVar, varLabel, dirLabel, surfIntVars, surf_cvars, 
+   surfNodes, bSurf, basisStr, NSurf, numNodes, NSurfIndexing, numNodesIndexing, rdSurfVar2, rdx2vec, 
+   phi_e, alphaSurfL_e, alphaSurfR_e, fl_e, fc_e, fr_e, fUpL_e, fUpR_e, GhatL_c, GhatR_c, GhatL_e, GhatR_e, 
+   incrL_c, incrR_c],
+  /* NOTE: THIS FUNCTION REQUIRES A FURTHER SEARCH AND REPLACE AFTER GENERATION TO fUpL -> f1/2UpL, SAME FOR R */
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+
+  numC : length(bC), 
+
+  surfVar : varsC[surfDir],         /* Surface variable. */
+  varLabel : makelist(string(varsC[d]),d,1,cdim),
+  dirLabel : varLabel[surfDir],
+
+  surfIntVars : delete(surfVar,varsC), 
+  surf_cvars : delete(surfVar, makelist(varsC[i],i,1,cdim)),
+  nodeVars : surfIntVars,
+
+  /* Generate surface basis. this produces the ndim-1 orthogonal basis with no surfVar dependence. */
+  /* Also generate necessary basis strings and surface nodes given by tensor product of Gauss-Legendre quadrature points */
+  bSurf : basisFromVars(basisFun,surfIntVars,polyOrder), 
+
+  surfNodes : gaussOrd(polyOrder+1, cdim-1),
+
+  basisStr : sconcat(basisFun, "_", cdim, "x", "_p", polyOrder),
+
+  NSurf : length(bSurf),
+  numNodes  : length(surfNodes),
+
+  NSurfIndexing : NSurf,
+  numNodesIndexing : numNodes,
+
+  print("Working on ", funcNm),
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dxv, const double *phi, 
+  const double *alpha_surf_l, const double *alpha_surf_r, 
+  const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
+  const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
+  const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[NDIM]: cell-center.~%"),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // phi: Potential in fluid system given by grad^2 phi = f where f is (one of) the evolved quantities.~%"),
+  printf(fh, "  // alpha_surf_l: Surface expansion of phase space flux on the left.~%"),
+  printf(fh, "  // alpha_surf_r: Surface expansion of phase space flux on the right.~%"),
+  printf(fh, "  // sgn_alpha_surf_l: sign(alpha_surf_l) at quadrature points.~%"),
+  printf(fh, "  // sgn_alpha_surf_r: sign(alpha_surf_r) at quadrature points.~%"),
+  printf(fh, "  // const_sgn_alpha_l: Boolean array true if sign(alpha_surf_l) is only one sign, either +1 or -1.~%"),
+  printf(fh, "  // const_sgn_alpha_r: Boolean array true if sign(alpha_surf_r) is only one sign, either +1 or -1.~%"),
+  printf(fh, "  // fl,fc,fr: input state vector in left, center and right cells.~%"),
+  printf(fh, "  // out: output increment in center cell.~%"),
+  printf(fh, "~%"),
+
+  /* Declare cell spacing for evaluating surface integrals. */
+  rdx2vec : makelist(eval_string(sconcat("rd",varLabel[i],"2")),i,1,cdim),
+  /* Initiate variables for canonical PB calculation 
+     This creates the appropriate variable pair for fluids 
+     so we can re-use all the same infrastructure we used for the 
+     kinetic canonical PB computation. */
+  varsP : [varsC[1], varsC[2]],
+
+  rdSurfVar2 : eval_string(sconcat("rd",dirLabel,"2")),
+  printf(fh, "  double ~a = 2.0/dxv[~a];~%", rdSurfVar2, surfDir-1),
+  printf(fh, "~%"),
+
+  /* Expand potential in the configuration basis. */
+  phi_e : doExpand1(phi,bC),
+
+  /* Compute the surface alpha but do *not* write it out; we already computed it
+     We just need to re-compute it here in Maxima to get the right sparsity pattern */
+  alphaSurfL_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bC,varsP,bSurf,basisFun,rdx2vec,rdx2vec2,phi_e,"L",1,1,2),
+  alphaSurfR_e : calc_canonical_pb_alpha_no_write(fh,surfDir,bC,varsP,bSurf,basisFun,rdx2vec,rdx2vec2,phi_e,"R",1,1,2),
+  printf(fh, "  const double *alphaL = &alpha_surf_l[~a];~%", (surfDir-1)*NSurfIndexing),
+  printf(fh, "  const double *alphaR = &alpha_surf_r[~a];~%", (surfDir-1)*NSurfIndexing),
+  printf(fh, "  const double *sgn_alpha_surfL = &sgn_alpha_surf_l[~a];~%", (surfDir-1)*numNodesIndexing),
+  printf(fh, "  const double *sgn_alpha_surfR = &sgn_alpha_surf_r[~a];~%", (surfDir-1)*numNodesIndexing),
+
+  printf(fh, "  const int *const_sgn_alphaL = &const_sgn_alpha_l[~a];~%", surfDir-1),
+  printf(fh, "  const int *const_sgn_alphaR = &const_sgn_alpha_r[~a];~%", surfDir-1),
+  printf(fh, "~%"),
+
+  printf(fh, "  const double *f1l = &fl[~a]; ~%", 0),
+  printf(fh, "  const double *f2l = &fl[~a]; ~%", numC),
+  printf(fh, "  const double *f1c = &fc[~a]; ~%", 0),
+  printf(fh, "  const double *f2c = &fc[~a]; ~%", numC),
+  printf(fh, "  const double *f1r = &fr[~a]; ~%", 0),
+  printf(fh, "  const double *f2r = &fr[~a]; ~%", numC),
+  printf(fh, "  double *out1 = &out[~a]; ~%", 0),
+  printf(fh, "  double *out2 = &out[~a]; ~%", numC),
+  f1l_e : doExpand1(f1l, bC),
+  f2l_e : doExpand1(f2l, bC),
+  f1c_e : doExpand1(f1c, bC),
+  f2c_e : doExpand1(f2c, bC),
+  f1r_e : doExpand1(f1r, bC),
+  f2r_e : doExpand1(f2r, bC),
+
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,f1l_e,f1c_e,basisStr,"L",cdim, vdim, polyOrder,basisFun,true),
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,f1c_e,f1r_e,basisStr,"R",cdim, vdim, polyOrder,basisFun,true),
+
+  f1UpL_e : doExpand1(f1UpL, bSurf), 
+  f1UpR_e : doExpand1(f1UpR, bSurf), 
+  printf(fh, "  double Ghat1L[~a] = {0.};~%", NSurf),
+  printf(fh, "  double Ghat1R[~a] = {0.};~%", NSurf), 
+  Ghat1L_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfL_e*f1UpL_e), 
+  Ghat1R_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfR_e*f1UpR_e), 
+  writeCExprsNoExpand1(Ghat1L, gcfac(float(expand(Ghat1L_c)))),
+  printf(fh, "~%"),
+  flush_output(fh),
+  writeCExprsNoExpand1(Ghat1R, gcfac(float(expand(Ghat1R_c)))),  
+  printf(fh, "~%"),
+  flush_output(fh),
+  Ghat1L_e : doExpand1(Ghat1L, bSurf), 
+  Ghat1R_e : doExpand1(Ghat1R, bSurf), 
+
+  incr1L_c : calcInnerProdList(surfIntVars, 1.0, subst(surfVar=-1, bC), Ghat1L_e),
+  incr1R_c : calcInnerProdList(surfIntVars, -1.0, subst(surfVar=1, bC), Ghat1R_e),
+
+  /* Write the actual increments to the left and right cells, which are
+     built with incr, dxv factors and some sign changes. */
+  writeCIncrExprsNoExpand1(out1, rdSurfVar2*(incr1L_c+incr1R_c)),
+  printf(fh, "~%"),
+  flush_output(fh),
+
+  /* Now update the second fluid identically to the first */
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,f2l_e,f2c_e,basisStr,"L",cdim, vdim, polyOrder,basisFun,true),
+  calcAndWrite_CanonicalPBfUpwind(fh,surfDir,surfVar,surfIntVars,bSurf,NSurf,f2c_e,f2r_e,basisStr,"R",cdim, vdim, polyOrder,basisFun,true),
+
+  f2UpL_e : doExpand1(f2UpL, bSurf), 
+  f2UpR_e : doExpand1(f2UpR, bSurf), 
+  printf(fh, "  double Ghat2L[~a] = {0.};~%", NSurf),
+  printf(fh, "  double Ghat2R[~a] = {0.};~%", NSurf), 
+  Ghat2L_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfL_e*f2UpL_e), 
+  Ghat2R_c : calcInnerProdList(surfIntVars, 1, bSurf, alphaSurfR_e*f2UpR_e), 
+  writeCExprsNoExpand1(Ghat2L, gcfac(float(expand(Ghat2L_c)))),
+  printf(fh, "~%"),
+  flush_output(fh),
+  writeCExprsNoExpand1(Ghat2R, gcfac(float(expand(Ghat2R_c)))),  
+  printf(fh, "~%"),
+  flush_output(fh),
+  Ghat2L_e : doExpand1(Ghat2L, bSurf), 
+  Ghat2R_e : doExpand1(Ghat2R, bSurf), 
+
+  incr2L_c : calcInnerProdList(surfIntVars, 1.0, subst(surfVar=-1, bC), Ghat2L_e),
+  incr2R_c : calcInnerProdList(surfIntVars, -1.0, subst(surfVar=1, bC), Ghat2R_e),
+
+  /* Write the actual increments to the left and right cells, which are
+     built with incr, dxv factors and some sign changes. */
+  writeCIncrExprsNoExpand1(out2, rdSurfVar2*(incr2L_c+incr2R_c)),
+  printf(fh, "~%"),
+  flush_output(fh),
+
+  /* Extra 1/2 factor is because we are multiplying by 2/dx and we only need 1/dx 
+     Also need to divide out 1/sqrt(2^(pDim-1)) to convert 0th component of surface alpha
+     expansion to cell average (so we take the surface averaged alpha as our estimate of the
+     maximum velocity to compute the largest frequency) */
+  printf(fh, "  double cflFreq = fmax(fabs(alphaL[0]), fabs(alphaR[0])); ~%"),
+  printf(fh, "  return ~a*cflFreq; ~%",float(0.5*(2*polyOrder+1)*rdSurfVar2*2.0^(-0.5*(cdim-1)))),
+  printf(fh, "~%"),
+
+  printf(fh, "} ~%"),
+  flush_output(fh)
+
+)$

--- a/maxima/g0/canonical_pb/fluid-canonical-funcs-vol.mac
+++ b/maxima/g0/canonical_pb/fluid-canonical-funcs-vol.mac
@@ -1,0 +1,101 @@
+/*
+   Create kernels for the volume term of canonical poisson bracket
+   for a fluid system such as incompressible Euler or Hasegawa-Wakatani.
+  
+   *hamil* is assumed to be written in canonical coordinates
+   and for fluid systems is simply phi, the potential given by
+   grad^2 phi = f, where f is (one of) the evolved quantities
+   (vorticity in incompressible Euler and Hasegawa-Wakatani)
+*/
+
+load("modal-basis")$
+load("out-scripts")$
+load(stringproc)$
+load("scifac")$
+load("canonical_pb/canonicalUtils")$
+load("utilities")$
+fpprec : 24$
+
+dxv : [dxv0, dxv1]$
+
+cidx(cdim) := makelist(i,i,0,cdim-1)$
+PB_vol(f,g,x,y) := diff(f,x)*diff(g,y) - diff(g,x)*diff(f,y)$
+
+buildFluidCanonicalPBVolKernel(fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [varsC, bC, numC, f_e, phi_e, pb, pbBasis],
+
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+
+  numC : length(bC), 
+
+  printf(fh, "double ~a(const double *w, const double *dxv, const double *phi, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[NDIM]: cell-center.~%"),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // phi: Potential in fluid system given by grad^2 phi = f where f is (one of) the evolved quantities.~%"),
+  printf(fh, "  // f: input state vector in center cell.~%"),
+  printf(fh, "  // out: output increment in center cell.~%"),
+
+  printf(fh, "  double dxdvInv = 4.0/(dxv[0]*dxv[1]); ~%"),
+
+  f_e : doExpand1(f, bC),
+  phi_e : doExpand1(phi, bC),
+
+  pbBasis : PB_vol(bC,phi_e,varsC[1],varsC[2]),
+  pb : fullratsimp(calcInnerProdList(varsC, 1, pbBasis, f_e)), 
+
+  /* Cell average contribution from volume term is 0, but all other terms have non-zero values */
+  for i : 2 thru length(pb) do (
+    printf(fh, "  ~a += ~a; ~%", out[i-1], dxdvInv*(float(expand(pb[i]))))
+  ), 
+  
+  /*  No CFL contribution, returns 0. */
+  printf(fh, "  return 0.; ~%"),
+  printf(fh, "} ~%"),
+  flush_output(fh)
+);
+
+buildTwoFluidCanonicalPBVolKernel(fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [varsC, bC, numC, f_e, phi_e, pb, pbBasis],
+
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+
+  numC : length(bC), 
+
+  printf(fh, "double ~a(const double *w, const double *dxv, const double *phi, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // w[NDIM]: cell-center.~%"),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // phi: Potential in fluid system given by grad^2 phi = f where f is (one of) the evolved quantities.~%"),
+  printf(fh, "  // f: input state vector in center cell.~%"),
+  printf(fh, "  // out: output increment in center cell.~%"),
+
+  printf(fh, "  double dxdvInv = 4.0/(dxv[0]*dxv[1]); ~%"),
+  printf(fh, "  const double *f1 = &f[~a]; ~%", 0),
+  printf(fh, "  const double *f2 = &f[~a]; ~%", numC),
+  printf(fh, "  double *out1 = &out[~a]; ~%", 0),
+  printf(fh, "  double *out2 = &out[~a]; ~%", numC),
+
+  f1_e : doExpand1(f1, bC),
+  f2_e : doExpand1(f2, bC),
+  phi_e : doExpand1(phi, bC),
+
+  pbBasis : PB_vol(bC,phi_e,varsC[1],varsC[2]),
+  pb1 : fullratsimp(calcInnerProdList(varsC, 1, pbBasis, f1_e)), 
+  pb2 : fullratsimp(calcInnerProdList(varsC, 1, pbBasis, f2_e)), 
+
+  /* Cell average contribution from volume term is 0, but all other terms have non-zero values */
+  for i : 2 thru length(pb1) do (
+    printf(fh, "  ~a += ~a; ~%", out1[i-1], dxdvInv*(float(expand(pb1[i])))), 
+    printf(fh, "  ~a += ~a; ~%", out2[i-1], dxdvInv*(float(expand(pb2[i]))))
+  ), 
+  
+  /*  No CFL contribution, returns 0. */
+  printf(fh, "  return 0.; ~%"),
+  printf(fh, "} ~%"),
+  flush_output(fh)
+);

--- a/maxima/g0/canonical_pb/fluid-canonical-source.mac
+++ b/maxima/g0/canonical_pb/fluid-canonical-source.mac
@@ -1,0 +1,123 @@
+/*
+   Create kernels for the source terms of canonical poisson bracket
+   for a fluid system such as Hasegawa-Mima or Hasegawa-Wakatani.
+  
+   the potential given by grad^2 phi = f, where f is (one of) the evolved quantities
+   (vorticity in Hasegawa-Mima and Hasegawa-Wakatani)
+*/
+
+load("modal-basis")$
+load("out-scripts")$
+load(stringproc)$
+load("scifac")$
+load("canonical_pb/canonicalUtils")$
+load("utilities")$
+fpprec : 24$
+
+buildFluidCanonicalPBSourceHasegawaMimaKernel(fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [varsC, bC, numC, phi_e, source_c],
+
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+
+  numC : length(bC), 
+
+  printf(fh, "void ~a(const double *dxv, double alpha, const double *phi, const double *n0, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // alpha: Adiabaticity parameter for adiabatic coupling of vorticity and density (zero for Hasegawa-Mima).~%"),
+  printf(fh, "  // phi: Potential in fluid system given by grad^2 phi = f where f is (one of) the evolved quantities.~%"),
+  printf(fh, "  // n0: Background density gradient.~%"),
+  printf(fh, "  // f: input state vector in center cell.~%"),
+  printf(fh, "  // out: output increment in center cell.~%"),
+
+  printf(fh, "  double dx = 2.0/dxv[0]; ~%"),
+  printf(fh, "  double dy = 2.0/dxv[1]; ~%"),
+
+  n0_e : doExpand1(n0, bC),
+  phi_e : doExpand1(phi, bC),
+  source_c : calcInnerProdList(varsC, 1, bC, dx*dy*(diff(phi_e, x)*diff(n0_e, y) - diff(phi_e, y)*diff(n0_e, x))), 
+  writeCIncrExprs1(out, source_c),
+
+  printf(fh, "} ~%"),
+  flush_output(fh)
+);
+
+buildFluidCanonicalPBSourceHasegawaWakataniKernel(fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [varsC, bC, numC, phi_e, n_e, source_zeta_c, source_n_c],
+
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+
+  numC : length(bC), 
+
+  printf(fh, "void ~a(const double *dxv, double alpha, const double *phi, const double *n0, const double *adiabatic_coupling_phi_n, double* GKYL_RESTRICT out) ~%{ ~%", funcNm),
+  printf(fh, "  // dxv[NDIM]: cell length.~%"),
+  printf(fh, "  // alpha: Adiabaticity parameter for adiabatic coupling of vorticity and density (zero for Hasegawa-Mima).~%"),
+  printf(fh, "  // phi: Potential in fluid system given by grad^2 phi = f where f is (one of) the evolved quantities.~%"),
+  printf(fh, "  // n0: Background density gradient.~%"),
+  printf(fh, "  // adiabatic_coupling_phi_n: (phi, n) array for adiabatic coupling, with potentially zonal component subtracted out.~%"),
+  printf(fh, "  // out: output increment in center cell.~%"),
+
+  printf(fh, "  double dx = 2.0/dxv[0]; ~%"),
+  printf(fh, "  double dy = 2.0/dxv[1]; ~%"),
+  printf(fh, "  const double *phi_adiabat = &adiabatic_coupling_phi_n[~a]; ~%", 0), 
+  printf(fh, "  const double *n_adiabat = &adiabatic_coupling_phi_n[~a]; ~%", numC), 
+  printf(fh, "  double *out_zeta = &out[~a]; ~%", 0),
+  printf(fh, "  double *out_n = &out[~a]; ~%", numC),
+
+  n0_e : doExpand1(n0, bC),
+  /* phi and phi_adiabat may be different, as the total phi drives the turbulence through the 
+     Poisson bracket term with the background gradient, but only the zonal component enters 
+     into the adiabatic coupling when solving the modified Hasegawa-Wakatani. */
+  phi_e : doExpand1(phi, bC),
+  phi_adiabat_e : doExpand1(phi_adiabat, bC), 
+  n_adiabat_e : doExpand1(n_adiabat, bC), 
+
+  source_zeta_c : calcInnerProdList(varsC, 1, bC, alpha*(phi_adiabat_e - n_adiabat_e)), 
+  source_n_c : calcInnerProdList(varsC, 1, bC, alpha*(phi_adiabat_e - n_adiabat_e) + dx*dy*(diff(phi_e, x)*diff(n0_e, y) - diff(phi_e, y)*diff(n0_e, x))), 
+  writeCIncrExprs1(out_zeta, source_zeta_c),
+  writeCIncrExprs1(out_n, source_n_c),
+
+  printf(fh, "} ~%"),
+  flush_output(fh)
+);
+
+buildFluidCanonicalPBSubtractZonalKernel(fh, funcNm, cdim, basisFun, polyOrder) := block(
+  [varsC, bC, numC, phi_e, n_e, source_zeta_c, source_n_c],
+
+  kill(varsC,bC),
+
+  /* Load basis of dimensionality requested. */
+  [varsC,bC] : loadBasis(basisFun, cdim, polyOrder),
+  /* 1D basis in x for subtracting zonal component */
+  [varsC_1d,bC_1d] : loadBasis(basisFun, 1, polyOrder),
+
+  numC : length(bC), 
+
+  printf(fh, "void ~a(const double *phi_zonal, const double *n_zonal, double* GKYL_RESTRICT adiabatic_coupling_phi_n) ~%{ ~%", funcNm),
+  printf(fh, "  // phi_zonal: 1/Ly int phi dy.~%"),
+  printf(fh, "  // n_zonal: 1/Ly int n dy.~%"),
+  printf(fh, "  // adiabatic_coupling_phi_n: (phi, n) array for adiabatic coupling, with zonal component subtracted out.~%"),
+  printf(fh, "  double *out_phi = &adiabatic_coupling_phi_n[~a]; ~%", 0),
+  printf(fh, "  double *out_n = &adiabatic_coupling_phi_n[~a]; ~%", numC),
+
+  phi_zonal_e : doExpand1(phi_zonal, bC_1d), 
+  n_zonal_e : doExpand1(n_zonal, bC_1d), 
+
+  phi_zonal_c : calcInnerProdList(varsC, 1, bC, phi_zonal_e), 
+  n_zonal_c : calcInnerProdList(varsC, 1, bC, n_zonal_e), 
+  /* adiabatic_coupling_phi_n already contains (phi, n) so just subtract off the zonal piece from each component */
+  for i : 1 thru numC do (
+    if (phi_zonal_c[i] # 0) then (
+      printf(fh, "  out_phi[~a] -= ~a; ~%", i-1, float(expand(phi_zonal_c[i]))),
+      printf(fh, "  out_n[~a] -= ~a; ~%", i-1, float(expand(n_zonal_c[i])))
+    )
+  ), 
+
+  printf(fh, "} ~%"),
+  flush_output(fh)
+);  

--- a/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
+++ b/maxima/g0/canonical_pb/ms-canonical-pb-header.mac
@@ -74,6 +74,40 @@ printPrototypes() := block([],
   )
 )$
 
+printFluidPrototypes() := block([],
+  for bInd : 1 thru length(bName) do (
+    for c : 2 thru 2 do ( /* only support dimensionality = 2 for now */
+      minPolyOrderB : minPolyOrder[bInd], 
+      if (bName[bInd] = "tensor") then minPolyOrderB : 2, /* For fluids, Serendipity p=1 and Tensor p=1 are equivalent */
+      for polyOrder : minPolyOrderB thru maxPolyOrder[bInd] do (
+        printf(fh, "GKYL_CU_DH double canonical_pb_vol_~ax_~a_p~a(const double *w, const double *dxv, const double *phi, const double *fin, double* GKYL_RESTRICT out); ~%", c, bName[bInd], polyOrder),
+        printf(fh, "GKYL_CU_DH double canonical_pb_two_fluid_vol_~ax_~a_p~a(const double *w, const double *dxv, const double *phi, const double *fin, double* GKYL_RESTRICT out); ~%", c, bName[bInd], polyOrder),
+        printf(fh, "GKYL_CU_DH void canonical_pb_fluid_hasegawa_mima_source_~ax_~a_p~a(const double *dxv, double alpha, const double *phi, const double *n0, const double *adiabatic_coupling_phi_n, double* GKYL_RESTRICT out); ~%", c, bName[bInd], polyOrder),
+        printf(fh, "GKYL_CU_DH void canonical_pb_fluid_hasegawa_wakatani_source_~ax_~a_p~a(const double *dxv, double alpha, const double *phi, const double *n0, const double *adiabatic_coupling_phi_n, double* GKYL_RESTRICT out); ~%", c, bName[bInd], polyOrder),
+        printf(fh, "GKYL_CU_DH void canonical_pb_fluid_subtract_zonal_~ax_~a_p~a(const double *phi_zonal, const double *n_zonal, double* GKYL_RESTRICT adiabatic_coupling_phi_n); ~%", c, bName[bInd], polyOrder),
+
+        for surfDir : 1 thru c do ( /* Iterate over each phase space coordinate */
+          dirlabel : clabels[surfDir],
+          printf(fh, "GKYL_CU_DH int canonical_pb_alpha_surf~a_~ax_~a_p~a(const double *w, const double *dxv, const double *phi, double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, bName[bInd], polyOrder),
+          printf(fh, "GKYL_CU_DH int canonical_pb_alpha_edge_surf~a_~ax_~a_p~a(const double *w, const double *dxv, const double *phi, double* GKYL_RESTRICT alpha_surf, double* GKYL_RESTRICT sgn_alpha_surf); ~%", dirlabel, c, bName[bInd], polyOrder), 
+          printf(fh, "GKYL_CU_DH double canonical_pb_surf~a_~ax_~a_p~a(const double *w, const double *dxv, const double *phi, 
+          const double *alpha_surf_l, const double *alpha_surf_r, 
+          const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
+          const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
+          const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", dirlabel, c, bName[bInd], polyOrder), 
+          printf(fh, "GKYL_CU_DH double canonical_pb_two_fluid_surf~a_~ax_~a_p~a(const double *w, const double *dxv, const double *phi, 
+          const double *alpha_surf_l, const double *alpha_surf_r, 
+          const double *sgn_alpha_surf_l, const double *sgn_alpha_surf_r, 
+          const int *const_sgn_alpha_l, const int *const_sgn_alpha_r, 
+          const double *fl, const double *fc, const double *fr, double* GKYL_RESTRICT out); ~%", dirlabel, c, bName[bInd], polyOrder)
+        ), 
+        printf(fh, "~%")
+      )
+    )
+  ), 
+  printf(fh, "GKYL_CU_DH void canonical_pb_fluid_default_source(const double *dxv, double alpha, const double *phi, const double *n0, const double *f, double* GKYL_RESTRICT out); ~%")  
+)$
+
 fh : openw("~/max-out/gkyl_canonical_pb_kernels.h")$
 printf(fh, "#pragma once~%")$
 printf(fh, "~%")$
@@ -83,6 +117,7 @@ printf(fh, "~%")$
 printf(fh, "EXTERN_C_BEG~%")$
 printf(fh, "~%")$
 printPrototypes()$
+printFluidPrototypes()$
 printf(fh, "~%")$
 printf(fh, "EXTERN_C_END~%")$
 close(fh)$

--- a/maxima/g0/canonical_pb/ms-fluid-canonical-pb-alpha-surf.mac
+++ b/maxima/g0/canonical_pb/ms-fluid-canonical-pb-alpha-surf.mac
@@ -1,0 +1,61 @@
+/*
+  Generate the kernel for surface expansions of the characteristics
+  in a fluid canonical Poisson bracket equation system. Only works 
+  in 2x for now (incompressible Euler, Hasegawa-Wakatani, etc.)
+
+  The functions called in this file are in fluid-canonical-alpha-surf.mac.
+*/
+load("canonical_pb/fluid-canonical-alpha-surf")$
+ratprint: false;
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor product basis. */
+minPolyOrder_Tensor : 1$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 2$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+clabels : ["x","y","z"]$
+
+/* Generate kernels of selected types. */
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+      /* Surface alpha in direction dir in configuration space.*/
+      for dir : 1 thru c do (
+        fname : sconcat("~/max-out/canonical_pb_alpha_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+        disp(printf(false,"Creating alpha surf~a file: ~a",clabels[dir],fname)),
+  
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+        funcName : sconcat("canonical_pb_alpha_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p", polyOrder),
+        buildCanonicalPBFluidAlphaKernel(dir, fh, funcName, c, bName[bInd], polyOrder, false), /* Not an edge */
+        close(fh),
+
+        fname : sconcat("~/max-out/canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+        disp(printf(false,"Creating alpha edge surf~a file: ~a",clabels[dir],fname)),
+  
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+
+        funcName : sconcat("canonical_pb_alpha_edge_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p", polyOrder),
+        buildCanonicalPBFluidAlphaKernel(dir, fh, funcName, c, bName[bInd], polyOrder, true), /* An edge */
+        close(fh)
+      )
+    )
+  )
+)$

--- a/maxima/g0/canonical_pb/ms-fluid-canonical-pb-source.mac
+++ b/maxima/g0/canonical_pb/ms-fluid-canonical-pb-source.mac
@@ -1,0 +1,71 @@
+/*
+  Generate the source update kernels for a canonical-pb fluid system such as
+  Hasegawa-Mima or Hasegawa-Wakatani.
+
+  The functions called in this file are in fluid-canonical-source.mac.
+*/
+load("canonical_pb/fluid-canonical-source")$
+ratprint: false;
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor product basis. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 2$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
+
+clabels : ["x","y","z"]$
+
+/* Generate kernels of selected types. */
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+      fname : sconcat("~/max-out/canonical_pb_fluid_hasegawa_mima_source_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating volume file: ~a",fname)),
+
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+
+      funcName : sconcat("canonical_pb_fluid_hasegawa_mima_source_", c, "x_", bName[bInd], "_p", polyOrder),
+      buildFluidCanonicalPBSourceHasegawaMimaKernel(fh, funcName, c, bName[bInd], polyOrder), 
+      close(fh), 
+
+      fname : sconcat("~/max-out/canonical_pb_fluid_hasegawa_wakatani_source_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating volume file: ~a",fname)),
+
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+
+      funcName : sconcat("canonical_pb_fluid_hasegawa_wakatani_source_", c, "x_", bName[bInd], "_p", polyOrder),
+      buildFluidCanonicalPBSourceHasegawaWakataniKernel(fh, funcName, c, bName[bInd], polyOrder), 
+      close(fh), 
+
+      fname : sconcat("~/max-out/canonical_pb_fluid_subtract_zonal_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating volume file: ~a",fname)),
+
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+
+      funcName : sconcat("canonical_pb_fluid_subtract_zonal_", c, "x_", bName[bInd], "_p", polyOrder),
+      buildFluidCanonicalPBSubtractZonalKernel(fh, funcName, c, bName[bInd], polyOrder), 
+      close(fh)               
+    )
+  )
+)$

--- a/maxima/g0/canonical_pb/ms-fluid-canonical-pb-surf.mac
+++ b/maxima/g0/canonical_pb/ms-fluid-canonical-pb-surf.mac
@@ -1,0 +1,71 @@
+/*
+  Generate the surface kernels for a canonical-pb fluid system such as
+  incompressible Euler or Hasegawa-Wakatani.
+  Assumes surface alpha pre-computed so kernels are agnostic to different
+  forms of canonical-pb for fluid systems.
+
+  The functions called in this file are in fluid-canonical-funcs-surf.mac.
+*/
+load("canonical_pb/fluid-canonical-funcs-surf")$
+ratprint: false;
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor product basis. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 2$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
+
+clabels : ["x","y","z"]$
+
+includeSurfHeaders(fhIn, bname, c, porder, dir) := block([],
+  printf(fhIn, "#include <gkyl_canonical_pb_kernels.h>~%"),
+  printf(fh, "#include <gkyl_basis_~a_~ax_p~a_upwind_quad_to_modal.h> ~%", bname, c, porder)
+)$
+printf(fh, "~%"),
+
+/* Generate kernels of selected types. */
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+      for dir : 1 thru c do (
+        /* Advection in configuration space.*/
+        fname : sconcat("~/max-out/canonical_pb_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p",polyOrder, ".c"),
+        disp(printf(false,"Creating surface file: ~a",fname)),
+
+        fh : openw(fname),
+        includeSurfHeaders(fh, bName[bInd], c, polyOrder, dir),
+        funcName : sconcat("canonical_pb_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p", polyOrder),
+        calcFluidCanonicalPBSurfUpdateInDir(dir, fh, funcName, c, bName[bInd], polyOrder),
+        close(fh), 
+
+        fname : sconcat("~/max-out/canonical_pb_two_fluid_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p",polyOrder, ".c"),
+        disp(printf(false,"Creating surface file: ~a",fname)),
+
+        fh : openw(fname),
+        includeSurfHeaders(fh, bName[bInd], c, polyOrder, dir),
+        funcName : sconcat("canonical_pb_two_fluid_surf",clabels[dir],"_", c, "x_", bName[bInd], "_p", polyOrder),
+        /* NOTE: THIS FUNCTION REQUIRES A FURTHER SEARCH AND REPLACE AFTER GENERATION TO fUpL -> f1/2UpL, SAME FOR R */
+        calcTwoFluidCanonicalPBSurfUpdateInDir(dir, fh, funcName, c, bName[bInd], polyOrder),
+        close(fh)        
+      )
+    )
+  )
+)$

--- a/maxima/g0/canonical_pb/ms-fluid-canonical-pb-vol.mac
+++ b/maxima/g0/canonical_pb/ms-fluid-canonical-pb-vol.mac
@@ -1,0 +1,61 @@
+/*
+  Generate the volume kernels for a canonical-pb fluid system such as
+  incompressible Euler or Hasegawa-Wakatani.
+
+  The functions called in this file are in fluid-canonical-funcs-vol.mac.
+*/
+load("canonical_pb/fluid-canonical-funcs-vol")$
+ratprint: false;
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor product basis. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 2$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
+
+clabels : ["x","y","z"]$
+
+/* Generate kernels of selected types. */
+for bInd : 1 thru length(bName) do (
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+      fname : sconcat("~/max-out/canonical_pb_vol_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating volume file: ~a",fname)),
+
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+
+      funcName : sconcat("canonical_pb_vol_", c, "x_", bName[bInd], "_p", polyOrder),
+      buildFluidCanonicalPBVolKernel(fh, funcName, c, bName[bInd], polyOrder), 
+      close(fh), 
+
+      fname : sconcat("~/max-out/canonical_pb_two_fluid_vol_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating volume file: ~a",fname)),
+
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_canonical_pb_kernels.h> ~%"),
+
+      funcName : sconcat("canonical_pb_two_fluid_vol_", c, "x_", bName[bInd], "_p", polyOrder),
+      buildTwoFluidCanonicalPBVolKernel(fh, funcName, c, bName[bInd], polyOrder), 
+      close(fh)        
+    )
+  )
+)$


### PR DESCRIPTION
such as incompressible Euler, Hasegawa-Mima, and Hasegawa-Wakatani. Goes with gkylzero PR https://github.com/ammarhakim/gkylzero/pull/610