### PR TITLE
Calculate hamiltonian for gk neut can pb

### DIFF
--- a/maxima/g0/gk_neut_hamil/gk-neut-hamil.mac
+++ b/maxima/g0/gk_neut_hamil/gk-neut-hamil.mac
@@ -1,0 +1,164 @@
+/*  Generate kernels for gk neut hamiltonian
+    h = 1/2*gij*w_i*w_j
+    These quantities are derived from the grid and must be continuous, 
+    so they are projected onto basis functions using Gauss-Lobatto nodes. */
+
+load("modal-basis");
+load("out-scripts");
+load("nodal_operations/nodal_functions")$
+load(stringproc)$
+fpprec : 24$
+
+calcHamil(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
+  [bC, bP, NC, NP, wv, dv, vi_sq, vi_sq_e, gxx_e, gxy_e, g02_e,
+   gyy_e, gyz_e, gzz_e, hamil_e, hamil_nodal_e],
+
+  let(w0^2, w0_sq),
+  let(dv0^2, dv0_sq),
+  let(w1^2, w1_sq),
+  let(dv1^2, dv1_sq),
+  let(w2^2, w2_sq),
+  let(dv2^2, dv2_sq),
+
+  wv : [w0, w1, w2],
+  dv : [dv0, dv1, dv2],
+  vi_sq : [v0_sq, v1_sq, v2_sq],
+  vi_sq_e : [vx_sq_e, vy_sq_e, vz_sq_e],
+
+  /* Load basis of dimensionality requested. */
+  modNm : sconcat("basis-precalc/basis", basisFun, cdim, "x", vdim, "v"),
+  load(modNm),
+  bP : basisP[polyOrder],
+  bC : basisC[polyOrder],	
+  NC : length(bC),
+  NP : length(bP),
+  varsV : makelist(varsP[i],i,cdim+1,cdim+vdim),
+
+  printf(fh, "#include <gkyl_gk_neut_hamil_kernels.h> ~%"),
+  /* Function declaration with input/output variables. */
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *mass, const double *gij, double* GKYL_RESTRICT hamil) ~%{ ~%", funcNm),
+  printf(fh, "  // w:        Cell-center coordinates.~%"),
+  printf(fh, "  // dxv:      Cell spacing.~%"),
+  printf(fh, "  // mass:     Particle mass.~%"),
+  printf(fh, "  // gij[~a]:  Contravariant components of metric tensor.~%", NC*6),
+  printf(fh, "  // hamil:    Gk neut species Hamiltonian.~%"),
+  printf(fh, " ~%"),
+
+  if cdim = 3 then (
+    printf(fh, "  const double *g00 = &gij[~a]; ~%", NC*0),
+    printf(fh, "  const double *g01 = &gij[~a]; ~%", NC*1),
+    printf(fh, "  const double *g02 = &gij[~a]; ~%", NC*2),
+    printf(fh, "  const double *g11 = &gij[~a]; ~%", NC*3),
+    printf(fh, "  const double *g12 = &gij[~a]; ~%", NC*4),
+    printf(fh, "  const double *g22 = &gij[~a]; ~%", NC*5)
+  )
+  /* Changing order for 2x3v (vx, vz, vy) */
+  /* g01_can = g02_gk, g02_can = g01_gk   */
+  /* g11_can = g22_gk, g22_can = g11_gk   */  
+  else if cdim = 2 then ( 
+    printf(fh, "  const double *g00 = &gij[~a]; ~%", NC*0),
+    printf(fh, "  const double *g01 = &gij[~a]; ~%", NC*2),
+    printf(fh, "  const double *g02 = &gij[~a]; ~%", NC*1),
+    printf(fh, "  const double *g11 = &gij[~a]; ~%", NC*5),
+    printf(fh, "  const double *g12 = &gij[~a]; ~%", NC*4),
+    printf(fh, "  const double *g22 = &gij[~a]; ~%", NC*3)
+  )
+  /* Changing order for 1x3v (vx, vz, vy)                 */
+  /* g00_can = g22_gk, g01_can = g02_gk, g02_can = g12_gk */
+  /* g11_can = g00_gk, g12_can = g01_gk, g22_can = g11_gk */ 
+  else if cdim = 1 then ( /* Changing order for 1x3v (vz, vx, vy) */
+    printf(fh, "  const double *g00 = &gij[~a]; ~%", NC*5),
+    printf(fh, "  const double *g01 = &gij[~a]; ~%", NC*2),
+    printf(fh, "  const double *g02 = &gij[~a]; ~%", NC*4),
+    printf(fh, "  const double *g11 = &gij[~a]; ~%", NC*0),
+    printf(fh, "  const double *g12 = &gij[~a]; ~%", NC*1),
+    printf(fh, "  const double *g22 = &gij[~a]; ~%", NC*3)
+  ),
+
+  g00_e : doExpand1(g00, bC),
+  g01_e : doExpand1(g01, bC),
+  g02_e : doExpand1(g02, bC),
+  g11_e : doExpand1(g11, bC),
+  g12_e : doExpand1(g12, bC),
+  g22_e : doExpand1(g22, bC),
+  printf(fh, "~%"), 	 
+
+  basis_v0_sq : basisFromVars("ser", [varsV[1]], polyOrder),
+  NV1 : length(basis_v0_sq),
+  basis_v0_v1 : basisFromVars("ser", [varsV[1],varsV[2]], polyOrder),	
+  NV2 : length(basis_v0_v1),
+
+  for dir : 1 thru vdim do (
+    printf(fh, "  const double w~a = w[~a]; ~%", dir-1, cdim+dir-1),
+    printf(fh, "  const double dv~a = dxv[~a]; ~%", dir-1, cdim+dir-1),
+    printf(fh, "  const double w~a_sq = w~a*w~a, dv~a_sq = dv~a*dv~a; ~%", dir-1, dir-1, dir-1, dir-1, dir-1, dir-1),
+    printf(fh, "  double v~a_sq[~a] = {0.0};~%", dir-1, NV1)
+  ),
+  printf(fh, "~%"), 
+  printf(fh, "  double v0_v1[~a] = {0.0};~%", NV2),
+  printf(fh, "  double v0_v2[~a] = {0.0};~%", NV2),
+  printf(fh, "  double v1_v2[~a] = {0.0};~%", NV2),
+  printf(fh, "~%"),
+
+  /* construct the 6 velocity space terms in the hamiltonian */
+  for dir : 1 thru vdim do (
+    basis_vi_sq : basisFromVars("ser", [varsV[dir]], polyOrder),
+    vi_sq_c : calcInnerProdList([varsV[dir]], 1, basis_vi_sq, (dv[dir]/2.0*varsV[dir] + wv[dir])^2),
+    vi_sq_c : map(letsimp, vi_sq_c),
+    writeCExprs1(vi_sq[dir], vi_sq_c), 
+    printf(fh, "~%"), 
+    vi_sq_e[dir] : doExpand1(vi_sq[dir], basis_vi_sq)
+  ),
+
+  /* v0*v1 */
+  v0_v1_c : calcInnerProdList([varsV[1],varsV[2]], 1, basis_v0_v1, (dv0/2.0*varsV[1] + w0)*(dv1/2.0*varsV[2] + w1)),
+  v0_v1_c : map(letsimp, v0_v1_c),
+  writeCExprs1(v0_v1, v0_v1_c), 
+  printf(fh, "~%"), 
+  v0_v1_e : doExpand1(v0_v1, basis_v0_v1),
+
+  /* v0*v2 */
+  basis_v0_v2 : basisFromVars("ser", [varsV[1],varsV[3]], polyOrder),
+  v0_v2_c : calcInnerProdList([varsV[1],varsV[3]], 1, basis_v0_v2, (dv0/2.0*varsV[1] + w0)*(dv2/2.0*varsV[3] + w2)),
+  v0_v2_c : map(letsimp, v0_v2_c),
+  writeCExprs1(v0_v2, v0_v2_c), 
+  printf(fh, "~%"), 
+  v0_v2_e : doExpand1(v0_v2, basis_v0_v2),
+
+  /* v1*v2 */
+  basis_v1_v2 : basisFromVars("ser", [varsV[2],varsV[3]], polyOrder),
+  v1_v2_c : calcInnerProdList([varsV[2],varsV[3]], 1, basis_v1_v2, (dv1/2.0*varsV[2] + w1)*(dv2/2.0*varsV[3] + w2)),
+  v1_v2_c : map(letsimp, v1_v2_c),
+  writeCExprs1(v1_v2, v1_v2_c), 
+  printf(fh, "~%"), 
+  v1_v2_e : doExpand1(v1_v2, basis_v1_v2),
+
+  /* Construct the hamiltonian */
+  /* hamil_e is modal expansion of g^ij * modal expansions of */
+  /* velocity space coordinates */
+  hamil_c : calcInnerProdList(varsP, 1, bP, 0.5*(g00_e*vi_sq_e[1] + g11_e*vi_sq_e[2] + g22_e*vi_sq_e[3]) + g01_e*v0_v1_e + g02_e*v0_v2_e + g12_e*v1_v2_e),
+
+  hamil_e : doExpand(hamil_c, bP),
+
+  /* Use Hybrid for (Gauss-Lobatto nodes) */
+  nodes_lobatto : getNodes("tensor", cdim+vdim, polyOrder),
+  num_nodes_lobatto : length(nodes_lobatto),
+  print("num nodes lobatto", num_nodes_lobatto),
+  hamil_nodes : expand(float(evAtNodes(hamil_e,nodes_lobatto,varsP))),  
+  printf(fh, "  double hamil_nodal[~a] = {0.0};~%", num_nodes_lobatto),
+  printf(fh, "~%"), 
+  for i : 1 thru num_nodes_lobatto do (
+    printf(fh, "  hamil_nodal[~a] = ~a;~%", i-1, hamil_nodes[i])
+  ), 
+  printf(fh, "~%"), 
+
+  basis_nodal_lobatto : getVarsNodalBasisWithNodes(basisFun, cdim+vdim, polyOrder, varsP, nodes_lobatto),
+  hamil_nodal_e : doExpand1(hamil_nodal,basis_nodal_lobatto),
+
+  hamil_c : calcInnerProdList(varsP, 1, bP, hamil_nodal_e), 
+  writeCExprs1(hamil, hamil_c), 
+  printf(fh, "~%"), 
+  flush_output(fh),
+
+  printf(fh, "} ~%")
+)$

