### PR TITLE
Pass nu to LBO primitive moment kernels to avoid creating singular matrices

### DIFF
--- a/maxima/g0/pkpm/SelfPrimMoms-vlasovPKPMFuncs.mac
+++ b/maxima/g0/pkpm/SelfPrimMoms-vlasovPKPMFuncs.mac
@@ -59,11 +59,12 @@ calcSelfPrimMoms(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block([bP,bC,NP
   nodes : eval_string(sconcat("nodesSer", cdim, "xp", 1)),
 
   /* Function declaration with input/output variables. */
-  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *vlasov_pkpm_moms, const double *boundary_corrections) ~%{ ~%", funcNm, polyOrder),
+  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *vlasov_pkpm_moms, const double *boundary_corrections, const double *nu) ~%{ ~%", funcNm, polyOrder),
   printf(fh, "  // A:                    Matrix to be inverted to solve Ax = rhs (set by this function). ~%"),
   printf(fh, "  // rhs:                  right-hand side of Ax = rhs (set by this function). ~%"),
   printf(fh, "  // vlasov_pkpm_moms:     [rho, p_parallel, p_perp], Moments computed from kinetic equation in pkpm model. ~%"),
   printf(fh, "  // boundary_corrections: boundary corrections to vtSq. ~%"),
+  printf(fh, "  // nu:                   collision frequency. ~%"),
   printf(fh, " ~%"),
 
   /* Get pointers to PKPM moments, rho, p_parallel, p_perp, M1. M1 used here to insure collision operator conserves momentum */

--- a/maxima/g0/pkpm/ms-PrimMoments-vlasov-pkpm-header.mac
+++ b/maxima/g0/pkpm/ms-PrimMoments-vlasov-pkpm-header.mac
@@ -27,7 +27,7 @@ minCdim      : [minCdim_Ser, minCdim_Tensor]$
 maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
 
 printPKPMPrototype(deco, ci, bStr, pi) := block([si],
-  printf(fh, "~avoid pkpm_self_prim_moments_~ax1v_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *vlasov_pkpm_moms, const double *boundary_corrections); ~%", deco, ci, bStr, pi),
+  printf(fh, "~avoid pkpm_self_prim_moments_~ax1v_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *vlasov_pkpm_moms, const double *boundary_corrections, const double *nu); ~%", deco, ci, bStr, pi),
   printf(fh, "~%")  
 )$
 

--- a/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
+++ b/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
@@ -80,12 +80,14 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   printf(fh, sconcat("  double m2r[~a] = {0.0}; ~%"), numB),
   printf(fh, sconcat("  double cMr[~a] = {0.0}; ~%"), udim*numB),
   printf(fh, sconcat("  double cEr[~a] = {0.0}; ~%"), numB),
+  printf(fh, sconcat("  double u_selfr[~a] = {0.0}; ~%"), udim*numB),
+  printf(fh, sconcat("  double u_otherr[~a] = {0.0}; ~%"), udim*numB),
   printf(fh, " ~%"),
 
   /* If cell average collsion frequency is not positive, set moments to 1 and
      corrections to 0 to avoid inversion of singular system. In this case the
      collision operator will be turned off anyway. */
-  printf(fh, "  if (nu[0] > 0.0) { ~%"),
+  printf(fh, "  if (nu[0] > 0.0 && moms_self[~a] > 0.0) { ~%",numB*(1+udim)),
   printf(fh, "  ~%"),
 
   /* In order to avoid dividing by very small, negative or zero densities
@@ -121,6 +123,8 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   writeCExprs1s(m2r,makelist(moms_self[i+numB*(1+udim)],i,0,numB-1)),
   writeCExprs1s(cMr,makelist(boundary_corrections[i],i,0,udim*numB-1)),
   writeCExprs1s(cEr,makelist(boundary_corrections[i+udim*numB],i,0,numB-1)),
+  writeCExprs1s(u_selfr,makelist(u_self[i-1],i,1,udim*numB)),
+  writeCExprs1s(u_otherr,makelist(u_other[i-1],i,1,udim*numB)),
   printf(fh, "  } else { ~%"),
   /* Use the cell average of m0, m1 and m2. */
   writeCExprs1s(m0r,append([moms_self[0]],makelist(0.0,i,1,numB-1))),
@@ -136,6 +140,8 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   ),
   writeCExprs1s(m2r,append([moms_self[numB*(1+udim)]],makelist(0.0,i,1,numB-1))),
   writeCExprs1s(cEr,append([boundary_corrections[udim*numB]],makelist(0.0,i,1,numB-1))),
+  writeCExprs1s(u_selfr, append([u_self[0]],makelist(0.0,i,2,udim*numB))),
+  writeCExprs1s(u_otherr,append([u_other[0]],makelist(0.0,i,2,udim*numB))),
   printf(fh, "  } ~%"),
   printf(fh, " ~%"),
 
@@ -155,6 +161,8 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   ),
   writeCExprs1s(m2r,append([1.0],makelist(0.0,i,1,numB-1))),
   writeCExprs1s(cEr,append([0.0],makelist(0.0,i,1,numB-1))),
+  writeCExprs1s(u_selfr, append([1.0],makelist(0.0,i,2,udim*numB))),
+  writeCExprs1s(u_otherr,append([1.0],makelist(0.0,i,2,udim*numB))),
 
   printf(fh, "  ~%"),
   printf(fh, "  }~%"),
@@ -193,14 +201,14 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
 
   for vd : 1 thru udim do (
     /* Expand u function and create a list of expansion coefficients. */
-    u_self_c   : makelist(u_self[i-1],i,1,numB),
-    u_other_c  : makelist(u_other[i-1],i,1,numB),
+    u_self_c   : makelist(u_selfr[i-1],i,1,numB),
+    u_other_c  : makelist(u_otherr[i-1],i,1,numB),
     m1_c       : makelist(m1r[i-1],i,1,numB),
     cM_c       : makelist(cMr[i-1],i,1,numB),
     uCross_c   : makelist(uCross[i-1],i,1,numB),
     /* Use the vd component of u, m1 and cM. */
-    u_self_c   : subst(makelist(u_self[i]=u_self[(vd-1)*numB+i],i,0,numB-1),u_self_c),
-    u_other_c  : subst(makelist(u_other[i]=u_other[(vd-1)*numB+i],i,0,numB-1),u_other_c),
+    u_self_c   : subst(makelist(u_selfr[i]=u_selfr[(vd-1)*numB+i],i,0,numB-1),u_self_c),
+    u_other_c  : subst(makelist(u_otherr[i]=u_otherr[(vd-1)*numB+i],i,0,numB-1),u_other_c),
     m1_c       : subst(makelist(m1r[i]=m1r[(vd-1)*numB+i],i,0,numB-1),m1_c),
     cM_c       : subst(makelist(cMr[i]=cMr[(vd-1)*numB+i],i,0,numB-1),cM_c),
     uCross_c   : subst(makelist(uCross[i]=uCross[(vd-1)*numB+i],i,0,numB-1),uCross_c),
@@ -258,11 +266,11 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   ),
 
   /* Need the weak dot product of u_self and cM. */
-  u_self_e   : doExpand1(u_self,basis),
-  u_other_e  : doExpand1(u_other,basis),
+  u_self_e   : doExpand1(u_selfr,basis),
+  u_other_e  : doExpand1(u_otherr,basis),
   cM_e       : doExpand1(cMr, basis),
-  u_self_e   : psubst(makelist(u_self[i]=u_self[a0+i],i,0,numB-1),u_self_e),
-  u_other_e  : psubst(makelist(u_other[i]=u_other[a0+i],i,0,numB-1),u_other_e),
+  u_self_e   : psubst(makelist(u_selfr[i]=u_selfr[a0+i],i,0,numB-1),u_self_e),
+  u_other_e  : psubst(makelist(u_otherr[i]=u_otherr[a0+i],i,0,numB-1),u_other_e),
   cM_e       : psubst(makelist(cMr[i]=cMr[a0+i],i,0,numB-1),cM_e),
   ucMSelf_c  : calcInnerProdList(vars,u_self_e,basis,cM_e),
   ucMOther_c : calcInnerProdList(vars,u_other_e,basis,cM_e),
@@ -323,7 +331,7 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
     printf(fh, "    ~a += ~a; ~%", uM1Other[i-1], expr[i])
   ),
   tempVars : [],
