### PR TITLE
Fix the gk boltzmann sheath kernels to give the correct potential

### DIFF
--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -17,7 +17,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
    boundaryStr,ghostEvSign,skinEvSign,GammaJacIon_e,GammaJacIonB_c,
    cmag_e,jacobtotInv_e,x3HalfMomJacElc_e,x3HalfMomJacElcB_c,x3HalfMomJacElcB_e,x3HalfMomJacElcB_n,
    GammaJacIonB_e,m0JacIon_e,m0JacIonB_c,m0JacIonB_e,phiSlowD_c,
-   phiSlowD_e,phiS_c,expr,jacInv_e,m0Ion_c,m0Ion_e,m0IonS_c],
+   phiSlowD_e,phiS_c,expr,m0Ion_c,m0Ion_e,m0IonS_c],
 
   numQuad : polyOrder+1, /* Number of quarature points in 1D. */
 
@@ -51,24 +51,21 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   ghostEvSign : [1, -1],  skinEvSign  : [-1, 1],
 
   for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *cmag, const double *jacobtotInv, const double *GammaJac_i, const double *m0JacIon, double *out) ~%{ ~%"), boundaryStr[bS]),
+    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double sheathDirDx, double q_e, double m_e, double T_e, const double *cmag, const double *jacobtotInv, const double *GammaJac_i, const double *m0Ion, const double *m0JacIon, double *out) ~%{ ~%"), boundaryStr[bS]),
     printf(fh,"  // sheathDirDx: cell length in direction of the sheath.~%"),
     printf(fh,"  // q_e:         electron change.~%"),
     printf(fh,"  // m_e:         electron mass.~%"),
     printf(fh,"  // T_e:         electron temperature.~%"),
-    printf(fh,"  // jacInv:      reciprocal of the geometry Jacobian (1/J).~%"),
     printf(fh,"  // cmag:        Clebsch function in definition of magnetic field.~%"),
     printf(fh,"  // jacobtotInv: reciprocal of the phase-space and conf-space Jacobians (1/(J*B)).~%"),
     printf(fh,"  // GammaJac_i:  ion particle flux (times the Jacobian) through sheath entrance.~%"),
+    printf(fh,"  // m0Ion:       ion density.~%"),
     printf(fh,"  // m0JacIon:    ion density (times the geometry Jacobian).~%"),
     printf(fh,"  // out:         ion density and electrostatic potential at the sheath entrance.~%"),
     printf(fh,"~%"),
 
-    /* Density at the sheath entrance. */
+    m0Ion_e : doExpand1(m0Ion, basis),
     m0JacIon_e : doExpand1(m0JacIon, basis),
-    jacInv_e : doExpand1(jacInv,bmagBasis),
-    m0Ion_c : calcInnerProdList(vars, jacInv_e, basis, m0JacIon_e),
-    m0Ion_e : doExpand(m0Ion_c,basis),
 
     m0IonS_c : calcInnerProdList(vars, 1, basis, subst(sheathVar=skinEvSign[bS],m0Ion_e)),
     printf(fh,"  // Particle number density evaluate at the sheath entrance~%"),
@@ -180,8 +177,8 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
 
 genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   /* Compute the potential in the domain volume using Gaussian quadrature. */
-  [numQuad,vars,basis,numB,bmagBasis,normOrds,weights,ordNum,m0JacIon_e,
-  jacInv_e,m0Ion_c,m0Ion_e,m0IonS_e,phiS_e,m0Ion_n,m0IonS_n,
+  [numQuad,vars,basis,numB,normOrds,weights,ordNum,
+  m0Ion_e,m0IonS_e,phiS_e,m0Ion_n,m0IonS_n,
   phiS_n,nOrd,cSub,phi_n,phi_c],
 
   numQuad : polyOrder+1, /* Number of quarature points in 1D. */
@@ -189,31 +186,19 @@ genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   [vars, basis] : loadBasis(basisNm, dim, polyOrder),
   numB : length(basis),
 
-  bmagBasis : getAxisymmetricConfBasis(basis),
-
   /* Get the Gaussian quadrature weights and ordinates (in [-1,1] space) */
   [normOrds, weights] : gaussOrdWeight(numQuad,dim),
   ordNum : length(normOrds),
 
-  printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi) ~%{ ~%")),
-  printf(fh,"  // q_e:        electron change.~%"),
-  printf(fh,"  // T_e:        electron temperature.~%"),
-  printf(fh,"  // jacInv:     reciprocal of the geometry Jacobian (1/J).~%"),
-  printf(fh,"  // m0JacIon:   ion density.~%"),
+  printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double q_e, double T_e, const double *m0Ion, const double *sheathvals, double *phi) ~%{ ~%")),
+  printf(fh,"  // q_e: electron change.~%"),
+  printf(fh,"  // T_e: electron temperature.~%"),
+  printf(fh,"  // m0Ion: ion density.~%"),
   printf(fh,"  // sheathvals: ion density and electrostatic potential at the sheath entrance.~%"),
-  printf(fh,"  // phi:        electrostatic potential in domain volume.~%"),
+  printf(fh,"  // phi: electrostatic potential in domain volume.~%"),
   printf(fh,"~%"),
 
-  m0JacIon_e : doExpand1(m0JacIon, basis),
-
-  jacInv_e : doExpand1(jacInv,bmagBasis),
-  m0Ion_c : calcInnerProdList(vars, jacInv_e, basis, m0JacIon_e),
-  m0Ion_e : doExpand(m0Ion_c,basis),
-  printf(fh,"  double m0Ion[~a];~%", numB),
-  writeCExprs1(m0Ion, m0Ion_c),
-  printf(fh,"~%"),
-  m0Ion_c : makelistNoZeros1(m0Ion_c, m0Ion),
-  m0Ion_e : doExpand(m0Ion_c,basis),
+  m0Ion_e : doExpand1(m0Ion, basis),
 
   m0IonS_e : doExpand(makelist(sheathvals[i-1],i,1,numB), basis),
   phiS_e   : doExpand(makelist(sheathvals[numB+i-1],i,1,numB), basis),

--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -83,11 +83,11 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
     GammaJacIon_e : (sheathDirDx/2)*doExpand1(GammaJac_i, basis),
     /* Evaluate the (ghost cell) flux at the boundary surface. */
     GammaJacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=ghostEvSign[bS], GammaJacIon_e)),
