### PR TITLE
Add support for conf-space and other options in translate_dim

### DIFF
--- a/maxima/g0/translate_dim/ms-trans_dim-header.mac
+++ b/maxima/g0/translate_dim/ms-trans_dim-header.mac
@@ -8,7 +8,7 @@
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 1$
-minCdim_Ser : 2$
+minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
 /* Tensor order basis. No need to generate p=1. */
@@ -29,19 +29,52 @@ maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
-printPrototypes(fh) := block([],
+varsCall : [x,y,z]$
+
+printPrototypes(fh) := block([bInd,cdim,maxPolyOrderB,polyOrder,cdim_tar,gkV,vdim,cdim_low],
 
   for bInd : 1 thru length(bName) do (
-    for c : max(2,minCdim[bInd]) thru maxCdim[bInd] do (
-      for gkV : 1 thru length(gkVdims[c]) do (
-        v : gkVdims[c][gkV],
+    /* Print declaration of conf-space kernels. */
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+  
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (cdim=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x */
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        for cdim_tar : cdim-1 thru cdim+1 do (
+          if ((cdim_tar > 0 and cdim_tar < 4) and (cdim_tar # cdim)) then (
+
+            nevals : 1,
+            ndirs : 1,
+            dirStrs : [[""]],
+            if (cdim_tar < cdim) then (
+              ndirs : cdim,
+              nevals : 3,
+              edgeStrs : ["lo","mid","up"],
+              dirStrs : makelist(makelist(sconcat("_dir",varsCall[i],"_",edgeStrs[j]),j,1,nevals),i,1,ndirs)
+            ),
+
+            for dir : 1 thru ndirs do (
+              for evI : 1 thru nevals do (
+                printf(fh, "GKYL_CU_DH void translate_dim_~ax_~a_p~a_to_~ax_p~a~a(const double *fdo, double *ftar);~%", cdim, bName[bInd], polyOrder, cdim_tar, polyOrder, dirStrs[dir][evI])
+              )
+            )
+          )
+        ),
+        printf(fh, "~%")
+      )
+    ),
+
+    /* Print declaration of gyrokinetic kernels. */
+    for cdim : max(2,minCdim[bInd]) thru maxCdim[bInd] do (
+      for gkV : 1 thru length(gkVdims[cdim]) do (
+        vdim : gkVdims[cdim][gkV],
   
         maxPolyOrderB : maxPolyOrder[bInd],
-        if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+        if (cdim=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
         for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
 
-          for c_low : 1 thru c-1 do (
-            printf(fh, "GKYL_CU_DH void translate_dim_gyrokinetic_~ax~av_~a_p~a_from_~ax~av_p~a(const double *flow, double *fout);~%", c, v, bName[bInd], polyOrder, c_low, v, polyOrder)
+          for cdim_low : 1 thru cdim-1 do (
+            printf(fh, "GKYL_CU_DH void translate_dim_gyrokinetic_~ax~av_~a_p~a_from_~ax~av_p~a(const double *flow, double *fout);~%", cdim, vdim, bName[bInd], polyOrder, cdim_low, vdim, polyOrder)
           ),
           printf(fh, "~%")
         )
@@ -50,7 +83,7 @@ printPrototypes(fh) := block([],
   )
 )$
 
-fh : openw("~/max-out/gkyl_translate_dim_gyrokinetic_kernels.h")$
+fh : openw("~/max-out/gkyl_translate_dim_kernels.h")$
 printf(fh, "#pragma once~%")$
 printf(fh, "~%")$
 printf(fh, "#include <gkyl_util.h>~%")$

--- a/maxima/g0/translate_dim/ms-trans_dim.mac
+++ b/maxima/g0/translate_dim/ms-trans_dim.mac
@@ -1,7 +1,23 @@
-/*
-  Generate kernels to translate a lower dimensional
-  field to a higher dimensional field.
-*/
+/**
+ * Create kernels which translate DG coefficients of a field into the DG
+ * coefficients of a nother field of a different dimensionality. Currently
+ * it is meant for:
+ *   - x     -> x,y
+ *   - x,y   -> x,y,z
+ * 
+ *   - x,y   -> y
+ *   - x,y   -> x
+ *   - x,y,z -> y,z
+ *   - x,y,z -> x,z
+ *   - x,y,z -> x,y
+ *
+ *   - 1x2v z,vpar,mu -> 2x2v x,z,vpar,mu
+ *   - 1x2v z,vpar,mu -> 3x2v x,y,z,vpar,mu
+ *   - 2x2v x,z,vpar,mu -> 3x2v x,y,z,vpar,mu
+ *
+ * When down projecting, we create kernels for evaluating
+ * the removed direction at -1,0 or 1).
+ */
 load("translate_dim/trans_dim.mac")$
 
 /* ...... USER INPUTS........ */
@@ -9,7 +25,7 @@ load("translate_dim/trans_dim.mac")$
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 1$
-minCdim_Ser : 2$
+minCdim_Ser : 1$
 maxCdim_Ser : 3$
 
 /* Tensor order basis. No need to generate p=1. */
@@ -30,8 +46,26 @@ maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
 minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
-/* Generate kernels of selected types. */
 for bInd : 1 thru length(bName) do (
+  /* Generate kernels that translate conf-space fields. */
+  for c : minCdim[bInd] thru maxCdim[bInd] do (
+    maxPolyOrderB : maxPolyOrder[bInd],
+    if (c=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+      fname : sconcat("~/max-out/translate_dim_", c, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating file: ~a",fname)),
+  
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_translate_dim_kernels.h> ~%"),
+      printf(fh, "~%"),
+
+      funcName : sconcat("translate_dim_", c, "x_", bName[bInd], "_p", polyOrder),
+      gen_trans_dim_kernel(fh, funcName, c, bName[bInd], polyOrder),
+      close(fh)
+    )
+  ),
+
+  /* Generate kernels that translate GK distributions. */
   for c : max(2,minCdim[bInd]) thru maxCdim[bInd] do (
     for gkV : 1 thru length(gkVdims[c]) do (
       v : gkVdims[c][gkV],
@@ -43,7 +77,7 @@ for bInd : 1 thru length(bName) do (
         disp(printf(false,"Creating file: ~a",fname)),
   
         fh : openw(fname),
-        printf(fh, "#include <gkyl_translate_dim_gyrokinetic_kernels.h> ~%"),
+        printf(fh, "#include <gkyl_translate_dim_kernels.h> ~%"),
         printf(fh, "~%"),
 
         funcName : sconcat("translate_dim_gyrokinetic_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),

--- a/maxima/g0/translate_dim/trans_dim.mac
+++ b/maxima/g0/translate_dim/trans_dim.mac
@@ -1,11 +1,82 @@
 /**
- * Create kernels which translate DG coefficients of a low-dimensional field
- * into the DG coefficients of our current (higher dimensional) field.
+ * Create kernels which translate DG coefficients of a field into the DG
+ * coefficients of a nother field of a different dimensionality. Currently
+ * it is meant for:
+ *   - x     -> x,y
+ *   - x,y   -> x,y,z
+ * 
+ *   - x,y   -> y
+ *   - x,y   -> x
+ *   - x,y,z -> y,z
+ *   - x,y,z -> x,z
+ *   - x,y,z -> x,y
  *
- */
+ *   - 1x2v z,vpar,mu -> 2x2v x,z,vpar,mu
+ *   - 1x2v z,vpar,mu -> 3x2v x,y,z,vpar,mu
+ *   - 2x2v x,z,vpar,mu -> 3x2v x,y,z,vpar,mu
+ *
+ * When down projecting, we create kernels for evaluating
+ * the removed direction at -1,0 or 1).
+*/
 load("modal-basis");
 load("out-scripts");
 fpprec : 24$
+
+gen_trans_dim_kernel(fh, funcNm, cdim_do, basisFun, polyOrder_do) := block(
+  [polyOrder_tar,varsC_do,bC_do,fdo_e,cdim_tar,nevals,ev_lst,ndirs,dirStrs,
+   varsub_lst,edgeStrs,sub_vars,dir,evI,varsC_tar,bC_tar,ftar_c],
+
+  /* Assume polyOrder remain the same. */
+  polyOrder_tar : polyOrder_do,
+
+  /* Get desired basis. */
+  [varsC_do,bC_do] : loadBasis(basisFun, cdim_do, polyOrder_do),
+
+  fdo_e : doExpand1(fdo,bC_do),
+  
+  for cdim_tar : cdim_do-1 thru cdim_do+1 do (
+    if ((cdim_tar > 0 and (cdim_tar < 4)) and (cdim_tar # cdim_do)) then (
+
+      /* Load donor basis. */
+      [varsC_tar,bC_tar] : loadBasis(basisFun, cdim_tar, polyOrder_tar),
+    
+      nevals : 1,
+      ev_lst : [[[]]],
+      ndirs : 1,
+      dirStrs : [[""]],
+      varsub_lst : [[]],
+      if (cdim_tar < cdim_do) then (
+        ndirs : cdim_do,
+        nevals : 3,
+        edgeStrs : ["lo","mid","up"],
+        ev_lst : makelist(makelist([varsC_do[i]=-1+j-1],j,1,nevals),i,1,ndirs),
+        dirStrs : makelist(makelist(sconcat("_dir",varsC_do[i],"_",edgeStrs[j]),j,1,nevals),i,1,ndirs),
+        sub_vars : makelist(delete(varsC_do[i],varsC_do),i,1,ndirs),
+        varsub_lst : makelist(makelist(varsC_tar[i]=sub_vars[d][i],i,1,cdim_tar),d,1,ndirs)
+      ),
+
+      for dir : 1 thru ndirs do (
+        for evI : 1 thru nevals do (
+
+          printf(fh, "GKYL_CU_DH void ~a_to_~ax_p~a~a(const double *fdo, double *ftar) ~%{ ~%", funcNm, cdim_tar, polyOrder_tar,dirStrs[dir][evI]),
+          printf(fh, "  // fdo: donor field to get DG coefficients from.~%"),
+          printf(fh, "  // ftar: target field whose DG coefficients to populate.~%"),
+          printf(fh, "~%"),
+  
+          vars : psubst(varsub_lst[dir],copylist(varsC_tar)),
+          basis : psubst(varsub_lst[dir],copylist(bC_tar)),
+      
+          ftar_c : calcInnerProdList(vars,1,basis,subst(ev_lst[dir][evI],fdo_e)),
+          writeCExprsWithZeros1(ftar, ftar_c),
+      
+          printf(fh, "}~%"),
+          printf(fh, "~%")
+        )
+      )
+    )
+  )
+
+)$
 
 gen_trans_dim_gk_kernel(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   [vdim_low,polyOrder_low,varsC,bC,varsP,bP,vSub,cdim_low,varsC_low,


### PR DESCRIPTION
Previously the translate_dim_gyrokinetic was used to translate the DG coefficients of a lower dimensional distribution, say a 2x2v one, to a higher dimensional one, i.e. 3x2v.

In this PR we generalize this updater, and rename it translate_dim, so that it also works for translating conf-space fields to lower or upper dimensional fields. For projecting down to lower dimensions we generate kernels:
- For each dimension (that can be removed).
- For each location within a cell where the higher dimensional field can be evaluated along along the dimension to be removed, and we support the locations -1, 0 and +1.

This new functionality is used to turn the volume-expansion of the boundary flux into a surface array, see [PR 653 of gkylzero](https://github.com/ammarhakim/gkylzero/pull/653).