### PR TITLE
[Bug Fix] Revert Modal Basis Change

### DIFF
--- a/maxima/g0/modal-basis.mac
+++ b/maxima/g0/modal-basis.mac
@@ -308,7 +308,7 @@ loadPhaseBasis(basisType, cdim, vdim, pOrder) := block(
   kill(varsC, varsP, basisC, basisP),
   if vdim>0 then (
     if cdim>0 then (
-      if pOrder = 1 and bType = "Ser" then  /* Forcing p=1 to hybrid. */
+      if pOrder = 1 then /* Forcing p=1 to hybrid. */  /* Forcing p=1 to hybrid. */
         modNm : sconcat("basis-precalc/basisHybrid", cdim, "x", vdim, "v")
       else
         modNm : sconcat("basis-precalc/basis", btype, cdim, "x", vdim, "v")

--- a/maxima/g0/modal-basis.mac
+++ b/maxima/g0/modal-basis.mac
@@ -308,7 +308,7 @@ loadPhaseBasis(basisType, cdim, vdim, pOrder) := block(
   kill(varsC, varsP, basisC, basisP),
   if vdim>0 then (
     if cdim>0 then (
-      if pOrder = 1 then /* Forcing p=1 to hybrid. */  /* Forcing p=1 to hybrid. */
+      if pOrder = 1 then /* Forcing p=1 to hybrid. */
         modNm : sconcat("basis-precalc/basisHybrid", cdim, "x", vdim, "v")
       else
         modNm : sconcat("basis-precalc/basis", btype, cdim, "x", vdim, "v")


### PR DESCRIPTION
Reverted a modified if statement from [PR75](https://github.com/ammarhakim/gkylcas/pull/75) which makes Vlasov and Can-pb select the wrong hybrid kernels. Any kernels generated for Vlasov and Can-pb from Main between April 4th-May 8th 2025 need to be recomputed for hybrid basis. 

@manauref this likely effects your [PR75](https://github.com/ammarhakim/gkylcas/pull/75) kernel basis selection since you added this if statement for those changes. Before you merge, could you verify that this isn't introducing a bug into your positivity fix? 