-    GammaJacIonB_c : makelistNoZeros1(GammaJacIonB_c, GammaJacIonB),
-    GammaJacIonB_e : doExpand(GammaJacIonB_c,basisLowD),
     printf(fh,"  double GammaJacIonB[~a];~%", numBLowD),
     writeCExprs1(GammaJacIonB, GammaJacIonB_c),
     printf(fh,"~%"),
+    GammaJacIonB_c : makelistNoZeros1(GammaJacIonB_c, GammaJacIonB),
+    GammaJacIonB_e : doExpand(GammaJacIonB_c,basisLowD),
 
     /*
       Evaluate the x^3 half moment (over positive or negative vpar) of the electrons,
@@ -97,19 +97,19 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
     jacobtotInv_e : doExpand1(jacobtotInv, bmagBasis),
     x3HalfMomJacElc_e : (1/sqrt(2*%pi))*cmag_e*jacobtotInv_e*m0JacIon_e*sqrt(T_e/m_e),
     x3HalfMomJacElcB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=skinEvSign[bS], x3HalfMomJacElc_e)),
-    x3HalfMomJacElcB_c : makelistNoZeros1(x3HalfMomJacElcB_c, x3HalfMomJacElcB),
-    x3HalfMomJacElcB_e : doExpand(x3HalfMomJacElcB_c,basisLowD),
     printf(fh,"  double x3HalfMomJacElcB[~a];~%", numBLowD),
     writeCExprs1(x3HalfMomJacElcB, x3HalfMomJacElcB_c),
     printf(fh,"~%"),
+    x3HalfMomJacElcB_c : makelistNoZeros1(x3HalfMomJacElcB_c, x3HalfMomJacElcB),
+    x3HalfMomJacElcB_e : doExpand(x3HalfMomJacElcB_c,basisLowD),
 
     /* Evaluate the (skin cell) ion density at the boundary surface. */
     m0JacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=skinEvSign[bS], m0JacIon_e)),