-  sqCoeffs : [makelist(u_self[a0+k-1],k,1,numB),makelist(u_other[a0+k-1],k,1,numB)],
+  sqCoeffs : [makelist(u_selfr[a0+k-1],k,1,numB),makelist(u_otherr[a0+k-1],k,1,numB)],
   tempVars : writeCIncrExprsCollect1noPowers(uSumSq, uSumSq_c, [dx], sqCoeffs, tempVars),
   printf(fh, "  } ~%"),
   printf(fh, " ~%"),

--- a/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
+++ b/maxima/g0/prim_moments/CrossPrimMomsLBO.mac
@@ -58,12 +58,13 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   numB : length(basis),
 
   /* Function declaration with input/output variables. */
-  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *boundary_corrections) ~%{ ~%", funcNm),
+  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *boundary_corrections, const double *nu) ~%{ ~%", funcNm),
   printf(fh, "  // greene:               Greene's factor. ~%"),
   printf(fh, "  // m_:                   mass. ~%"),
   printf(fh, "  // moms:                 moments of the distribution function. ~%"),
   printf(fh, "  // prim_mom              self primitive moments: mean flow velocity and thermal speed squared. ~%"),
   printf(fh, "  // boundary_corrections: corrections to momentum and energy conservation due to finite velocity space. ~%"),
+  printf(fh, "  // nu:                   Collision frequency. ~%"),
   printf(fh, " ~%"),
 
   /* Create pointers to u and vtsq of each species. */
@@ -72,6 +73,20 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   printf(fh, "  const double *u_other = &prim_mom_other[~a];~%", 0*numB),
   printf(fh, "  const double *vtsq_other = &prim_mom_other[~a];~%", udim*numB),
   printf(fh, " ~%"),
+
+  /* Declare new buffers where moments are stored. */
+  printf(fh, sconcat("  double m0r[~a] = {0.0}; ~%"), numB),
+  printf(fh, sconcat("  double m1r[~a] = {0.0}; ~%"), udim*numB),
+  printf(fh, sconcat("  double m2r[~a] = {0.0}; ~%"), numB),
+  printf(fh, sconcat("  double cMr[~a] = {0.0}; ~%"), udim*numB),
+  printf(fh, sconcat("  double cEr[~a] = {0.0}; ~%"), numB),
+  printf(fh, " ~%"),
+
+  /* If cell average collsion frequency is not positive, set moments to 1 and
+     corrections to 0 to avoid inversion of singular system. In this case the
+     collision operator will be turned off anyway. */
+  printf(fh, "  if (nu[0] > 0.0) { ~%"),
+  printf(fh, "  ~%"),
 
   /* In order to avoid dividing by very small, negative or zero densities
      use the cell averages when m0,m2,vtSq<0 at one of the corners. */
@@ -99,12 +114,6 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
     printf(fh, " ~%")
   ),
 
