### PR TITLE
2x and 3x Boltzmann electron kernels

### DIFF
--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -121,7 +121,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
       phiS_n : makelist(0,i,1,ordNum),
       for i : 1 thru ordNum do (
         phiS_n[i] : (T_e/q_e)*log(sqrt(2*%pi)*GammaJacIonB_n[i]/(m0JacIonB_n[i]*sqrt(T_e/m_e))),
-        printf(fh,"  if ((isfinite(~a)) && (~a>0.) && (~a>0.)) {~%",GammaJacIonB_n[i],GammaJacIonB_n[i],m0JacIonB_n[i]),
+        printf(fh,"  if ((isfinite(~a)) && (~a>0.) && (~a>0.)) {~%",float(GammaJacIonB_n[i]),float(GammaJacIonB_n[i]),float(m0JacIonB_n[i])),
         printf(fh,"    phiS_qp[~a] = ~a;~%",i-1,float(expand(phiS_n[i]))),
         printf(fh,"  } else {~%"),
         printf(fh,"    phiS_qp[~a] = 0.0;~%",i-1),
@@ -137,9 +137,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
           phiSlowD_c[k] : phiSlowD_c[k]+weights[i]*subst(makelist(varsLowD[d]=nOrd[d],d,1,dim-1),basisLowD[k])*phiS_qp[i-1]
         )
       ),
-      writeCExprsNoExpand1(phiSlowD, phiSlowD_c),
-      phiSlowD_e : doExpand(phiSlowD_c, basisLowD),
-      printf(fh,"~%")
+      phiSlowD_e : doExpand(phiSlowD_c, basisLowD)
     ),
 
     phiS_c : calcInnerProdList(vars, 1, basis, phiSlowD_e),

--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -28,7 +28,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
 
   /* Load a basis of one fewer dimension for projecting onto sheath surface. */
   if dim>1 then (
-    [basisLowD, varsLowD] : loadBasis(basisNm, dim-1, polyOrder),
+    [varsLowD, basisLowD] : loadBasis(basisNm, dim-1, polyOrder),
     subList   : makelist(varsLowD[i]=sheathSurfVars[i],i,1,dim-1),
     varsLowD  : psubst(subList, varsLowD),
     basisLowD : psubst(subList, basisLowD)
@@ -120,7 +120,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
       printf(fh,"  double phiS_qp[~a];~%", ordNum),
       phiS_n : makelist(0,i,1,ordNum),
       for i : 1 thru ordNum do (
-        phiS_n[i] : (T_e/q_e)**log(sqrt(2*%pi)*GammaJacIonB_n[i]/(m0JacIonB_n[i]*sqrt(T_e/m_e))),
+        phiS_n[i] : (T_e/q_e)*log(sqrt(2*%pi)*GammaJacIonB_n[i]/(m0JacIonB_n[i]*sqrt(T_e/m_e))),
         printf(fh,"  if ((isfinite(~a)) && (~a>0.) && (~a>0.)) {~%",GammaJacIonB_n[i],GammaJacIonB_n[i],m0JacIonB_n[i]),
         printf(fh,"    phiS_qp[~a] = ~a;~%",i-1,float(expand(phiS_n[i]))),
         printf(fh,"  } else {~%"),

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential.mac
@@ -8,8 +8,8 @@ load(stringproc)$
 
 /* Serendipity basis. */
 maxPolyOrder_Ser : 2$
-minDim_Ser : 3$
-maxDim_Ser : 1$
+minDim_Ser : 1$
+maxDim_Ser : 3$
 
 /* Tensor basis. */
 maxPolyOrder_Tensor : 2$

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential.mac
@@ -8,7 +8,7 @@ load(stringproc)$
 
 /* Serendipity basis. */
 maxPolyOrder_Ser : 2$
-minDim_Ser : 1$
+minDim_Ser : 3$
 maxDim_Ser : 1$
 
 /* Tensor basis. */
@@ -30,7 +30,7 @@ for bInd : 1 thru length(bName) do (
 
     for polyOrder : 1 thru maxPolyOrderB do (
 
-      disp(printf(false,sconcat("Creating asheath_potential_ ~ax p~a ",bName[bInd]),cD,polyOrder)),
+      disp(printf(false,sconcat("Creating a sheath_potential_ ~ax p~a ",bName[bInd]),cD,polyOrder)),
 
       fname : sconcat("~/max-out/ambi_bolt_potential_", cD, "x_p", polyOrder, "_", bName[bInd], ".c"),
       fh : openw(fname),


### PR DESCRIPTION
Purpose: Support is extended to 2x and 3x for Boltzmann electron simulations. This is needed in the mirror simulations for WHAM. Extensive unit testing is performed.

See https://github.com/ammarhakim/gkylzero/pull/639 for full details