-    m0JacIonB_c : makelistNoZeros1(m0JacIonB_c, m0JacIonB),
-    m0JacIonB_e : doExpand(m0JacIonB_c,basisLowD),
     printf(fh,"  double m0JacIonB[~a];~%", numBLowD),
     writeCExprs1(m0JacIonB, m0JacIonB_c),
     printf(fh,"~%"),
+    m0JacIonB_c : makelistNoZeros1(m0JacIonB_c, m0JacIonB),
+    m0JacIonB_e : doExpand(m0JacIonB_c,basisLowD),
 
     /* Compute the sheath potential
          phiS = (T_e/q_e)*log( GammaJac_i/((1/sqrt(2*pi))*(c/(J*B))*n_i*sqrt(T_e/m_e)) )
@@ -181,7 +181,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
 genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   /* Compute the potential in the domain volume using Gaussian quadrature. */
   [numQuad,vars,basis,numB,bmagBasis,normOrds,weights,ordNum,m0JacIon_e,
-  jacInv_e,m0Ion_c,m0Ion_e,m0Ion_noZero_c,m0IonS_e,phiS_e,m0Ion_n,m0IonS_n,
+  jacInv_e,m0Ion_c,m0Ion_e,m0IonS_e,phiS_e,m0Ion_n,m0IonS_n,
   phiS_n,nOrd,cSub,phi_n,phi_c],
 
   numQuad : polyOrder+1, /* Number of quarature points in 1D. */
@@ -209,11 +209,11 @@ genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   jacInv_e : doExpand1(jacInv,bmagBasis),
   m0Ion_c : calcInnerProdList(vars, jacInv_e, basis, m0JacIon_e),
   m0Ion_e : doExpand(m0Ion_c,basis),
-  m0Ion_noZero_c : makelistNoZeros1(m0Ion_c, m0Ion),
-  m0Ion_e : doExpand(m0Ion_noZero_c,basis),
   printf(fh,"  double m0Ion[~a];~%", numB),
   writeCExprs1(m0Ion, m0Ion_c),
   printf(fh,"~%"),
+  m0Ion_c : makelistNoZeros1(m0Ion_c, m0Ion),
+  m0Ion_e : doExpand(m0Ion_c,basis),
 
   m0IonS_e : doExpand(makelist(sheathvals[i-1],i,1,numB), basis),
   phiS_e   : doExpand(makelist(sheathvals[numB+i-1],i,1,numB), basis),

--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -8,19 +8,22 @@ load("modal-basis");
 load("out-scripts");
 load(stringproc)$
 load("nodal_operations/quadrature_functions")$
+load("utilities_gyrokinetic")$
 fpprec : 24$
 
 genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   /* Compute the sheath entrance potential using Gaussian quadrature. */