-  /* Declare new buffers where moments are stored. */
-  printf(fh, sconcat("  double m0r[~a] = {0.0}; ~%"), numB),
-  printf(fh, sconcat("  double m1r[~a] = {0.0}; ~%"), udim*numB),
-  printf(fh, sconcat("  double m2r[~a] = {0.0}; ~%"), numB),
-  printf(fh, sconcat("  double cMr[~a] = {0.0}; ~%"), udim*numB),
-  printf(fh, sconcat("  double cEr[~a] = {0.0}; ~%"), numB),
   printf(fh, "  if (notCellAvg) { ~%"),
   /* Use the original expansion polynomial. */
   writeCExprs1s(m0r,makelist(moms_self[i],i,0,numB-1)),
@@ -129,6 +138,27 @@ calcCrossPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   writeCExprs1s(cEr,append([boundary_corrections[udim*numB]],makelist(0.0,i,1,numB-1))),
   printf(fh, "  } ~%"),
   printf(fh, " ~%"),
+
+  printf(fh, "  } else { ~%"),
+  printf(fh, "  ~%"),
+
+  writeCExprs1s(m0r,append([1.0],makelist(0.0,i,1,numB-1))),
+  for vd : 1 thru udim do (
+    expr : float(expand(append([1.0],makelist(0.0,i,1,numB-1)))),
+    for i : 1 thru length(expr) do (
+      printf(fh, "    ~a = ~a; ~%", m1r[(vd-1)*numB+i-1], expr[i])
+    ),
+    expr : float(expand(append([0.0],makelist(0.0,i,1,numB-1)))),
+    for i : 1 thru length(expr) do (
+      printf(fh, "    ~a = ~a; ~%", cMr[(vd-1)*numB+i-1], expr[i])
+    )
+  ),
+  writeCExprs1s(m2r,append([1.0],makelist(0.0,i,1,numB-1))),
+  writeCExprs1s(cEr,append([0.0],makelist(0.0,i,1,numB-1))),
+
+  printf(fh, "  ~%"),
+  printf(fh, "  }~%"),
+  printf(fh, "  ~%"),
 
   /* Expansion in configuration space basis and coefficients
      of m0, m2 and the Greene factor. */

