### PR TITLE
Fix a bug in diffusion boundary surf kernels

### DIFF
--- a/maxima/g0/dg_diffusion_fluid/diffFuncs-fluid-boundary-surf.mac
+++ b/maxima/g0/dg_diffusion_fluid/diffFuncs-fluid-boundary-surf.mac
@@ -159,15 +159,15 @@ genDGdiffFluidKernelBoundarySurf(fh, funcNm, dim, basisType, polyOrder, dir, dif
     writeCExprs1(boundSurf_incr, boundSurf_incr_c),
     printf(fh, "~%"),
 
+    printf(fh, "  }~%"),
+    printf(fh, "~%"),
+
     vol_out  : makelist(vol_incr[i-1],i,1,numBasis),
     diff_out : makelist(edgeSurf_incr[i-1],i,1,numBasis),
     edge_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
     writeCIncrExprsNoExpand1(out, ((-1)^(diffOrder/2+1))*Jfac*(diff_out + edge_out + vol_out)),
     printf(fh, "~%"),
   
-    printf(fh, "  }~%"),
-    printf(fh, "~%"),
-
     printf(fh, "  return 0.;~%"),  /* Return CFL frequency in volume kernel. */
     printf(fh, "}~%~%")
   )

--- a/maxima/g0/dg_diffusion_gyrokinetic/diffFuncs-gyrokinetic-boundary-surf.mac
+++ b/maxima/g0/dg_diffusion_gyrokinetic/diffFuncs-gyrokinetic-boundary-surf.mac
@@ -154,15 +154,15 @@ genDGdiffGyrokineticKernelBoundarySurf(fh, funcNm, cdim, vdim, basisType, polyOr
     writeCExprs1(boundSurf_incr, boundSurf_incr_c),
     printf(fh, "~%"),
 
+    printf(fh, "  }~%"),
+    printf(fh, "~%"),
+
     vol_out  : makelist(vol_incr[i-1],i,1,numBasis),
     diff_out : makelist(edgeSurf_incr[i-1],i,1,numBasis),
     edge_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
     writeCIncrExprsNoExpand1(out, ((-1)^(diffOrder/2+1))*rdx2Sq*(diff_out + edge_out + vol_out)),
     printf(fh, "~%"),
   
-    printf(fh, "  }~%"),
-    printf(fh, "~%"),
-
     printf(fh, "  return 0.;~%"),  /* Return CFL frequency in volume kernel. */
     printf(fh, "}~%~%")
   )

--- a/maxima/g0/dg_diffusion_vlasov/diffFuncs-vlasov-boundary-surf.mac
+++ b/maxima/g0/dg_diffusion_vlasov/diffFuncs-vlasov-boundary-surf.mac
@@ -127,15 +127,15 @@ genDGdiffVlasovKernelBoundarySurf(fh, funcNm, cdim, vdim, basisType, polyOrder, 
     writeCExprs1(boundSurf_incr, boundSurf_incr_c),
     printf(fh, "~%"),
 
+    printf(fh, "  }~%"),
+    printf(fh, "~%"),
+
     vol_out  : makelist(vol_incr[i-1],i,1,numBasis),
     diff_out : makelist(edgeSurf_incr[i-1],i,1,numBasis),
     edge_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
     writeCIncrExprsNoExpand1(out, ((-1)^(diffOrder/2+1))*Jfac*(diff_out + edge_out + vol_out)),
     printf(fh, "~%"),
   
-    printf(fh, "  }~%"),
-    printf(fh, "~%"),
-
     printf(fh, "  return 0.;~%"),  /* Return CFL frequency in volume kernel. */
     printf(fh, "}~%~%")
   )


### PR DESCRIPTION
There was a curly braces closing an if-statement that was printed in the wrong place, so our kernels looked like
```
if (edge == -1) {
...
}
else {
...
out[0] = ...
out[1] = ...
...
}
```
instead of 
```
if (edge == -1) {
...
}
else {
...
}
out[0] = ...
out[1] = ...
...

```
so diffusion wasn't applied in the lower skin cell.