-  [numQuad,vars,basis,numB,sheathDir,sheathVar,sheathSurfVars,varsLowD,basisLowD,numBLowD,
-   boundaryStr,ghostEvSign,skinEvSign,GammaJacIon_e,GammaJacIonB_c,GammaJacIonB_noZero_c,
-   GammaJacIonB_e,m0JacIon_e,m0JacIonB_c,m0JacIonB_noZero_c,m0JacIonB_e,phiSlowD_c,
+  [numQuad,vars,basis,numB,bmagBasis,sheathDir,sheathVar,sheathSurfVars,varsLowD,basisLowD,numBLowD,
+   boundaryStr,ghostEvSign,skinEvSign,GammaJacIon_e,GammaJacIonB_c,
+   cmag_e,jacobtotInv_e,x3HalfMomJacElc_e,x3HalfMomJacElcB_c,x3HalfMomJacElcB_e,x3HalfMomJacElcB_n,
+   GammaJacIonB_e,m0JacIon_e,m0JacIonB_c,m0JacIonB_e,phiSlowD_c,
    phiSlowD_e,phiS_c,expr,jacInv_e,m0Ion_c,m0Ion_e,m0IonS_c],
 
   numQuad : polyOrder+1, /* Number of quarature points in 1D. */
 
   [vars, basis] : loadBasis(basisNm, dim, polyOrder),
   numB : length(basis),
+  bmagBasis : getAxisymmetricConfBasis(basis),
 
   sheathDir : dim,  /* Assume the last dimension is the sheath direction. */
   sheathVar : vars[sheathDir],
@@ -48,39 +51,22 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   ghostEvSign : [1, -1],  skinEvSign  : [-1, 1],
 
   for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out) ~%{ ~%"), boundaryStr[bS]),
+    printf(fh,sconcat("GKYL_CU_DH void ",funcNm,"(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *cmag, const double *jacobtotInv, const double *GammaJac_i, const double *m0JacIon, double *out) ~%{ ~%"), boundaryStr[bS]),
     printf(fh,"  // sheathDirDx: cell length in direction of the sheath.~%"),
     printf(fh,"  // q_e:         electron change.~%"),
     printf(fh,"  // m_e:         electron mass.~%"),
     printf(fh,"  // T_e:         electron temperature.~%"),
     printf(fh,"  // jacInv:      reciprocal of the geometry Jacobian (1/J).~%"),
+    printf(fh,"  // cmag:        Clebsch function in definition of magnetic field.~%"),
+    printf(fh,"  // jacobtotInv: reciprocal of the phase-space and conf-space Jacobians (1/(J*B)).~%"),
     printf(fh,"  // GammaJac_i:  ion particle flux (times the Jacobian) through sheath entrance.~%"),
     printf(fh,"  // m0JacIon:    ion density (times the geometry Jacobian).~%"),
     printf(fh,"  // out:         ion density and electrostatic potential at the sheath entrance.~%"),
     printf(fh,"~%"),
 
-    /* Particle flux expanded in basis. Need to multiply by an extra dx/2
-       because of the way the boundary fluxes are computed. */
-    GammaJacIon_e : (sheathDirDx/2)*doExpand1(GammaJac_i, basis),
-    /* Evaluate the (ghost cell) flux at the boundary surface. */
-    GammaJacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=ghostEvSign[bS], GammaJacIon_e)),
-    GammaJacIonB_noZero_c : makelistNoZeros1(GammaJacIonB_c, GammaJacIonB),
-    GammaJacIonB_e : doExpand(GammaJacIonB_noZero_c,basisLowD),
-    printf(fh,"  double GammaJacIonB[~a];~%", numBLowD),
-    writeCExprs1(GammaJacIonB, GammaJacIonB_c),
-    printf(fh,"~%"),
-
-    m0JacIon_e : doExpand1(m0JacIon, basis),
-    /* Evaluate the (skin cell) ion density at the boundary surface. */
-    m0JacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=skinEvSign[bS], m0JacIon_e)),
-    m0JacIonB_noZero_c : makelistNoZeros1(m0JacIonB_c, m0JacIonB),
-    m0JacIonB_e : doExpand(m0JacIonB_noZero_c,basisLowD),
-    printf(fh,"  double m0JacIonB[~a];~%", numBLowD),
-    writeCExprs1(m0JacIonB, m0JacIonB_c),
-    printf(fh,"~%"),
-
     /* Density at the sheath entrance. */