--- a/maxima/g0/prim_moments/SelfPrimMomsLBO.mac
+++ b/maxima/g0/prim_moments/SelfPrimMomsLBO.mac
@@ -48,12 +48,26 @@ calcSelfPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   NC : length(bC),
 
   /* Function declaration with input/output variables. */
-  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *moms, const double *boundary_corrections) ~%{ ~%", funcNm, polyOrder),
+  printf(fh, "GKYL_CU_DH void ~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *moms, const double *boundary_corrections, const double *nu) ~%{ ~%", funcNm, polyOrder),
   printf(fh, "  // A:                    Matrix to be inverted to solve Ax = rhs (set by this function). ~%"),
   printf(fh, "  // rhs:                  right-hand side of Ax = rhs (set by this function). ~%"),
   printf(fh, "  // moms:                 moments of the distribution function (Zeroth, First, and Second in single array). ~%"),
   printf(fh, "  // boundary_corrections: boundary corrections to u and vtSq. ~%"),
+  printf(fh, "  // nu:                   collision frequency. ~%"),
   printf(fh, " ~%"),
+
+  /* Declare new buffers where moments and boundary corrections are stored. */
+  printf(fh, "  double m0r[~a] = {0.0}; ~%", NC),
+  printf(fh, "  double m1r[~a] = {0.0}; ~%", udim*NC),
+  printf(fh, "  double cMr[~a] = {0.0}; ~%", udim*NC),
+  printf(fh, "  double cEr[~a] = {0.0}; ~%", NC),
+  printf(fh, "  ~%"),
+
+  /* If cell average collsion frequency is not positive, set moments to 1 and
+     corrections to 0 to avoid inversion of singular system. In this case the
+     collision operator will be turned off anyway. */
+  printf(fh, "  if (nu[0] > 0.0) { ~%"),
+  printf(fh, "  ~%"),
 
   /* In order to avoid dividing by very small, negative or zero densities
      use the cell average operations when m0,m2<0 at one of the corners. */
@@ -71,12 +85,6 @@ calcSelfPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
     printf(fh, "  if (notCellAvg && (~a < 0)) notCellAvg = false; ~%", m2Corners[i])
   ),
   printf(fh, " ~%"),
-
-  /* Declare new buffers where moments and boundary corrections are stored. */
-  printf(fh, "  double m0r[~a] = {0.0}; ~%", NC),
-  printf(fh, "  double m1r[~a] = {0.0}; ~%", udim*NC),
-  printf(fh, "  double cMr[~a] = {0.0}; ~%", udim*NC),
-  printf(fh, "  double cEr[~a] = {0.0}; ~%", NC),
 
   printf(fh, "  if (notCellAvg) { ~%"),
   /* Use the original expansion polynomial. */
