### PR TITLE
Add functions to calculate integrated moments M0, M1, and M2.

### DIFF
--- a/maxima/g0/moments/gkIntMomentsFuncs.mac
+++ b/maxima/g0/moments/gkIntMomentsFuncs.mac
@@ -9,6 +9,130 @@ fpprec : 24$
 
 volExpr(totDim) := prod(dxv[i-1], i, 1, totDim)$
 
+
+/* Integrated M0. */
+calcGkIntM0(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
+   d,f_e,M,m0,m1,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
+
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+
+  vmap_c : [],
+  for d : 1 thru vdim do (
+    vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+  ),
+  
+  printf(fh, "GKYL_CU_DH void ~a_int_M0_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+  if vdim = 1 then printf(fh, "  const double volFact = ~a; ~%", volExpr(cdim+vdim)*float(1/(2^(cdim+vdim))) )
+  else printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+
+  printf(fh, " ~%"),
+
+  f_e : doExpand1(f, bP),
+
+  M : [],
+
+  m0 : fullratsimp(innerProd(varsP, 1, 1, f_e)),
+  M  : endcons(m0,M),
+
+  M : map(letsimp, M),
+
+  tempPowVars : [],
+  tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+
+  printf(fh, "} ~%~%")
+)$
+
+/* Integrated parallel momentum (M1). */
+calcGkIntM1(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
+   d,f_e,M,m0,m1,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
+
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+
+  vmap_c : [],
+  for d : 1 thru vdim do (
+    vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+  ),
+  
+  printf(fh, "GKYL_CU_DH void ~a_int_M1_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+  if vdim = 1 then printf(fh, "  const double volFact = ~a; ~%", volExpr(cdim+vdim)*float(1/(2^(cdim+vdim))) )
+  else printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+
+  printf(fh, " ~%"),
+
+  f_e : doExpand1(f, bP),
+
+  M : [],
+
+  m1 : fullratsimp(innerProd(varsP, 1, vmap_e[1], f_e)),
+  M  : endcons(m1,M),
+
+  M : map(letsimp, M),
+
+  tempPowVars : [],
+  tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+
+  printf(fh, "} ~%~%")
+)$
+
+/* Integrated particle kinetic energy (M2). */
+calcGkIntM2(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
+   d,f_e,M,m0,m1,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
+
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+
+  vmap_c : [],
+  for d : 1 thru vdim do (
+    vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+  ),
+  
+  printf(fh, "GKYL_CU_DH void ~a_int_M2_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+  if vdim = 1 then printf(fh, "  const double volFact = ~a; ~%", volExpr(cdim+vdim)*float(1/(2^(cdim+vdim))) )
+  else printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+
+  printf(fh, " ~%"),
+
+  f_e : doExpand1(f, bP),
+
+  M : [],
+
+  m2 : fullratsimp(innerProd(varsP, 1, (vmap_e[1])^2, f_e)),
+  if (vdim > 1) then (
+    bmag_e : doExpand1(bmag, bC),
+
+    Mtemp : calcInnerProdList(varsP, vmap_e[2], bC, f_e),
+    Mtemp : map(letsimp, Mtemp),
+
+    printf(fh, "  double tmp[~a]; ~%", length(bC)),
+
+    writeCExprs1(tmp, 2/m_*Mtemp),
+    printf(fh, " ~%"),
+    tmp_e : doExpand1(tmp, bC),
+
+    m2 : m2+fullratsimp(innerProd(varsC, 1, bmag_e, tmp_e))
+  ),
+  M : endcons(m2, M),
+
+  M : map(letsimp, M),
+
+  tempPowVars : [],
+  tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+
+  printf(fh, "} ~%~%")
+)$
+
+
 calcGkIntThreeMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
    d,f_e,M,m0,m1,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
@@ -189,6 +313,9 @@ calcGkIntHamiltonianMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder) := bloc
 
 calcIntMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block([],
   printf(fh, "#include <gkyl_mom_gyrokinetic_kernels.h> ~%"),
+  calcGkIntM0(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  calcGkIntM1(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  calcGkIntM2(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntThreeMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntFourMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntHamiltonianMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder)

--- a/maxima/g0/moments/gkIntMomentsFuncs.mac
+++ b/maxima/g0/moments/gkIntMomentsFuncs.mac
@@ -13,7 +13,7 @@ volExpr(totDim) := prod(dxv[i-1], i, 1, totDim)$
 /* Integrated M0. */
 calcGkIntM0(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
-   d,f_e,M,m0,m1,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
+   d,f_e,M,m0,tempPowVars],
 
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
 
@@ -49,7 +49,7 @@ calcGkIntM0(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 /* Integrated parallel momentum (M1). */
 calcGkIntM1(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
-   d,f_e,M,m0,m1,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
+   d,f_e,M,m1,tempPowVars],
 
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
 
@@ -82,10 +82,96 @@ calcGkIntM1(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   printf(fh, "} ~%~%")
 )$
 
+/* Integrated parallel particle kinetic energy (M2par). */
+calcGkIntM2par(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
+   d,f_e,M,m2par,bmag_e,Mtemp,tmp_e,tempPowVars],
+
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+
+  vmap_c : [],
+  for d : 1 thru vdim do (
+    vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+  ),
+  
+  printf(fh, "GKYL_CU_DH void ~a_int_M2_par_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+  if vdim = 1 then printf(fh, "  const double volFact = ~a; ~%", volExpr(cdim+vdim)*float(1/(2^(cdim+vdim))) )
+  else printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+
+  printf(fh, " ~%"),
+
+  f_e : doExpand1(f, bP),
+
+  M : [],
+
+  m2par : fullratsimp(innerProd(varsP, 1, (vmap_e[1])^2, f_e)),
+  M : endcons(m2par, M),
+
+  M : map(letsimp, M),
+
+  tempPowVars : [],
+  tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+
+  printf(fh, "} ~%~%")
+)$
+
+/* Integrated perpendicular particle kinetic energy (M2perp). */
+calcGkIntM2perp(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
+   d,f_e,M,m2perp,bmag_e,Mtemp,tmp_e,tempPowVars],
+
+  if (vdim > 1) then (
+    [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+    [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+
+    vmap_c : [],
+    for d : 1 thru vdim do (
+      vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+    ),
+    
+    printf(fh, "GKYL_CU_DH void ~a_int_M2_perp_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+    printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+
+    printf(fh, " ~%"),
+
+    f_e : doExpand1(f, bP),
+
+    M : [],
+
+    bmag_e : doExpand1(bmag, bC),
+
+    Mtemp : calcInnerProdList(varsP, vmap_e[2], bC, f_e),
+    Mtemp : map(letsimp, Mtemp),
+
+    printf(fh, "  double tmp[~a]; ~%", length(bC)),
+
+    writeCExprs1(tmp, 2/m_*Mtemp),
+    printf(fh, " ~%"),
+    tmp_e : doExpand1(tmp, bC),
+
+    m2perp : fullratsimp(innerProd(varsC, 1, bmag_e, tmp_e)),
+
+    M : endcons(m2perp, M),
+
+    M : map(letsimp, M),
+
+    tempPowVars : [],
+    tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+
+    printf(fh, "} ~%~%")
+  )
+)$
+
+
 /* Integrated particle kinetic energy (M2). */
 calcGkIntM2(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
-   d,f_e,M,m0,m1,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
+   d,f_e,M,m2,bmag_e,Mtemp,tmp_e,tempPowVars],
 
   [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
 
@@ -315,6 +401,8 @@ calcIntMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block([],
   printf(fh, "#include <gkyl_mom_gyrokinetic_kernels.h> ~%"),
   calcGkIntM0(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntM1(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  calcGkIntM2par(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  calcGkIntM2perp(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntM2(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntThreeMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntFourMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder),

--- a/maxima/g0/moments/gkIntMomentsFuncs.mac
+++ b/maxima/g0/moments/gkIntMomentsFuncs.mac
@@ -123,48 +123,46 @@ calcGkIntM2perp(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
    d,f_e,M,m2perp,bmag_e,Mtemp,tmp_e,tempPowVars],
 
-  if (vdim > 1) then (
-    [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
 
-    [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+  [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
 
-    vmap_c : [],
-    for d : 1 thru vdim do (
-      vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
-    ),
-    
-    printf(fh, "GKYL_CU_DH void ~a_int_M2_perp_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+  vmap_c : [],
+  for d : 1 thru vdim do (
+    vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+  ),
+  
+  printf(fh, "GKYL_CU_DH void ~a_int_M2_perp_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
 
-    printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+  printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
 
-    printf(fh, " ~%"),
+  printf(fh, " ~%"),
 
-    f_e : doExpand1(f, bP),
+  f_e : doExpand1(f, bP),
 
-    M : [],
+  M : [],
 
-    bmag_e : doExpand1(bmag, bC),
+  bmag_e : doExpand1(bmag, bC),
 
-    Mtemp : calcInnerProdList(varsP, vmap_e[2], bC, f_e),
-    Mtemp : map(letsimp, Mtemp),
+  Mtemp : calcInnerProdList(varsP, vmap_e[2], bC, f_e),
+  Mtemp : map(letsimp, Mtemp),
 
-    printf(fh, "  double tmp[~a]; ~%", length(bC)),
+  printf(fh, "  double tmp[~a]; ~%", length(bC)),
 
-    writeCExprs1(tmp, 2/m_*Mtemp),
-    printf(fh, " ~%"),
-    tmp_e : doExpand1(tmp, bC),
+  writeCExprs1(tmp, 2/m_*Mtemp),
+  printf(fh, " ~%"),
+  tmp_e : doExpand1(tmp, bC),
 
-    m2perp : fullratsimp(innerProd(varsC, 1, bmag_e, tmp_e)),
+  m2perp : fullratsimp(innerProd(varsC, 1, bmag_e, tmp_e)),
 
-    M : endcons(m2perp, M),
+  M : endcons(m2perp, M),
 
-    M : map(letsimp, M),
+  M : map(letsimp, M),
 
-    tempPowVars : [],
-    tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+  tempPowVars : [],
+  tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
 
-    printf(fh, "} ~%~%")
-  )
+  printf(fh, "} ~%~%")
 )$
 
 
@@ -218,6 +216,90 @@ calcGkIntM2(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   printf(fh, "} ~%~%")
 )$
 
+/* Integrated parallel heat flux. */
+calcGkIntM3par(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
+   d,f_e,M,m3par,bmag_e,Mtemp,tmp_e,tempPowVars],
+
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+
+  vmap_c : [],
+  for d : 1 thru vdim do (
+    vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+  ),
+  
+  printf(fh, "GKYL_CU_DH void ~a_int_M3_par_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+  if vdim = 1 then printf(fh, "  const double volFact = ~a; ~%", volExpr(cdim+vdim)*float(1/(2^(cdim+vdim))) )
+  else printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+
+  printf(fh, " ~%"),
+
+  f_e : doExpand1(f, bP),
+
+  M : [],
+
+  m3par : fullratsimp(innerProd(varsP, 1, (vmap_e[1])^3, f_e)),
+  M : endcons(m3par, M),
+
+  M : map(letsimp, M),
+
+  tempPowVars : [],
+  tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+
+  printf(fh, "} ~%~%")
+)$
+
+
+/* Integrated particle kinetic energy (M2). */
+calcGkIntM3perp(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
+   d,f_e,M,m3perp,bmag_e,Mtemp,tmp_e,tempPowVars],
+
+  [varsC,bC,varsP,bP,vSub] : loadGkBasis(basisFun, cdim, vdim, polyOrder),
+
+  [vmap_e,vmapSq_e,vmap_prime_e] : expandVmapFields(varsP),
+
+  vmap_c : [],
+  for d : 1 thru vdim do (
+    vmap_c : append( vmap_c, delete(mu,delete(vpar,listofvars(vmap_e[d]))) )
+  ),
+  
+  printf(fh, "GKYL_CU_DH void ~a_int_M3_perp_~ax~av_~a_p~a(const double *dxv, const double *vmap, double m_, const double *bmag, const double *f, double* GKYL_RESTRICT out) ~%{ ~%", funcNm, cdim, vdim, basisFun, polyOrder),
+
+  if vdim = 1 then printf(fh, "  const double volFact = ~a; ~%", volExpr(cdim+vdim)*float(1/(2^(cdim+vdim))) )
+  else printf(fh, "  const double volFact = ~a/m_; ~%", volExpr(cdim+vdim)*float(2*%pi/(2^(cdim+vdim))) ),
+
+  printf(fh, " ~%"),
+
+  f_e : doExpand1(f, bP),
+
+  M : [],
+
+  bmag_e : doExpand1(bmag, bC),
+
+  Mtemp : calcInnerProdList(varsP, vmap_e[1]*vmap_e[2], bC, f_e),
+  Mtemp : map(letsimp, Mtemp),
+
+  printf(fh, "  double tmp[~a]; ~%", length(bC)),
+
+  writeCExprs1(tmp, 2/m_*Mtemp),
+  printf(fh, " ~%"),
+  tmp_e : doExpand1(tmp, bC),
+
+  m3perp : fullratsimp(innerProd(varsC, 1, bmag_e, tmp_e)),
+
+  M : endcons(m3perp, M),
+
+  M : map(letsimp, M),
+
+  tempPowVars : [],
+  tempPowVars : writeCIncrExprsCollect1noPowers(out, volFact*M, [volFact], [vmap_c], tempPowVars),
+
+  printf(fh, "} ~%~%")
+)$
 
 calcGkIntThreeMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [varsC,bC,varsP,bP,vSub,vmap_e,vmapSq_e,vmap_prime_e,vmap_c,
@@ -402,8 +484,10 @@ calcIntMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block([],
   calcGkIntM0(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntM1(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntM2par(fh, funcNm, cdim, vdim, basisFun, polyOrder),
-  calcGkIntM2perp(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  if vdim > 1 then calcGkIntM2perp(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntM2(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  calcGkIntM3par(fh, funcNm, cdim, vdim, basisFun, polyOrder),
+  if vdim > 1 then calcGkIntM3perp(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntThreeMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntFourMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder),
   calcGkIntHamiltonianMoments(fh, funcNm, cdim, vdim, basisFun, polyOrder)


### PR DESCRIPTION
It is a very minor modification where we just split the three-moments moments function (that computes M0, M1 and M2) into separated functions that we call to generate the single integrated moment kernels.

We want to use the integrated M2 moments for the source adaptation in gkylzero this [DR](https://github.com/ammarhakim/gkylzero/issues/631).