-    jacInv_e : doExpand1(jacInv,basis),
+    m0JacIon_e : doExpand1(m0JacIon, basis),
+    jacInv_e : doExpand1(jacInv,bmagBasis),
     m0Ion_c : calcInnerProdList(vars, jacInv_e, basis, m0JacIon_e),
     m0Ion_e : doExpand(m0Ion_c,basis),
 
@@ -92,13 +78,47 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
     ),
     printf(fh,"~%"),
 
+    /* Particle flux expanded in basis. Need to multiply by an extra dx/2
+       because of the way the boundary fluxes are computed. */
+    GammaJacIon_e : (sheathDirDx/2)*doExpand1(GammaJac_i, basis),
+    /* Evaluate the (ghost cell) flux at the boundary surface. */
+    GammaJacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=ghostEvSign[bS], GammaJacIon_e)),
+    GammaJacIonB_c : makelistNoZeros1(GammaJacIonB_c, GammaJacIonB),
+    GammaJacIonB_e : doExpand(GammaJacIonB_c,basisLowD),
+    printf(fh,"  double GammaJacIonB[~a];~%", numBLowD),
+    writeCExprs1(GammaJacIonB, GammaJacIonB_c),
+    printf(fh,"~%"),
+
+    /*
+      Evaluate the x^3 half moment (over positive or negative vpar) of the electrons,
+      where x^3=C*vpar/(J*B), and assume quasineutrality so n_i appears instead of n_e.
+    */
+    cmag_e : doExpand1(cmag, bmagBasis),
+    jacobtotInv_e : doExpand1(jacobtotInv, bmagBasis),
+    x3HalfMomJacElc_e : (1/sqrt(2*%pi))*cmag_e*jacobtotInv_e*m0JacIon_e*sqrt(T_e/m_e),
+    x3HalfMomJacElcB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=skinEvSign[bS], x3HalfMomJacElc_e)),
+    x3HalfMomJacElcB_c : makelistNoZeros1(x3HalfMomJacElcB_c, x3HalfMomJacElcB),
+    x3HalfMomJacElcB_e : doExpand(x3HalfMomJacElcB_c,basisLowD),
+    printf(fh,"  double x3HalfMomJacElcB[~a];~%", numBLowD),
+    writeCExprs1(x3HalfMomJacElcB, x3HalfMomJacElcB_c),
+    printf(fh,"~%"),
+
+    /* Evaluate the (skin cell) ion density at the boundary surface. */
+    m0JacIonB_c : calcInnerProdList(varsLowD,1,basisLowD,subst(sheathVar=skinEvSign[bS], m0JacIon_e)),
+    m0JacIonB_c : makelistNoZeros1(m0JacIonB_c, m0JacIonB),
+    m0JacIonB_e : doExpand(m0JacIonB_c,basisLowD),
+    printf(fh,"  double m0JacIonB[~a];~%", numBLowD),
+    writeCExprs1(m0JacIonB, m0JacIonB_c),
+    printf(fh,"~%"),
+
     /* Compute the sheath potential
-         phiS = (T_e/q_e)*log( sqrt(2*pi)*GammaJac_i/(n_i*sqrt(T_e/m_e)) )
+         phiS = (T_e/q_e)*log( GammaJac_i/((1/sqrt(2*pi))*(c/(J*B))*n_i*sqrt(T_e/m_e)) )
        using quadrature. If dim=1 no quadrature is needed. */
     phiSlowD_c : makelist(0,i,1,numBLowD),
     if dim=1 then (
+
       printf(fh,"  double phiS_qp[1];~%"),
-      phiSlowD_c : [(T_e/q_e)*log(sqrt(2*%pi)*GammaJacIonB_e/(m0JacIonB_e*sqrt(T_e/m_e)))],
+      phiSlowD_c : [(T_e/q_e)*log(GammaJacIonB_e/x3HalfMomJacElcB_e)],
       printf(fh,"  if ((isfinite(~a)) && (~a>0.) && (~a>0.)) {~%",GammaJacIonB_e,GammaJacIonB_e,m0JacIonB_e),
       printf(fh,"    phiS_qp[0] = ~a;~%",float(expand(phiSlowD_c[1]))),
       printf(fh,"  } else {~%"),
@@ -106,21 +126,25 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
       printf(fh,"  }~%"),
       printf(fh,"~%"),
       phiSlowD_e : phiS_qp[0]
+
     ) else (
-      m0JacIonB_n    : makelist(0,i,1,ordNum),
+
+      m0JacIonB_n : makelist(0,i,1,ordNum),
       GammaJacIonB_n : makelist(0,i,1,ordNum),
+      x3HalfMomJacElcB_n : makelist(0,i,1,ordNum),
       for i : 1 thru ordNum do (
         nOrd : normOrds[i],
         cSub : makelist(varsLowD[d]=normOrds[i][d],d,1,dim-1),
 
-        m0JacIonB_n[i]    : subst(cSub, m0JacIonB_e),
-        GammaJacIonB_n[i] : subst(cSub, GammaJacIonB_e)
+        m0JacIonB_n[i] : subst(cSub, m0JacIonB_e),
+        GammaJacIonB_n[i] : subst(cSub, GammaJacIonB_e),
+        x3HalfMomJacElcB_n[i] : subst(cSub, x3HalfMomJacElcB_e)
       ),
 
       printf(fh,"  double phiS_qp[~a];~%", ordNum),
       phiS_n : makelist(0,i,1,ordNum),
       for i : 1 thru ordNum do (
-        phiS_n[i] : (T_e/q_e)*log(sqrt(2*%pi)*GammaJacIonB_n[i]/(m0JacIonB_n[i]*sqrt(T_e/m_e))),
+        phiS_n[i] : (T_e/q_e)*log(GammaJacIonB_n[i]/x3HalfMomJacElcB_n[i]),
         printf(fh,"  if ((isfinite(~a)) && (~a>0.) && (~a>0.)) {~%",float(GammaJacIonB_n[i]),float(GammaJacIonB_n[i]),float(m0JacIonB_n[i])),
         printf(fh,"    phiS_qp[~a] = ~a;~%",i-1,float(expand(phiS_n[i]))),
         printf(fh,"  } else {~%"),
@@ -138,6 +162,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
         )
       ),
       phiSlowD_e : doExpand(phiSlowD_c, basisLowD)