@@ -115,8 +123,37 @@ calcSelfPrimMomsLBO(fh, funcNm, cdim, vdim, basisFun, polyOrder) := block(
   for i : 1 thru length(expr) do (
     printf(fh,"    gkyl_mat_set(rhs,~a,0,~a); ~%", i-1+udim*NC, expr[i])
   ),
-  printf(fh, "  } ~%"),
+  printf(fh, "  }~%"),
   printf(fh, " ~%"),
+
+  printf(fh, "  } else { ~%"),
+  printf(fh, "  ~%"),
+
+  /* Use the cell average of m0 and m1. */
+  writeCExprs1s(m0r,append([1.0],makelist(0.0,i,1,NC-1))),
+  for vd : 1 thru udim do (
+    expr : float(expand(append([1.0],makelist(0.0,i,1,NC-1)))),
+    for i : 1 thru length(expr) do (
+      printf(fh, "    ~a = ~a; ~%", m1r[(vd-1)*NC+i-1], expr[i])
+    ),
+    for i : 1 thru length(expr) do (
+      printf(fh,"    gkyl_mat_set(rhs,~a,0,~a); ~%", i-1, expr[i])
+    ),
+    expr : float(expand(append([0.0],makelist(0.0,i,1,NC-1)))),
+    for i : 1 thru length(expr) do (
+      printf(fh, "    ~a = ~a; ~%", cMr[(vd-1)*NC+i-1], expr[i])
+    )
+  ),
+  writeCExprs1s(cEr,append([0.0],makelist(0.0,i,1,NC-1))),
+  /* Use cell average of 2nd moment. */
+  expr : float(expand(append([1.0],makelist(0.0,i,1,NC-1)))),
+  for i : 1 thru length(expr) do (
+    printf(fh,"    gkyl_mat_set(rhs,~a,0,~a); ~%", i-1+udim*NC, expr[i])
+  ),
+
+  printf(fh, "  ~%"),
+  printf(fh, "  }~%"),
+  printf(fh, "  ~%"),
 
   /* Expansion in configuration space basis and coefficients of m0. */
   m0_e : doExpand1(m0r, bC),

--- a/maxima/g0/prim_moments/ms-gkPrimMoments-header.mac
+++ b/maxima/g0/prim_moments/ms-gkPrimMoments-header.mac
@@ -53,10 +53,10 @@ for bInd : 1 thru length(bName) do (
       if (ci+vi>4 and maxPolyOrderB > 2) then maxPolyOrderB : 2,
       for pi : minPolyOrderB thru maxPolyOrderB do (
         /* Primitive moments for self-collision terms with p>1. */
-        printf(fh, "GKYL_CU_DH void gyrokinetic_self_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *moms, const double *boundary_corrections); ~%", ci, vi, bName[bInd], pi),
+        printf(fh, "GKYL_CU_DH void gyrokinetic_self_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *moms, const double *boundary_corrections, const double *nu); ~%", ci, vi, bName[bInd], pi),
 
         /* Primitive moments for cross-collision GkLBO terms. */
-        printf(fh, "GKYL_CU_DH void gyrokinetic_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self,~%  const double m_other, const double *moms_other, const double *prim_mom_other,~%  const double *boundary_corrections); ~%", ci, vi, bName[bInd], pi),
+        printf(fh, "GKYL_CU_DH void gyrokinetic_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self,~%  const double m_other, const double *moms_other, const double *prim_mom_other,~%  const double *boundary_corrections, const double *nu); ~%", ci, vi, bName[bInd], pi),
 
         printf(fh, "~%")
       )

--- a/maxima/g0/prim_moments/ms-vlasovPrimMoments-header.mac
+++ b/maxima/g0/prim_moments/ms-vlasovPrimMoments-header.mac
@@ -32,8 +32,8 @@ maxVdim      : [maxVdim_Ser, maxVdim_Tensor]$
 
 printPrototype(deco, ci, vi, bStr, pi) := block([si],
   /* Primitive moments for collision terms. */
-  printf(fh, "~avoid vlasov_self_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *moms, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
-  printf(fh, "~avoid vlasov_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *boundary_corrections); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~avoid vlasov_self_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs,~%  const double *moms, const double *boundary_corrections, const double *nu); ~%", deco, ci, vi, bStr, pi),
+  printf(fh, "~avoid vlasov_cross_prim_moments_~ax~av_~a_p~a(struct gkyl_mat *A, struct gkyl_mat *rhs, const double *greene, const double m_self, const double *moms_self, const double *prim_mom_self, const double m_other, const double *moms_other, const double *prim_mom_other, const double *boundary_corrections, const double *nu); ~%", deco, ci, vi, bStr, pi),
   printf(fh, "~%")  
 )$
 


### PR DESCRIPTION
Recently (https://github.com/ammarhakim/gkylzero/pull/705) we incorporated the collision frequency into the primitive moment linear problem in order to conserve momentum and energy when using a spatial and time dependent collision frequency $\nu(x,t)$. So now, the self primitive moments are computed via solving the system
$\nu ~ u_{\parallel} ~ M_0 - \nu ~ v_t^2 ~ c_M = \nu ~ M_1$
$\nu ~ u_{\parallel} ~ M_1 + \nu ~ v_t^2 ~ (3 M_0 - c_E)  = \nu ~ M_2$
where $c_M$ and $c_E$ are boundary corrections.

But note that there are protections on $\nu(x,t)$ to avoid problematic values. The collision frequency $\nu(x,t) \propto n$, so when we detect that $n\leq0$ is are a quadrature point, $\nu(x,t)$ is set to zero there. This can make $\nu(x,t)=0$ in a cell, which would make the LHS matrix of the system shown above become singular. This wasn't apparent until recently when more normNu sims were done.

To address this we change the primitive moment kernels so that so that when $nu(x,t)^{(0)}$ and $M_2^{(0)}$ (the cell average coefficients of $\nu$ and $M_2$ are greater than 0, it continues as before. But if either of these is not positive, when we set the entries corresponding to the LHS quantities in the system above to 1. This is just so that the matrix is not singular and our linear solvers don't error out. The resulting primitive moments $u_{\parallel}$ and $v_t^2$ will be meaningless in this cell, but that's ok because LBO kernels are wrapped in an if-statement that turns them off if $M_2^{(0)}$ is not positive.

The signature of the PKPM lbo had to change because it uses common infrastructure, but the contents of their kernels didn't change.