--- a/maxima/g0/gk_neut_hamil/gk-neut-hamil.mac
+++ b/maxima/g0/gk_neut_hamil/gk-neut-hamil.mac
@@ -10,8 +10,10 @@ load(stringproc)$
 fpprec : 24$
 
 calcHamil(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
-  [bC, bP, NC, NP, wv, dv, vi_sq, vi_sq_e, gxx_e, gxy_e, g02_e,
-   gyy_e, gyz_e, gzz_e, hamil_e, hamil_nodal_e],
+  [bC, bP, NC, NP, wv, dv, vi_sq, vi_sq_e, g00_e, g01_e, g02_e,
+   g11_e, g12_e, g22_e, v0_sq, v0_v1, v0_v2, v1_sq, v1_v2, v2_sq,
+   v0_sq_e, v0_v1_e, v0_v2_e, v1_sq_e, v1_v2_e, v2_sq_e,
+   hamil_e, hamil_nodal_e],
 
   let(w0^2, w0_sq),
   let(dv0^2, dv0_sq),
@@ -34,12 +36,11 @@ calcHamil(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   NP : length(bP),
   varsV : makelist(varsP[i],i,cdim+1,cdim+vdim),
 
-  printf(fh, "#include <gkyl_gk_neut_hamil_kernels.h> ~%"),
+  printf(fh, "#include <gkyl_dg_gk_neut_hamil_kernels.h> ~%"),
   /* Function declaration with input/output variables. */
-  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *mass, const double *gij, double* GKYL_RESTRICT hamil) ~%{ ~%", funcNm),
+  printf(fh, "GKYL_CU_DH void ~a(const double *w, const double *dxv, const double *gij, double* GKYL_RESTRICT hamil) ~%{ ~%", funcNm),
   printf(fh, "  // w:        Cell-center coordinates.~%"),
   printf(fh, "  // dxv:      Cell spacing.~%"),
-  printf(fh, "  // mass:     Particle mass.~%"),
   printf(fh, "  // gij[~a]:  Contravariant components of metric tensor.~%", NC*6),
   printf(fh, "  // hamil:    Gk neut species Hamiltonian.~%"),
   printf(fh, " ~%"),

--- a/maxima/g0/gk_neut_hamil/ms-gk-neut-hamil.mac
+++ b/maxima/g0/gk_neut_hamil/ms-gk-neut-hamil.mac
@@ -1,0 +1,37 @@
+load("gk_neut_hamil/gk-neut-hamil")$
+load(stringproc)$
+/*  This script calls the func that generates kernels for gk neut hamiltonian
+    h = 1/2*gij*w_i*w_j
+    These quantities are derived from the grid and must be continuous, 
+    so they are projected onto basis functions using Gauss-Lobatto nodes. */
+
+/* ...... USER INPUTS........ */
+
+/* Tensor basis. */
+minPolyOrder : 1$
+maxPolyOrder : 1$
+minVdim : 3$    /* see begining of v loop below though. */
+maxVdim : 3$
+
+/* ...... END OF USER INPUTS........ */
+
+bName        : ["tensor"]$
+minPolyOrder : [minPolyOrder]$
+maxPolyOrder : [maxPolyOrder]$
+minVdim      : [minVdim]$
+maxVdim      : [maxVdim]$
+for bInd : 1 thru length(bName) do (
+  for v : 3 thru maxVdim[bInd] do (
+    for c : 1 thru 3 do ( 
+      minPolyOrderB : minPolyOrder[bInd],
+      maxPolyOrderB : maxPolyOrder[bInd],
+      for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+        fname : sconcat("~/max-out/gk_neut_hamil_", c, "x", v, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        fh : openw(fname),
+        funcName : sconcat("gk_neut_hamil_", c, "x", v, "v_", bName[bInd], "_p", polyOrder),
+        calcHamil(fh, funcName, c, v, bName[bInd], polyOrder),
+        close(fh)
+      )
+    )
+  )
+);


### PR DESCRIPTION
Adding Maxima scripts that generate the kernels to calculate the hamiltonian for the canonical PB GK neutrals:

H = 0.5*h^ij*w_i*w_j

Here h^ij are equivalent to the gk_geom gij object, which is passed at initialization of this updater. The w_i and w_j are the velocity variables corresponding to the curvilinear coordinate system, in this case vz, vy, vz. The hamiltonian must be continuous, so it is calculated on the nodal values and then returns the modal values. For 1x and 2x there is a reordering of the metric coefficients because the convention of velocity space order always places the ignorable coordinates last. It will assume the following order: 

1x : (z, vz, vx, vy)
2x: (x, z, vx, vz, vy)
3x: (x, y, z, vx, vy, vz)

This requires a reordering of the metric coefficients in the kernel for 1x and 2x.

1x: 
    g00_cpb  = gzz_gk,
    g01_cpb = gxz_gk, 
    g02_cpb = gyz_gk, 
    g11_cpb = gxx_gk, 
    g12_cpb = gxy_gk, 
    g22_cpb = gyy_gk, 

2x: 
    g00_cpb  = gxx_gk,
    g01_cpb = gxz_gk, 
    g02_cpb = gxy_gk, 
    g11_cpb = gzz_gk, 
    g12_cpb = gyz_gk, 
    g22_cpb = gyy_gk, 

3x (no reordering):
    g00_cpb  = gxx_gk,
    g01_cpb = gxy_gk, 
    g02_cpb = gxz_gk, 
    g11_cpb = gyy_gk, 
    g12_cpb = gyz_gk, 
    g22_cpb = gzz_gk, 