+
     ),
 
     phiS_c : calcInnerProdList(vars, 1, basis, phiSlowD_e),
@@ -155,7 +180,7 @@ genSheathCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
 
 genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
   /* Compute the potential in the domain volume using Gaussian quadrature. */
-  [numQuad,vars,basis,numB,normOrds,weights,ordNum,m0JacIon_e,
+  [numQuad,vars,basis,numB,bmagBasis,normOrds,weights,ordNum,m0JacIon_e,
   jacInv_e,m0Ion_c,m0Ion_e,m0Ion_noZero_c,m0IonS_e,phiS_e,m0Ion_n,m0IonS_n,
   phiS_n,nOrd,cSub,phi_n,phi_c],
 
@@ -163,6 +188,8 @@ genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
 
   [vars, basis] : loadBasis(basisNm, dim, polyOrder),
   numB : length(basis),
+
+  bmagBasis : getAxisymmetricConfBasis(basis),
 
   /* Get the Gaussian quadrature weights and ordinates (in [-1,1] space) */
   [normOrds, weights] : gaussOrdWeight(numQuad,dim),
@@ -179,7 +206,7 @@ genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
 
   m0JacIon_e : doExpand1(m0JacIon, basis),
 
-  jacInv_e : doExpand1(jacInv,basis),
+  jacInv_e : doExpand1(jacInv,bmagBasis),
   m0Ion_c : calcInnerProdList(vars, jacInv_e, basis, m0JacIon_e),
   m0Ion_e : doExpand(m0Ion_c,basis),
   m0Ion_noZero_c : makelistNoZeros1(m0Ion_c, m0Ion),

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
@@ -30,9 +30,9 @@ for bInd : 1 thru length(bName) do (
      for ci : 1 thru 3 do (
 
        for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-         printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *cmag, const double *jacobtotInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
+         printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(double sheathDirDx, double q_e, double m_e, double T_e, const double *cmag, const double *jacobtotInv, const double *GammaJac_i, const double *m0Ion, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
        ),
-       printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_phi_calc_~ax_~a_p~a(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi); ~%", ci, bName[bInd], pi),
+       printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_phi_calc_~ax_~a_p~a(double q_e, double T_e, const double *m0Ion, const double *sheathvals, double *phi); ~%", ci, bName[bInd], pi),
        printf(fh, "~%")
 
      ),

--- a/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
+++ b/maxima/g0/ambi_bolt_potential/ms-ambi_bolt_potential-header.mac
@@ -18,7 +18,7 @@ printf(fh, "//------------------------------------------------------------------
 printf(fh, "#pragma once~%")$
 printf(fh, "~%")$
 printf(fh, "#include <gkyl_util.h>~%")$
-printf(fh, "#include <math>~%~%")$
+printf(fh, "#include <math.h>~%~%")$
 printf(fh, "~%")$
 
 printf(fh, "EXTERN_C_BEG~%")$
@@ -30,7 +30,7 @@ for bInd : 1 thru length(bName) do (
      for ci : 1 thru 3 do (
 
        for bS : 1 thru 2 do ( /* One kernel for each of lower and upper boundaries. */
-         printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
+         printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_sheath_calc_~a_~ax_~a_p~a(double sheathDirDx, double q_e, double m_e, double T_e, const double *jacInv, const double *cmag, const double *jacobtotInv, const double *GammaJac_i, const double *m0JacIon, double *out); ~%", boundaryStr[bS], ci, bName[bInd], pi)
        ),
        printf(fh, "  GKYL_CU_DH void ambi_bolt_potential_phi_calc_~ax_~a_p~a(double q_e, double T_e, const double *jacInv, const double *m0JacIon, const double *sheathvals, double *phi); ~%", ci, bName[bInd], pi),
        printf(fh, "~%")


### PR DESCRIPTION
G0 PR: https://github.com/ammarhakim/gkylzero/pull/668

This was merged a while ago, but the gkylcas PR never happened. The G0 PR has more details of the change made.

I checked these changed files and they reproduce what is on G0/main

The Boltzmann electron model has been using the following definition of the sheath potential
$$\phi_s = \frac{T_e}{e}\ln\left(\frac{n_{i,s}v_{te}}{\sqrt{2\pi}\Gamma_{i,s}}\right)$$
but this arises from assuming that the advecting velocity along the field line is $v_\parallel$. In field-aligned coordinates, neglecting perpendicular drifts and using $b_2=0$ the electron kinetic equation is
$\frac{\partial(J_x B f_e)}{\partial t} + \frac{\partial}{\partial z} \frac{\mathcal{C}}{J_x B}v_\parallel J_x B f_e + \frac{\partial}{\partial v_\parallel}\dot{v_\parallel}J_x B f_e = 0$
Hence, assuming a non-drifting Maxwellian $f_e$ with density $n_i$ (assuming quasineutrality) and temperature $T_e=mv_{te}^2$ , the electron particle flux (multiplied by $J_x$) out of the z boundary is
$J_x\Gamma = \frac{\mathcal{C}}{J_x B}\frac{n_iv_{te}}{\sqrt{2\pi}}$
So our Boltzmann elc model needs to use the following for the sheath potential:
$$\phi_s = \frac{T_e}{e}\ln\left(\frac{\mathcal{C}}{J_x B}\frac{n_{i,s}v_{te}}{\sqrt{2\pi}\Gamma_{i,s}}\right)$$