### PR TITLE
GK anomalous diffusion operator Maxima

### DIFF
--- a/maxima/g0/dg_diffusion_gyrokinetic/diffFuncs-gyrokinetic-boundary-diag.mac
+++ b/maxima/g0/dg_diffusion_gyrokinetic/diffFuncs-gyrokinetic-boundary-diag.mac
@@ -3,16 +3,20 @@ load("recovery")$
 load("out-scripts")$
 fpprec : 24$
 
+/* NOTE: this is based on the maxima for boundary_surf, but note that the use
+   of fSkin and fEdge are different because we assume that this kernel
+   is called in the ghost cell (so fEdge is actually the skin f, and fSkin is the ghost f). */
+
 /* For higher order diffusion and spatially varying diffusion coefficient, it
    is not clear where the coefficient should appear, e.g. d_xxx( D d_x(f) )
    or d_xx( D d_xx(f)); different models appear in the literature. Since we don't
    a good physical justfication for either we just arbitrarily pick one. */
 
-genDGdiffGyrokineticKernelBoundarySurf(fh, funcNm, cdim, vdim, basisType, polyOrder, dir, diffOrder) := block(
+genDGdiffGyrokineticKernelBoundaryDiag(fh, funcNm, cdim, vdim, basisType, polyOrder, dir, diffOrder) := block(
   [constCoeff,dim,bType,vars,basis,varsC,basisC,vSub,numBasis,surfVar,surfIntVars,
-   coeffType,coeff_e,coeff_c,vol_incr_c,qEdge_c,qSkin_c,qEdge_e,qSkin_2,jacobgeo_inv_e,
-   fEdge_c,fSkin_c,fEdge_e,fSkin_e,hOrder,bcRecCond,i,fRecr_e,edgeSurf_incr_c,fRecl_e,
-   boundSurf_incr_c,vol_out,diff_out,edge_out],
+   coeffType,coeff_e,coeff_c,qSkin_c,qGhost_c,qSkin_e,qGhost_2,jacobgeo_inv_e,
+   fSkin_c,fGhost_c,fSkin_e,fGhost_e,hOrder,bcRecCond,i,fRecr_e,fRecl_e,
+   boundSurf_incr_c,diff_out],
 
   printf(fh, "#include <gkyl_dg_diffusion_gyrokinetic_kernels.h>~%~%"),
 
@@ -43,75 +47,59 @@ genDGdiffGyrokineticKernelBoundarySurf(fh, funcNm, cdim, vdim, basisType, polyOr
       coeff_e : doExpand(coeff_c, basisC)
     ),
   
-    printf(fh, "GKYL_CU_DH double ~a_~acoeff(const double *w, const double *dx, const double *coeff, const double *jacobgeo_inv, int edge, const double *qEdge, const double *qSkin, double* GKYL_RESTRICT out) ~%", funcNm, coeffType),
+    printf(fh, "GKYL_CU_DH double ~a_~acoeff(const double *w, const double *dx, const double *coeff, const double *jacobgeo_inv, int edge, const double *qSkin, const double *qGhost, double* GKYL_RESTRICT out) ~%", funcNm, coeffType),
     printf(fh, "{~%"),
     printf(fh, "  // w[NDIM]: Cell-center coordinate.~%"),
     printf(fh, "  // dxv[NDIM]: Cell length.~%"),
     printf(fh, "  // coeff: Diffusion coefficient.~%"),
     printf(fh, "  // jacobgeo_inv: one divided by the configuration space Jacobian.~%"),
     printf(fh, "  // edge: -1 for lower boundary, +1 for upper boundary.~%"),
-    printf(fh, "  // qSkin/Edge: scalar field in skin and egde cells.~%"),
+    printf(fh, "  // qGhost/qSkin: scalar field in skin and egde cells.~%"),
     printf(fh, "  // out: Incremented output.~%~%"),
 
     printf(fh, "  const double rdx2Sq = pow(2./dx[~a],~a.);~%", dir-1, diffOrder),
     printf(fh, "~%"),
 
-    qEdge_c : makelist(qEdge[i-1], i, 1, numBasis),
     qSkin_c : makelist(qSkin[i-1], i, 1, numBasis),
-    qEdge_e : doExpand(qEdge_c, basis),
+    qGhost_c : makelist(qGhost[i-1], i, 1, numBasis),
     qSkin_e : doExpand(qSkin_c, basis),
+    qGhost_e : doExpand(qGhost_c, basis),
 
     if constCoeff then (
-      fSkin_c : makelist(qSkin[i-1], i, 1, numBasis),
-      fEdge_c : makelist(qEdge[i-1], i, 1, numBasis)
+      fGhost_c : makelist(qGhost[i-1], i, 1, numBasis),
+      fSkin_c : makelist(qSkin[i-1], i, 1, numBasis)
     ) else (
       /* Divide jacobGeo*f by jacobGeo. */
       jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
   
+      fGhost_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, qGhost_e),
       fSkin_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, qSkin_e),
-      fEdge_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, qEdge_e),
 
       /* Divide jacobGeo*f by jacobGeo. */
+      printf(fh, "  double fGhost[~a];~%", numBasis),
+      writeCExprsNoExpand1(fGhost, fGhost_c),
+      fGhost_c : makelist(fGhost[i-1], i, 1, numBasis),
+      printf(fh, "~%"),
       printf(fh, "  double fSkin[~a];~%", numBasis),
       writeCExprsNoExpand1(fSkin, fSkin_c),
       fSkin_c : makelist(fSkin[i-1], i, 1, numBasis),
-      printf(fh, "~%"),
-      printf(fh, "  double fEdge[~a];~%", numBasis),
-      writeCExprsNoExpand1(fEdge, fEdge_c),
-      fEdge_c : makelist(fEdge[i-1], i, 1, numBasis),
       printf(fh, "~%")
     ),
 
+    fGhost_e : doExpand(fGhost_c, basis),
     fSkin_e : doExpand(fSkin_c, basis),
-    fEdge_e : doExpand(fEdge_c, basis),
-
-    /* Volume increment (dimensional factor included later). */
-    vol_incr_c : ((-1)^(diffOrder/2+1))*calcInnerProdList(vars, 1, diff(coeff_e*diff(basis,surfVar,diffOrder/2),surfVar,diffOrder/2), fSkin_e),
-    printf(fh, "  double vol_incr[~a] = {0.0}; ~%", numBasis),
-    writeCExprs1(vol_incr, vol_incr_c),
-    printf(fh, "~%"),
 
     hOrder  : 2*polyOrder+1,
   
     bcRecCond : makelist([val=0,der=2*i-1],i,1,diffOrder/2),
 
-    printf(fh, "  double edgeSurf_incr[~a] = {0.0}; ~%", numBasis),
     printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", numBasis),
     printf(fh, "~%"),
 
     printf(fh, "  if (edge == -1) { ~%~%"),
 
-    fRecr_e  : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fSkin_c), dg(fEdge_c)),
-
-    /* Contribution from the skin-edge surface from integration by parts
+    /* Contribution from the boundary surface from integration by parts
        diffOrder times. Extra - sign in diffOrder=4 not included yet. */
-    edgeSurf_incr_c :
-       sum( calcInnerProdList(surfIntVars, (-1)^(i-1), subst(surfVar=1,diff(basis,surfVar,i-1)),
-                              subst(surfVar=0,diff(coeff_e*diff(fRecr_e,surfVar,diffOrder/2),surfVar,diffOrder/2-i)))
-           +calcInnerProdList(surfIntVars, (-1)^(diffOrder/2+i-1), subst(surfVar=1,diff(diff(basis,surfVar,diffOrder/2)*coeff_e,surfVar,i-1)),
-                              subst(surfVar=0,diff(fRecr_e,surfVar,diffOrder/2-i))),
-           i,1,diffOrder/2),
-
     fRecl_e  : calcRecov2CellGen(bType, surfVar, vars, polyOrder, apply(bcs,args(bcRecCond)), dg(fSkin_c)),
 
     boundSurf_incr_c :
@@ -121,25 +109,14 @@ genDGdiffGyrokineticKernelBoundarySurf(fh, funcNm, cdim, vdim, basisType, polyOr
                               subst(surfVar=0,diff(fRecl_e,surfVar,diffOrder/2-i))),
            i,1,diffOrder/2),
 
-    writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
-    printf(fh, "~%"),
     writeCExprs1(boundSurf_incr, boundSurf_incr_c),
     printf(fh, "~%"),
   
-    /* otherwise edge == +1, we are doing the right edge boundary and the skin cell needs to be evauluated at -1 */
+    /* otherwise edge == +1, we are doing the right edge boundary and the skin cell needs to be evaluated at -1 */
     printf(fh, "  } else { ~%~%"),
 
-    fRecl_e  : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fEdge_c), dg(fSkin_c)),
-  
-    /* Contribution from the skin-edge surface from integration by parts
+    /* Contribution from the boundary surface from integration by parts
        diffOrder times. Extra - sign in diffOrder=4 not included yet. */
-    edgeSurf_incr_c :
-       sum( calcInnerProdList(surfIntVars, -(-1)^(i-1), subst(surfVar=-1,diff(basis,surfVar,i-1)),
-                              subst(surfVar=0,diff(coeff_e*diff(fRecl_e,surfVar,diffOrder/2),surfVar,diffOrder/2-i)))
-           +calcInnerProdList(surfIntVars, -(-1)^(diffOrder/2+i-1), subst(surfVar=-1,diff(diff(basis,surfVar,diffOrder/2)*coeff_e,surfVar,i-1)),
-                              subst(surfVar=0,diff(fRecl_e,surfVar,diffOrder/2-i))),
-           i,1,diffOrder/2),
-
     fRecr_e  : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fSkin_c), apply(bcs,args(bcRecCond))),
 
     boundSurf_incr_c :
@@ -149,21 +126,17 @@ genDGdiffGyrokineticKernelBoundarySurf(fh, funcNm, cdim, vdim, basisType, polyOr
                               subst(surfVar=0,diff(fRecr_e,surfVar,diffOrder/2-i))),
            i,1,diffOrder/2),
   
-    writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
-    printf(fh, "~%"),
     writeCExprs1(boundSurf_incr, boundSurf_incr_c),
     printf(fh, "~%"),
 
     printf(fh, "  }~%"),
     printf(fh, "~%"),
 
-    vol_out  : makelist(vol_incr[i-1],i,1,numBasis),
-    diff_out : makelist(edgeSurf_incr[i-1],i,1,numBasis),
-    edge_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
-    writeCIncrExprsNoExpand1(out, ((-1)^(diffOrder/2+1))*rdx2Sq*(diff_out + edge_out + vol_out)),
+    diff_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
+    writeCIncrExprsNoExpand1(out, ((-1)^(diffOrder/2+1))*rdx2Sq*diff_out),
     printf(fh, "~%"),
   
-    printf(fh, "  return 0.;~%"),  /* Return CFL frequency in volume kernel. */
+    printf(fh, "  return 0.;~%"),
     printf(fh, "}~%~%")
   )
 )$

--- a/maxima/g0/dg_diffusion_gyrokinetic/ms-dg_diffusion_gyrokinetic-boundary-diag.mac
+++ b/maxima/g0/dg_diffusion_gyrokinetic/ms-dg_diffusion_gyrokinetic-boundary-diag.mac
@@ -1,0 +1,67 @@
+kill(all)$
+load("dg_diffusion_gyrokinetic/diffFuncs-gyrokinetic-boundary-diag")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+vDims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser     , minCdim_Tensor     ]$
+maxCdim      : [maxCdim_Ser     , maxCdim_Tensor     ]$
+dirVars      : [[[x,vpar],[x,vpar,mu]],[[null],[x,y,vpar,mu]],[[null],[x,y,z,vpar,mu]]]$ 
+
+for bInd : 1 thru length(bName) do (
+  for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+      for vdim in vDims[cdim] do (
+        /* To apply applying diffusion in velocity space replace cdim with
+           cdim+vdim in the loop upper limit below. If you wish the diffusion
+           coefficient to depend on velocity space, make that change in the
+           function that generates the kernel too. */
+        for dir : 1 thru cdim do (
+          dirVar : dirVars[cdim][vdim][dir], 
+
+          fname : sconcat("~/max-out/dg_diffusion_gyrokinetic_order2_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          funcName : sconcat("dg_diffusion_gyrokinetic_order2_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+          fh : openw(fname),
+          print("Generating:", fname),
+          genDGdiffGyrokineticKernelBoundaryDiag(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir, 2),
+          close(fh),
+
+          fname : sconcat("~/max-out/dg_diffusion_gyrokinetic_order4_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          funcName : sconcat("dg_diffusion_gyrokinetic_order4_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+          fh : openw(fname),
+          print("Generating:", fname),
+          genDGdiffGyrokineticKernelBoundaryDiag(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir, 4),
+          close(fh),
+
+          if polyOrder > 1 then (
+            fname : sconcat("~/max-out/dg_diffusion_gyrokinetic_order6_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+            funcName : sconcat("dg_diffusion_gyrokinetic_order6_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+            fh : openw(fname),
+            print("Generating:", fname),
+            genDGdiffGyrokineticKernelBoundaryDiag(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir, 6),
+            close(fh)
+          )
+        )
+      )
+    )
+  )
+)$

--- a/maxima/g0/dg_diffusion_gyrokinetic/ms-dg_diffusion_gyrokinetic-header.mac
+++ b/maxima/g0/dg_diffusion_gyrokinetic/ms-dg_diffusion_gyrokinetic-header.mac
@@ -83,11 +83,15 @@ for bInd : 1 thru length(bName) do (
           for dO in diffOrders do (
             for cT in coeffTypeStr do (
               funcName : sconcat("dg_diffusion_gyrokinetic_order",dO,"_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, "_", cT),
-              funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *w, const double *dx, const double *coeff, cont double *jacobgeo_inv, const double *ql, const double *qc, const double *qr, double* GKYL_RESTRICT out);~%"),
+              funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *w, const double *dx, const double *coeff, const double *jacobgeo_inv, const double *ql, const double *qc, const double *qr, double* GKYL_RESTRICT out);~%"),
               printf(fh, funcSign),
 
               funcName : sconcat("dg_diffusion_gyrokinetic_order",dO,"_boundary_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, "_", cT),
-              funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *w, const double *dx, const double *coeff, cont double *jacobgeo_inv, int edge, const double *qSkin, const double *qEdge, double* GKYL_RESTRICT out);~%"),
+              funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *w, const double *dx, const double *coeff, const double *jacobgeo_inv, int edge, const double *qEdge, const double *qSkin, double* GKYL_RESTRICT out);~%"),
+              printf(fh, funcSign),
+
+              funcName : sconcat("dg_diffusion_gyrokinetic_order",dO,"_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, "_", cT),
+              funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *w, const double *dx, const double *coeff, const double *jacobgeo_inv, int edge, const double *qSkin, const double *qGhost, double* GKYL_RESTRICT out);~%"),
               printf(fh, funcSign)
             )
           ),

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-diag.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-diag.mac
@@ -16,7 +16,7 @@ bound_side : ["lower","upper"]$
 
 gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir, side, bcType) := block(
   [dim,bType,vars,basis,varsC,basisC,vSub,numBasis,surfVar,surfIntVars,numBasisC,
-   nuSkin_c,nuGhost_c,nuSkin_e,nuGhost_e,JfSkin_c,JfGhost_c,JfSkin_e,JfGhost_e,jacobgeo_inv_e,
+   nuSkin_c,nuGhost_c,nuSkin_e,nuGhost_e,JfSkin_c,JfGhost_c,JfSkin_e,JfGhost_e,jacobgeo_invSkin_e,jacobgeo_invGhost_e,
    fSkin_c,fGhost_c,fSkin_e,fGhost_e,fRecl_e,nuAv_l,nuSkin_l,fRecr_e,nuAv_r,nuSkin_r,
    boundSurf_incr_c,bound_out],
 
@@ -39,12 +39,12 @@ gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyO
   nuSkin_e : doExpand(nuSkin_c, basisC),
   nuGhost_e : doExpand(nuGhost_c, basisC),
   
-  printf(fh, "GKYL_CU_DH double ~a(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_inv, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out) ~%", funcNm),
+  printf(fh, "GKYL_CU_DH double ~a(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_invSkin, const double *jacobgeo_invGhost, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out) ~%", funcNm),
   printf(fh, "{~%"),
   printf(fh, "  // w[NDIM]: Cell-center coordinate.~%"),
   printf(fh, "  // dxv[NDIM]: Cell length.~%"),
   printf(fh, "  // nuSkin/nuGhost: Diffusivity in skin and ghost cells.~%"),
-  printf(fh, "  // jacobgeo_inv: reciprocal of the configuration space Jacobian.~%"),
+  printf(fh, "  // jacobgeo_invSkin/jacobgeo_invGhost: reciprocal of the configuration space Jacobian.~%"),
   printf(fh, "  // edge: -1 for lower boundary, +1 for upper boundary.~%"),
   printf(fh, "  // JfSkin/JfGhost: distribution times conf-space Jacobian in skin and ghost cells.~%"),
   printf(fh, "  // out: Incremented output.~%~%"),
@@ -58,10 +58,11 @@ gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyO
   JfGhost_e : doExpand(JfGhost_c, basis),
 
   /* Divide jacobGeo*f by jacobGeo. */
-  jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
+  jacobgeo_invSkin_e  : doExpand1(jacobgeo_invSkin, basisC),
+  jacobgeo_invGhost_e : doExpand1(jacobgeo_invGhost, basisC),
   
-  fSkin_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfSkin_e),
-  fGhost_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfGhost_e),
+  fSkin_c  : calcInnerProdList(vars, jacobgeo_invSkin_e, basis, JfSkin_e),
+  fGhost_c : calcInnerProdList(vars, jacobgeo_invGhost_e, basis, JfGhost_e),
 
   /* Divide jacobGeo*f by jacobGeo. */
   printf(fh, "  double fSkin[~a];~%", numBasis),

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-diag.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-diag.mac
@@ -1,0 +1,94 @@
+load("modal-basis")$
+load("recovery")$
+load("out-scripts")$
+fpprec : 24$
+
+gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir) := block(
+  [dim,bType,vars,basis,varsC,basisC,vSub,numBasis,surfVar,surfIntVars,numBasisC,
+   nuEdge_e,nuEdge_c,nuSkin_e,nuSkin_c,JfEdge_c,KfSkin_c,JfEdge_e,JfSkin_e,jacobgeo_inv_e,
+   fEdge_c,fSkin_c,fEdge_e,fSkin_e,fRecr_e,nuAv_r,edgeSurf_incr_c,nuSkin_l,
+   boundSurf_incr_c,edge_out,bound_out],
+
+  dim : cdim+vdim,
+
+  bType : basisType,
+  if polyOrder=1 then bType : "gkhyb",  /* Force p=1 to mean hybrid. */
+
+  [varsC, basisC, vars, basis, vSub] : loadGkBasis(basisType, cdim, vdim, polyOrder),
+  numBasis : length(basis),
+
+  surfVar  : vars[dir],
+  surfIntVars : delete(surfVar,vars),
+  
+  /* Here we assume diffusivity only depends on position space,
+     but it could be easily changed to vary with velocity space too. */
+  numBasisC : length(basisC),
+  nuEdge_c : makelist(nuEdge[i-1],i,1,numBasisC),
+  nuEdge_e : doExpand(nuEdge_c, basisC),
+  nuSkin_c : makelist(nuSkin[i-1],i,1,numBasisC),
+  nuSkin_e : doExpand(nuSkin_c, basisC),
+  
+  printf(fh, "GKYL_CU_DH double ~a(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_inv, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out) ~%", funcNm),
+  printf(fh, "{~%"),
+  printf(fh, "  // w[NDIM]: Cell-center coordinate.~%"),
+  printf(fh, "  // dxv[NDIM]: Cell length.~%"),
+  printf(fh, "  // nuSkin/nuGhost: Diffusivity in skin and ghost cells.~%"),
+  printf(fh, "  // jacobgeo_inv: reciprocal of the configuration space Jacobian.~%"),
+  printf(fh, "  // edge: -1 for lower boundary, +1 for upper boundary.~%"),
+  printf(fh, "  // JfSkin/JfGhost: distribution times conf-space Jacobian in skin and ghost cells.~%"),
+  printf(fh, "  // out: Incremented output.~%~%"),
+
+  printf(fh, "  const double rdx2sq = pow(2./dxSkin[~a],2.0);~%", dir-1),
+  printf(fh, "~%"),
+
+  JfSkin_c : makelist(JfSkin[i-1], i, 1, numBasis),
+  JfSkin_e : doExpand(JfSkin_c, basis),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
+  
+  fSkin_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfSkin_e),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  printf(fh, "  double fSkin[~a];~%", numBasis),
+  writeCExprsNoExpand1(fSkin, fSkin_c),
+  fSkin_c : makelist(fSkin[i-1], i, 1, numBasis),
+  printf(fh, "~%"),
+
+  fSkin_e : doExpand(fSkin_c, basis),
+
+  printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", numBasis),
+  printf(fh, "~%"),
+
+  /* Lower doman boundary. */
+  printf(fh, "  if (edge == -1) { ~%~%"),
+
+  /* Contribution from the domain boundary surface. Minus sign is because this
+     contribution ought to be the opposite of that in boundary_surf. */
+  nuSkin_l : subst(surfVar=-1,nuSkin_e),
+  boundSurf_incr_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuSkin_l*subst(surfVar=-1,diff(fSkin_e,surfVar))),
+
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
+  printf(fh, "~%"),
+  
+  /* Upper doman boundary. */
+  printf(fh, "  } else { ~%~%"),
+
+  /* Contribution from the domain boundary surface. Minus sign is because this
+     contribution ought to be the opposite of that in boundary_surf. */
+  nuSkin_r : subst(surfVar=1,nuSkin_e),
+  boundSurf_incr_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuSkin_r*subst(surfVar=1,diff(fSkin_e,surfVar))),
+  
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
+  printf(fh, "~%"),
+
+  printf(fh, "  }~%"),
+  printf(fh, "~%"),
+
+  bound_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
+  writeCIncrExprsNoExpand1(out, rdx2sq*bound_out),
+  printf(fh, "~%"),
+  
+  printf(fh, "  return 0.;~%"),  /* Return CFL frequency in volume kernel. */
+  printf(fh, "}~%~%")
+)$

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-diag.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-diag.mac
@@ -3,11 +3,22 @@ load("recovery")$
 load("out-scripts")$
 fpprec : 24$
 
-gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir) := block(
+/* Types of boundary diagnostic stencils:
+     - bound_local: use the local (skin cell) solution to compute the boundary
+       surface.
+     - bound_recovery: treat the boundary surface like an interior surface
+       (should match the surface kernel).
+*/
+bound_diag_bc_type : ["bound_local","bound_recovery"]$
+
+/* Boundary sidex. */
+bound_side : ["lower","upper"]$
+
+gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir, side, bcType) := block(
   [dim,bType,vars,basis,varsC,basisC,vSub,numBasis,surfVar,surfIntVars,numBasisC,
-   nuEdge_e,nuEdge_c,nuSkin_e,nuSkin_c,JfEdge_c,KfSkin_c,JfEdge_e,JfSkin_e,jacobgeo_inv_e,
-   fEdge_c,fSkin_c,fEdge_e,fSkin_e,fRecr_e,nuAv_r,edgeSurf_incr_c,nuSkin_l,
-   boundSurf_incr_c,edge_out,bound_out],
+   nuSkin_c,nuGhost_c,nuSkin_e,nuGhost_e,JfSkin_c,JfGhost_c,JfSkin_e,JfGhost_e,jacobgeo_inv_e,
+   fSkin_c,fGhost_c,fSkin_e,fGhost_e,fRecl_e,nuAv_l,nuSkin_l,fRecr_e,nuAv_r,nuSkin_r,
+   boundSurf_incr_c,bound_out],
 
   dim : cdim+vdim,
 
@@ -23,10 +34,10 @@ gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyO
   /* Here we assume diffusivity only depends on position space,
      but it could be easily changed to vary with velocity space too. */
   numBasisC : length(basisC),
-  nuEdge_c : makelist(nuEdge[i-1],i,1,numBasisC),
-  nuEdge_e : doExpand(nuEdge_c, basisC),
   nuSkin_c : makelist(nuSkin[i-1],i,1,numBasisC),
+  nuGhost_c : makelist(nuGhost[i-1],i,1,numBasisC),
   nuSkin_e : doExpand(nuSkin_c, basisC),
+  nuGhost_e : doExpand(nuGhost_c, basisC),
   
   printf(fh, "GKYL_CU_DH double ~a(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_inv, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out) ~%", funcNm),
   printf(fh, "{~%"),
@@ -41,48 +52,75 @@ gk_anomalous_diff_gen_boundary_diag_ker(fh, funcNm, cdim, vdim, basisType, polyO
   printf(fh, "  const double rdx2sq = pow(2./dxSkin[~a],2.0);~%", dir-1),
   printf(fh, "~%"),
 
-  JfSkin_c : makelist(JfSkin[i-1], i, 1, numBasis),
-  JfSkin_e : doExpand(JfSkin_c, basis),
+  JfSkin_c  : makelist(JfSkin[i-1], i, 1, numBasis),
+  JfGhost_c : makelist(JfGhost[i-1], i, 1, numBasis),
+  JfSkin_e  : doExpand(JfSkin_c, basis),
+  JfGhost_e : doExpand(JfGhost_c, basis),
 
   /* Divide jacobGeo*f by jacobGeo. */
   jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
   
   fSkin_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfSkin_e),
+  fGhost_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfGhost_e),
 
   /* Divide jacobGeo*f by jacobGeo. */
   printf(fh, "  double fSkin[~a];~%", numBasis),
   writeCExprsNoExpand1(fSkin, fSkin_c),
   fSkin_c : makelist(fSkin[i-1], i, 1, numBasis),
   printf(fh, "~%"),
+  if bcType = "bound_recovery" then (
+    printf(fh, "  double fGhost[~a];~%", numBasis),
+    writeCExprsNoExpand1(fGhost, fGhost_c),
+    fGhost_c : makelist(fGhost[i-1], i, 1, numBasis),
+    printf(fh, "~%")
+  ),
 
-  fSkin_e : doExpand(fSkin_c, basis),
+  fSkin_e  : doExpand(fSkin_c, basis),
+  fGhost_e : doExpand(fGhost_c, basis),
 
   printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", numBasis),
   printf(fh, "~%"),
 
-  /* Lower doman boundary. */
-  printf(fh, "  if (edge == -1) { ~%~%"),
+  if side = "lower" then (
+    /* Lower doman boundary. */
 
-  /* Contribution from the domain boundary surface. Minus sign is because this
-     contribution ought to be the opposite of that in boundary_surf. */
-  nuSkin_l : subst(surfVar=-1,nuSkin_e),
-  boundSurf_incr_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuSkin_l*subst(surfVar=-1,diff(fSkin_e,surfVar))),
+    /* Contribution from the domain boundary surface. Minus sign is because this
+       contribution ought to be the opposite of that in boundary_surf. */
+    if bcType = "bound_recovery" then (
+
+      fRecl_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fGhost_c), dg(fSkin_c)),
+      nuAv_l  : (subst(surfVar=1,nuGhost_e) + subst(surfVar=-1,nuSkin_e))/2,
+      boundSurf_incr_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuAv_l*subst(surfVar=-1,diff(fRecl_e,surfVar)))
+
+    ) else if bcType = "bound_local" then (
+
+      nuSkin_l : subst(surfVar=-1,nuSkin_e),
+      boundSurf_incr_c : -calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuSkin_l*subst(surfVar=-1,diff(fSkin_e,surfVar)))
+
+    )
+  
+  ) else (
+    /* Upper doman boundary. */
+
+    /* Contribution from the domain boundary surface. Minus sign is because this
+       contribution ought to be the opposite of that in boundary_surf. */
+
+    if bcType = "bound_recovery" then (
+
+      fRecr_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fSkin_c), dg(fGhost_c)),
+      nuAv_r  : (subst(surfVar=1,nuSkin_e) + subst(surfVar=-1,nuGhost_e))/2,
+      boundSurf_incr_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuAv_r*subst(surfVar=1,diff(fRecr_e,surfVar)))
+
+    ) else if bcType = "bound_local" then (
+
+      nuSkin_r : subst(surfVar=1,nuSkin_e),
+      boundSurf_incr_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuSkin_r*subst(surfVar=1,diff(fSkin_e,surfVar)))
+    
+    )
+
+  ),
 
   writeCExprs1(boundSurf_incr, boundSurf_incr_c),
-  printf(fh, "~%"),
-  
-  /* Upper doman boundary. */
-  printf(fh, "  } else { ~%~%"),
-
-  /* Contribution from the domain boundary surface. Minus sign is because this
-     contribution ought to be the opposite of that in boundary_surf. */
-  nuSkin_r : subst(surfVar=1,nuSkin_e),
-  boundSurf_incr_c : -calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuSkin_r*subst(surfVar=1,diff(fSkin_e,surfVar))),
-  
-  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
-  printf(fh, "~%"),
-
-  printf(fh, "  }~%"),
   printf(fh, "~%"),
 
   bound_out : makelist(boundSurf_incr[i-1],i,1,numBasis),

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-surf.mac
@@ -15,7 +15,7 @@ bound_side : ["lower","upper"]$
 
 gk_anomalous_diff_gen_boundary_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir, side, bcType) := block(
   [dim,bType,vars,basis,varsC,basisC,vSub,numBasis,surfVar,surfIntVars,numBasisC,
-   nuEdge_e,nuEdge_c,nuSkin_e,nuSkin_c,JfEdge_c,JfSkin_c,JfEdge_e,JfSkin_e,jacobgeo_inv_e,
+   nuEdge_e,nuEdge_c,nuSkin_e,nuSkin_c,JfEdge_c,JfSkin_c,JfEdge_e,JfSkin_e,jacobgeo_invEdge_e,jacobgeo_invSkin_e,
    fEdge_c,fSkin_c,fEdge_e,fSkin_e,fRecr_e,nuAv_r,edgeSurf_incr_c,nuSkin_l,
    boundSurf_incr_c,edge_out,bound_out],
 
@@ -38,12 +38,12 @@ gk_anomalous_diff_gen_boundary_surf_ker(fh, funcNm, cdim, vdim, basisType, polyO
   nuSkin_c : makelist(nuSkin[i-1],i,1,numBasisC),
   nuSkin_e : doExpand(nuSkin_c, basisC),
   
-  printf(fh, "GKYL_CU_DH double ~a(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_inv, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out) ~%", funcNm),
+  printf(fh, "GKYL_CU_DH double ~a(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_invEdge, const double *jacobgeo_invSkin, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out) ~%", funcNm),
   printf(fh, "{~%"),
   printf(fh, "  // w[NDIM]: Cell-center coordinate.~%"),
   printf(fh, "  // dxv[NDIM]: Cell length.~%"),
   printf(fh, "  // nuEdge/nuSkin: Diffusivity in edge and skin cells.~%"),
-  printf(fh, "  // jacobgeo_inv: reciprocal of the configuration space Jacobian.~%"),
+  printf(fh, "  // jacobgeo_invEdge/jacobgeo_invSkin: reciprocal of the configuration space Jacobian.~%"),
   printf(fh, "  // edge: -1 for lower boundary, +1 for upper boundary.~%"),
   printf(fh, "  // JfEdge/JfSkin: distribution times conf-space Jacobian in egde and skin cells.~%"),
   printf(fh, "  // out: Incremented output.~%~%"),
@@ -57,10 +57,11 @@ gk_anomalous_diff_gen_boundary_surf_ker(fh, funcNm, cdim, vdim, basisType, polyO
   JfSkin_e : doExpand(JfSkin_c, basis),
 
   /* Divide jacobGeo*f by jacobGeo. */
-  jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
+  jacobgeo_invEdge_e : doExpand1(jacobgeo_invEdge, basisC),
+  jacobgeo_invSkin_e : doExpand1(jacobgeo_invSkin, basisC),
   
-  fEdge_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfEdge_e),
-  fSkin_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfSkin_e),
+  fEdge_c : calcInnerProdList(vars, jacobgeo_invEdge_e, basis, JfEdge_e),
+  fSkin_c : calcInnerProdList(vars, jacobgeo_invSkin_e, basis, JfSkin_e),
 
   /* Divide jacobGeo*f by jacobGeo. */
   printf(fh, "  double fEdge[~a];~%", numBasis),

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-surf.mac
@@ -1,0 +1,116 @@
+load("modal-basis")$
+load("recovery")$
+load("out-scripts")$
+fpprec : 24$
+
+gk_anomalous_diff_gen_boundary_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir) := block(
+  [dim,bType,vars,basis,varsC,basisC,vSub,numBasis,surfVar,surfIntVars,numBasisC,
+   nuEdge_e,nuEdge_c,nuSkin_e,nuSkin_c,JfEdge_c,KfSkin_c,JfEdge_e,JfSkin_e,jacobgeo_inv_e,
+   fEdge_c,fSkin_c,fEdge_e,fSkin_e,fRecr_e,nuAv_r,edgeSurf_incr_c,nuSkin_l,
+   boundSurf_incr_c,edge_out,bound_out],
+
+  dim : cdim+vdim,
+
+  bType : basisType,
+  if polyOrder=1 then bType : "gkhyb",  /* Force p=1 to mean hybrid. */
+
+  [varsC, basisC, vars, basis, vSub] : loadGkBasis(basisType, cdim, vdim, polyOrder),
+  numBasis : length(basis),
+
+  surfVar  : vars[dir],
+  surfIntVars : delete(surfVar,vars),
+  
+  /* Here we assume diffusivity only depends on position space,
+     but it could be easily changed to vary with velocity space too. */
+  numBasisC : length(basisC),
+  nuEdge_c : makelist(nuEdge[i-1],i,1,numBasisC),
+  nuEdge_e : doExpand(nuEdge_c, basisC),
+  nuSkin_c : makelist(nuSkin[i-1],i,1,numBasisC),
+  nuSkin_e : doExpand(nuSkin_c, basisC),
+  
+  printf(fh, "GKYL_CU_DH double ~a(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_inv, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out) ~%", funcNm),
+  printf(fh, "{~%"),
+  printf(fh, "  // w[NDIM]: Cell-center coordinate.~%"),
+  printf(fh, "  // dxv[NDIM]: Cell length.~%"),
+  printf(fh, "  // nuEdge/nuSkin: Diffusivity in edge and skin cells.~%"),
+  printf(fh, "  // jacobgeo_inv: reciprocal of the configuration space Jacobian.~%"),
+  printf(fh, "  // edge: -1 for lower boundary, +1 for upper boundary.~%"),
+  printf(fh, "  // JfEdge/JfSkin: distribution times conf-space Jacobian in egde and skin cells.~%"),
+  printf(fh, "  // out: Incremented output.~%~%"),
+
+  printf(fh, "  const double rdx2sq = pow(2./dxSkin[~a],2.0);~%", dir-1),
+  printf(fh, "~%"),
+
+  JfEdge_c : makelist(JfEdge[i-1], i, 1, numBasis),
+  JfSkin_c : makelist(JfSkin[i-1], i, 1, numBasis),
+  JfEdge_e : doExpand(JfEdge_c, basis),
+  JfSkin_e : doExpand(JfSkin_c, basis),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
+  
+  fEdge_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfEdge_e),
+  fSkin_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, JfSkin_e),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  printf(fh, "  double fEdge[~a];~%", numBasis),
+  writeCExprsNoExpand1(fEdge, fEdge_c),
+  fEdge_c : makelist(fEdge[i-1], i, 1, numBasis),
+  printf(fh, "~%"),
+  printf(fh, "  double fSkin[~a];~%", numBasis),
+  writeCExprsNoExpand1(fSkin, fSkin_c),
+  fSkin_c : makelist(fSkin[i-1], i, 1, numBasis),
+  printf(fh, "~%"),
+
+  fSkin_e : doExpand(fSkin_c, basis),
+  fEdge_e : doExpand(fEdge_c, basis),
+
+  printf(fh, "  double edgeSurf_incr[~a] = {0.0}; ~%", numBasis),
+  printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", numBasis),
+  printf(fh, "~%"),
+
+  /* Lower doman boundary. */
+  printf(fh, "  if (edge == -1) { ~%~%"),
+
+  /* Contribution from the skin-edge surface. */
+  fRecr_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fSkin_c), dg(fEdge_c)),
+  nuAv_r : (subst(surfVar=1,nuSkin_e) + subst(surfVar=-1,nuEdge_e))/2,
+  edgeSurf_incr_c : calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuAv_r*subst(surfVar=0,diff(fRecr_e,surfVar))),
+
+  /* Contribution from the domain boundary surface. */
+  nuSkin_l : subst(surfVar=-1,nuSkin_e),
+  boundSurf_incr_c : calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuSkin_l*subst(surfVar=-1,diff(fSkin_e,surfVar))),
+
+  writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
+  printf(fh, "~%"),
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
+  printf(fh, "~%"),
+  
+  /* Upper doman boundary. */
+  printf(fh, "  } else { ~%~%"),
+
+  /* Contribution from the skin-edge surface. */
+  fRecl_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fEdge_c), dg(fSkin_c)),
+  nuAv_l : (subst(surfVar=1,nuEdge_e) + subst(surfVar=-1,nuSkin_e))/2,
+  edgeSurf_incr_c : calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuAv_l*subst(surfVar=0,diff(fRecl_e,surfVar))),
+
+  /* Contribution from the domain boundary surface. */
+  nuSkin_r : subst(surfVar=1,nuSkin_e),
+  boundSurf_incr_c : calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuSkin_r*subst(surfVar=1,diff(fSkin_e,surfVar))),
+  
+  writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
+  printf(fh, "~%"),
+  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
+  printf(fh, "~%"),
+
+  printf(fh, "  }~%"),
+  printf(fh, "~%"),
+
+  edge_out  : makelist(edgeSurf_incr[i-1],i,1,numBasis),
+  bound_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
+  writeCIncrExprsNoExpand1(out, rdx2sq*(bound_out + edge_out)),
+  printf(fh, "~%"),
+  
+  printf(fh, "  return 0.;~%"),  /* Return CFL frequency in volume kernel. */
+  printf(fh, "}~%~%")
+)$

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-boundary-surf.mac
@@ -3,9 +3,19 @@ load("recovery")$
 load("out-scripts")$
 fpprec : 24$
 
-gk_anomalous_diff_gen_boundary_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir) := block(
+/* Types of boundary stencils:
+     - zero_flux: we don't apply the surface term on the boundary.
+     - bound_local: use the local (skin cell) solution to compute the boundary
+       surface.
+*/
+bound_surf_bc_type : ["zero_flux","bound_local"]$
+
+/* Boundary sidex. */
+bound_side : ["lower","upper"]$
+
+gk_anomalous_diff_gen_boundary_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir, side, bcType) := block(
   [dim,bType,vars,basis,varsC,basisC,vSub,numBasis,surfVar,surfIntVars,numBasisC,
-   nuEdge_e,nuEdge_c,nuSkin_e,nuSkin_c,JfEdge_c,KfSkin_c,JfEdge_e,JfSkin_e,jacobgeo_inv_e,
+   nuEdge_e,nuEdge_c,nuSkin_e,nuSkin_c,JfEdge_c,JfSkin_c,JfEdge_e,JfSkin_e,jacobgeo_inv_e,
    fEdge_c,fSkin_c,fEdge_e,fSkin_e,fRecr_e,nuAv_r,edgeSurf_incr_c,nuSkin_l,
    boundSurf_incr_c,edge_out,bound_out],
 
@@ -66,48 +76,56 @@ gk_anomalous_diff_gen_boundary_surf_ker(fh, funcNm, cdim, vdim, basisType, polyO
   fEdge_e : doExpand(fEdge_c, basis),
 
   printf(fh, "  double edgeSurf_incr[~a] = {0.0}; ~%", numBasis),
-  printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", numBasis),
+  if not bcType = "zero_flux" then (
+    printf(fh, "  double boundSurf_incr[~a] = {0.0}; ~%", numBasis)
+  ),
   printf(fh, "~%"),
 
-  /* Lower doman boundary. */
-  printf(fh, "  if (edge == -1) { ~%~%"),
+  if side = "lower" then (
+    /* Lower doman boundary. */
 
-  /* Contribution from the skin-edge surface. */
-  fRecr_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fSkin_c), dg(fEdge_c)),
-  nuAv_r : (subst(surfVar=1,nuSkin_e) + subst(surfVar=-1,nuEdge_e))/2,
-  edgeSurf_incr_c : calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuAv_r*subst(surfVar=0,diff(fRecr_e,surfVar))),
+    /* Contribution from the skin-edge surface. */
+    fRecr_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fSkin_c), dg(fEdge_c)),
+    nuAv_r : (subst(surfVar=1,nuSkin_e) + subst(surfVar=-1,nuEdge_e))/2,
+    edgeSurf_incr_c : calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuAv_r*subst(surfVar=0,diff(fRecr_e,surfVar))),
+  
+    /* Contribution from the domain boundary surface. */
+    if bcType = "bound_local" then (
+      nuSkin_l : subst(surfVar=-1,nuSkin_e),
+      boundSurf_incr_c : calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuSkin_l*subst(surfVar=-1,diff(fSkin_e,surfVar)))
+    ) else if bcType = "zero_flux" then (
+      boundSurf_incr_c : makelist(0,i,1,numBasis)
+    )
+  
+  ) else (
+    /* Upper doman boundary. */
 
-  /* Contribution from the domain boundary surface. */
-  nuSkin_l : subst(surfVar=-1,nuSkin_e),
-  boundSurf_incr_c : calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuSkin_l*subst(surfVar=-1,diff(fSkin_e,surfVar))),
-
+    /* Contribution from the skin-edge surface. */
+    fRecl_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fEdge_c), dg(fSkin_c)),
+    nuAv_l : (subst(surfVar=1,nuEdge_e) + subst(surfVar=-1,nuSkin_e))/2,
+    edgeSurf_incr_c : calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuAv_l*subst(surfVar=0,diff(fRecl_e,surfVar))),
+  
+    /* Contribution from the domain boundary surface. */
+    if bcType = "bound_local" then (
+      nuSkin_r : subst(surfVar=1,nuSkin_e),
+      boundSurf_incr_c : calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuSkin_r*subst(surfVar=1,diff(fSkin_e,surfVar)))
+    ) else if bcType = "zero_flux" then (
+      boundSurf_incr_c : makelist(0,i,1,numBasis)
+    )
+    
+  ),
+  
   writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
   printf(fh, "~%"),
   writeCExprs1(boundSurf_incr, boundSurf_incr_c),
-  printf(fh, "~%"),
-  
-  /* Upper doman boundary. */
-  printf(fh, "  } else { ~%~%"),
-
-  /* Contribution from the skin-edge surface. */
-  fRecl_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fEdge_c), dg(fSkin_c)),
-  nuAv_l : (subst(surfVar=1,nuEdge_e) + subst(surfVar=-1,nuSkin_e))/2,
-  edgeSurf_incr_c : calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuAv_l*subst(surfVar=0,diff(fRecl_e,surfVar))),
-
-  /* Contribution from the domain boundary surface. */
-  nuSkin_r : subst(surfVar=1,nuSkin_e),
-  boundSurf_incr_c : calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuSkin_r*subst(surfVar=1,diff(fSkin_e,surfVar))),
-  
-  writeCExprs1(edgeSurf_incr, edgeSurf_incr_c),
-  printf(fh, "~%"),
-  writeCExprs1(boundSurf_incr, boundSurf_incr_c),
-  printf(fh, "~%"),
-
-  printf(fh, "  }~%"),
   printf(fh, "~%"),
 
   edge_out  : makelist(edgeSurf_incr[i-1],i,1,numBasis),
-  bound_out : makelist(boundSurf_incr[i-1],i,1,numBasis),
+  if bcType = "zero_flux" then (
+    bound_out : makelist(0,i,1,numBasis)
+  ) else (
+    bound_out : makelist(boundSurf_incr[i-1],i,1,numBasis)
+  ),
   writeCIncrExprsNoExpand1(out, rdx2sq*(bound_out + edge_out)),
   printf(fh, "~%"),
   

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-surf.mac
@@ -1,0 +1,103 @@
+load("modal-basis")$
+load("recovery")$
+load("out-scripts")$
+fpprec : 24$
+
+gk_anomalous_diff_gen_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir) := block(
+  [dir,bType,varsC,basisC,vars,basis,vSub,numBasis,numBasisC,surfVar,surfIntVars,nul_c,nuc_c,nur_c,nul_e,nuc_e,nur_e,
+   Jfl_c,Jfc_c,Jfr_c,Jfl_e,Jfc_e,Jfr_e,jacobgeo_inv_e,fl_c,fc_c,fr_c,fl_e,fc_e,fr_e,
+   fRecl_e,nuAv_l,surf_incr_l_c,fRecr_e,nuAv_r,surf_incr_r_c,surf_l_out,surf_r_out],
+
+  dir : 1,
+  dim : cdim+vdim,
+  
+  bType : basisType,
+  if polyOrder=1 then bType : "gkhyb",  /* Force p=1 to mean hybrid. */
+
+  [varsC, basisC, vars, basis, vSub] : loadGkBasis(basisType, cdim, vdim, polyOrder),
+  numBasis : length(basis),
+  numBasisC : length(basisC),
+
+  surfVar  : vars[dir],
+  surfIntVars : delete(surfVar,vars),
+  
+  printf(fh, "GKYL_CU_DH double ~a(const double *wc, const double *dxc, const double *nul, const double *nuc, const double *nur, const double *jacobgeo_inv, const double *Jfl, const double *Jfc, const double *Jfr, double* GKYL_RESTRICT out) ~%", funcNm),
+  printf(fh, "{~%"),
+  printf(fh, "  // w[NDIM]: Cell-center coordinate.~%"),
+  printf(fh, "  // dxv[NDIM]: Cell length.~%"),
+  printf(fh, "  // nul: Diffusivity in the left cell.~%"),
+  printf(fh, "  // nuc: Diffusivity in the center cell.~%"),
+  printf(fh, "  // nur: Diffusivity in the right cell.~%"),
+  printf(fh, "  // jacobgeo_inv: one divided by the configuration space Jacobian.~%"),
+  printf(fh, "  // Jfl: Input field times conf-space Jacobian in the left cell.~%"),
+  printf(fh, "  // Jfc: Input field times conf-space Jacobian in the center cell.~%"),
+  printf(fh, "  // Jfr: Input field times conf-space Jacobian in the right cell.~%"),
+  printf(fh, "  // out: Incremented output.~%~%"),
+
+  printf(fh, "  const double rdx2sq = pow(2./dxc[~a],2.0);~%", dir-1),
+  printf(fh, "~%"),
+
+  /* Here we assume diffusivity only depends on position space,
+     but it could be easily changed to vary with velocity space too. */
+  nul_c : makelist(nul[i-1],i,1,numBasisC),
+  nuc_c : makelist(nuc[i-1],i,1,numBasisC),
+  nur_c : makelist(nur[i-1],i,1,numBasisC),
+  nul_e : doExpand(nul_c, basisC),
+  nuc_e : doExpand(nuc_c, basisC),
+  nur_e : doExpand(nur_c, basisC),
+  
+  Jfl_c : makelist(Jfl[i-1], i, 1, numBasis),
+  Jfc_c : makelist(Jfc[i-1], i, 1, numBasis),
+  Jfr_c : makelist(Jfr[i-1], i, 1, numBasis),
+  Jfl_e : doExpand(Jfl_c, basis),
+  Jfc_e : doExpand(Jfc_c, basis),
+  Jfr_e : doExpand(Jfr_c, basis),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
+  
+  fl_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, Jfl_e),
+  fc_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, Jfc_e),
+  fr_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, Jfr_e),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  printf(fh, "  double fl[~a];~%", numBasis),
+  writeCExprsNoExpand1(fl, fl_c),
+  printf(fh, "~%"),
+  flush_output(fh),
+  fl_c : makelist(fl[i-1], i, 1, numBasis),
+  fl_e : doExpand(fl_c, basis),
+
+  printf(fh, "  double fc[~a];~%", numBasis),
+  writeCExprsNoExpand1(fc, fc_c),
+  printf(fh, "~%"),
+  flush_output(fh),
+  fc_c : makelist(fc[i-1], i, 1, numBasis),
+  fc_e : doExpand(fc_c, basis),
+
+  printf(fh, "  double fr[~a];~%", numBasis),
+  writeCExprsNoExpand1(fr, fr_c),
+  printf(fh, "~%"),
+  flush_output(fh),
+  fr_c : makelist(fr[i-1], i, 1, numBasis),
+  fr_e : doExpand(fr_c, basis),
+
+  /* Contribution from lower surface. */
+  fRecl_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fl_c), dg(fc_c)),
+  nuAv_l : (subst(surfVar=1,nul_e) + subst(surfVar=-1,nuc_e))/2,
+  surf_incr_l_c : calcInnerProdList(surfIntVars, -1, subst(surfVar=-1,basis), nuAv_l*subst(surfVar=0,diff(fRecl_e,surfVar))),
+
+  /* Contribution from upper surface. */
+  fRecr_e : calcRecov2CellGen(bType, surfVar, vars, polyOrder, dg(fc_c), dg(fr_c)),
+  nuAv_r : (subst(surfVar=1,nuc_e) + subst(surfVar=-1,nur_e))/2,
+  surf_incr_r_c : calcInnerProdList(surfIntVars, 1, subst(surfVar=1,basis), nuAv_r*subst(surfVar=0,diff(fRecr_e,surfVar))),
+  
+  surf_l_out : makelist(surf_incr_l_c[i],i,1,numBasis),
+  surf_r_out : makelist(surf_incr_r_c[i],i,1,numBasis),
+  writeCIncrExprsNoExpand1(out, rdx2sq*(surf_l_out + surf_r_out)),
+  printf(fh, "~%"),
+  
+  printf(fh, "  return 0.;~%"), /* Return CFL frequency in volume kernel. */
+  printf(fh, "}~%~%")
+  
+)$

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-surf.mac
@@ -5,7 +5,7 @@ fpprec : 24$
 
 gk_anomalous_diff_gen_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir) := block(
   [dir,bType,varsC,basisC,vars,basis,vSub,numBasis,numBasisC,surfVar,surfIntVars,nul_c,nuc_c,nur_c,nul_e,nuc_e,nur_e,
-   Jfl_c,Jfc_c,Jfr_c,Jfl_e,Jfc_e,Jfr_e,jacobgeo_inv_e,fl_c,fc_c,fr_c,fl_e,fc_e,fr_e,
+   Jfl_c,Jfc_c,Jfr_c,Jfl_e,Jfc_e,Jfr_e,jacobgeo_invl_e,jacobgeo_invc_e,jacobgeo_invr_e,fl_c,fc_c,fr_c,fl_e,fc_e,fr_e,
    fRecl_e,nuAv_l,surf_incr_l_c,fRecr_e,nuAv_r,surf_incr_r_c,surf_l_out,surf_r_out],
 
   dir : 1,
@@ -21,14 +21,16 @@ gk_anomalous_diff_gen_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir
   surfVar  : vars[dir],
   surfIntVars : delete(surfVar,vars),
   
-  printf(fh, "GKYL_CU_DH double ~a(const double *wc, const double *dxc, const double *nul, const double *nuc, const double *nur, const double *jacobgeo_inv, const double *Jfl, const double *Jfc, const double *Jfr, double* GKYL_RESTRICT out) ~%", funcNm),
+  printf(fh, "GKYL_CU_DH double ~a(const double *wc, const double *dxc, const double *nul, const double *nuc, const double *nur, const double *jacobgeo_invl,  const double *jacobgeo_invc, const double *jacobgeo_invr, const double *Jfl, const double *Jfc, const double *Jfr, double* GKYL_RESTRICT out) ~%", funcNm),
   printf(fh, "{~%"),
   printf(fh, "  // w[NDIM]: Cell-center coordinate.~%"),
   printf(fh, "  // dxv[NDIM]: Cell length.~%"),
   printf(fh, "  // nul: Diffusivity in the left cell.~%"),
   printf(fh, "  // nuc: Diffusivity in the center cell.~%"),
   printf(fh, "  // nur: Diffusivity in the right cell.~%"),
-  printf(fh, "  // jacobgeo_inv: one divided by the configuration space Jacobian.~%"),
+  printf(fh, "  // jacobgeo_invl: reciprocal of the conf-space Jacobian in the left cell.~%"),
+  printf(fh, "  // jacobgeo_invc: reciprocal of the conf-space Jacobian in the center cell.~%"),
+  printf(fh, "  // jacobgeo_invr: reciprocal of the conf-space Jacobian in the right cell.~%"),
   printf(fh, "  // Jfl: Input field times conf-space Jacobian in the left cell.~%"),
   printf(fh, "  // Jfc: Input field times conf-space Jacobian in the center cell.~%"),
   printf(fh, "  // Jfr: Input field times conf-space Jacobian in the right cell.~%"),
@@ -54,11 +56,13 @@ gk_anomalous_diff_gen_surf_ker(fh, funcNm, cdim, vdim, basisType, polyOrder, dir
   Jfr_e : doExpand(Jfr_c, basis),
 
   /* Divide jacobGeo*f by jacobGeo. */
-  jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
+  jacobgeo_invl_e : doExpand1(jacobgeo_invl, basisC),
+  jacobgeo_invc_e : doExpand1(jacobgeo_invc, basisC),
+  jacobgeo_invr_e : doExpand1(jacobgeo_invr, basisC),
   
-  fl_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, Jfl_e),
-  fc_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, Jfc_e),
-  fr_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, Jfr_e),
+  fl_c : calcInnerProdList(vars, jacobgeo_invl_e, basis, Jfl_e),
+  fc_c : calcInnerProdList(vars, jacobgeo_invc_e, basis, Jfc_e),
+  fr_c : calcInnerProdList(vars, jacobgeo_invr_e, basis, Jfr_e),
 
   /* Divide jacobGeo*f by jacobGeo. */
   printf(fh, "  double fl[~a];~%", numBasis),

--- a/maxima/g0/gk_anomalous_diff/gk_anom_diff-vol.mac
+++ b/maxima/g0/gk_anomalous_diff/gk_anom_diff-vol.mac
@@ -1,0 +1,62 @@
+load("modal-basis")$
+load("recovery") $
+load("out-scripts");
+load("utilities")$
+load(stringproc)$
+fpprec : 24$
+
+/* Generate kernels for a gyrokinetic anomalous diffusion volume term. */
+
+gk_anomalous_diff_gen_boundary_vol_ker(fh, funcNm, cdim, vdim, basisType, polyOrder) := block(
+  [dir,varsC,basisC,vars,basis,vSub,numBasis,numBasisC,diffVar,nu_c,nu_e,
+   Jfin_c,Jfin_e,jacobgeo_inv_e,f_c,f_e,vol_incr_c,pOrderFact,nuAv],
+
+  dir : 1,
+    
+  printf(fh, "GKYL_CU_DH double ~a(const double *w, const double *dx, const double *nu, const double *jacobgeo_inv, const double *Jfin, double* GKYL_RESTRICT out) ~%{~%", funcNm),
+  printf(fh, "  // w[NDIM]: Cell-center coordinates~%"),
+  printf(fh, "  // dx[NDIM]: Cell spacing~%"),
+  printf(fh, "  // nu: Diffusivity~%"),
+  printf(fh, "  // jacobgeo_inv: reciprocal of the configuration space Jacobian.~%"),
+  printf(fh, "  // Jfin: Input field times conf-space Jacobian~%"),
+  printf(fh, "  // out: Incremented output~%~%"),
+
+  printf(fh, "  const double rdx2sq = pow(2.0/dx[~a],2.0); ~%", dir-1),
+  printf(fh, "~%"),
+
+  [varsC, basisC, vars, basis, vSub] : loadGkBasis(basisType, cdim, vdim, polyOrder),
+  numBasis : length(basis),
+  numBasisC : length(basisC),
+
+  diffVar : vars[dir],
+
+  nu_c : makelist(nu[i-1],i,1,numBasisC),
+  nu_e : doExpand(nu_c,basisC),
+
+  Jfin_c : makelist(Jfin[i-1], i, 1, numBasis),
+  Jfin_e : doExpand(Jfin_c, basis),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  jacobgeo_inv_e : doExpand1(jacobgeo_inv, basisC),
+  
+  f_c : calcInnerProdList(vars, jacobgeo_inv_e, basis, Jfin_e),
+
+  /* Divide jacobGeo*f by jacobGeo. */
+  printf(fh, "  double fin[~a];~%", numBasis),
+  writeCExprsNoExpand1(fin, f_c),
+  printf(fh, "~%"),
+
+  f_c : makelist(fin[i-1], i, 1, numBasis),
+  f_e : doExpand(f_c, basis),
+
+  /* Volume increment (dimensional factor included later). */
+  vol_incr_c : rdx2sq*calcInnerProdList(vars, -1, diff(basis,diffVar)*nu_e, diff(f_e,diffVar)),
+  writeCIncrExprs1(out, vol_incr_c),
+  printf(fh, "~%"),
+
+  pOrderFact : (polyOrder+1)^2,
+  nuAv : fullratsimp(innerProd(varsC, 1, 1, nu_e) / innerProd(varsC, 1, 1, 1)), 
+
+  printf(fh, "  return ~a*rdx2sq; ~%", float(expand(pOrderFact*nuAv))),
+  printf(fh, "}~%")
+)$

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-diag.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-diag.mac
@@ -1,0 +1,48 @@
+kill(all)$
+load("gk_anomalous_diff/gk_anom_diff-boundary-diag.mac")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+vDims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser     , minCdim_Tensor     ]$
+maxCdim      : [maxCdim_Ser     , maxCdim_Tensor     ]$
+dirVars      : [[[x,vpar],[x,vpar,mu]],[[null],[x,y,vpar,mu]],[[null],[x,y,z,vpar,mu]]]$ 
+
+for bInd : 1 thru length(bName) do (
+  for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+      for vdim in vDims[cdim] do (
+        dir : 1,
+        dirVar : dirVars[cdim][vdim][dir], 
+
+        fname : sconcat("~/max-out/gk_anomalous_diffusion_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        funcName : sconcat("gk_anomalous_diffusion_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_gk_anomalous_diffusion_kernels.h>~%~%"),
+        print("Generating:", fname),
+        gk_anomalous_diff_gen_boundary_diag_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir),
+        close(fh)
+
+      )
+    )
+  )
+)$

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-diag.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-diag.mac
@@ -35,11 +35,15 @@ for bInd : 1 thru length(bName) do (
         dirVar : dirVars[cdim][vdim][dir], 
 
         fname : sconcat("~/max-out/gk_anomalous_diffusion_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
-        funcName : sconcat("gk_anomalous_diffusion_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
         fh : openw(fname),
         printf(fh, "#include <gkyl_gk_anomalous_diffusion_kernels.h>~%~%"),
         print("Generating:", fname),
-        gk_anomalous_diff_gen_boundary_diag_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir),
+        for side in bound_side do (
+          for bc in bound_diag_bc_type do (
+            funcName : sconcat("gk_anomalous_diffusion_boundary_diag", dirVar,"_", side, "_", bc, "_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+            gk_anomalous_diff_gen_boundary_diag_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir, side, bc)
+          )
+        ),
         close(fh)
 
       )

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-surf.mac
@@ -1,0 +1,48 @@
+kill(all)$
+load("gk_anomalous_diff/gk_anom_diff-boundary-surf.mac")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+vDims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser     , minCdim_Tensor     ]$
+maxCdim      : [maxCdim_Ser     , maxCdim_Tensor     ]$
+dirVars      : [[[x,vpar],[x,vpar,mu]],[[null],[x,y,vpar,mu]],[[null],[x,y,z,vpar,mu]]]$ 
+
+for bInd : 1 thru length(bName) do (
+  for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+      for vdim in vDims[cdim] do (
+        dir : 1,
+        dirVar : dirVars[cdim][vdim][dir], 
+
+        fname : sconcat("~/max-out/gk_anomalous_diffusion_boundary_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        funcName : sconcat("gk_anomalous_diffusion_boundary_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_gk_anomalous_diffusion_kernels.h>~%~%"),
+        print("Generating:", fname),
+        gk_anomalous_diff_gen_boundary_surf_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir),
+        close(fh)
+
+      )
+    )
+  )
+)$

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-boundary-surf.mac
@@ -35,11 +35,15 @@ for bInd : 1 thru length(bName) do (
         dirVar : dirVars[cdim][vdim][dir], 
 
         fname : sconcat("~/max-out/gk_anomalous_diffusion_boundary_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
-        funcName : sconcat("gk_anomalous_diffusion_boundary_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
         fh : openw(fname),
         printf(fh, "#include <gkyl_gk_anomalous_diffusion_kernels.h>~%~%"),
         print("Generating:", fname),
-        gk_anomalous_diff_gen_boundary_surf_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir),
+        for side in bound_side do (
+          for bc in bound_surf_bc_type do (
+            funcName : sconcat("gk_anomalous_diffusion_boundary_surf", dirVar,"_", side, "_", bc, "_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+            gk_anomalous_diff_gen_boundary_surf_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir, side, bc)
+          )
+        ),
         close(fh)
 
       )

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-header.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-header.mac
@@ -28,6 +28,10 @@ dirVars      : [[[x,vpar],[x,vpar,mu]],[[null],[x,y,vpar,mu]],[[null],[x,y,z,vpa
 
 varsPerDim : [[x],[x,y],[x,y,z]]$
 
+bound_side : ["lower","upper"]$
+bound_surf_bc_type : ["zero_flux","bound_local"]$
+bound_diag_bc_type : ["bound_local","bound_recovery"]$
+
 fh : openw("~/max-out/gkyl_gk_anomalous_diffusion_kernels.h")$
 printf(fh, "#pragma once~%")$
 printf(fh, "#include <math.h>~%")$
@@ -57,13 +61,19 @@ for bInd : 1 thru length(bName) do (
         funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wc, const double *dxc, const double *nul, const double *nuc, const double *nur, const double *jacobgeo_inv, const double *Jfl, const double *Jfc, const double *Jfr, double* GKYL_RESTRICT out);~%"),
         printf(fh, funcSign),
 
-        funcName : sconcat("gk_anomalous_diffusion_boundary_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
-        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_inv, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out);~%"),
-        printf(fh, funcSign),
+        for side in bound_side do (
+          for bc in bound_surf_bc_type do (
+            funcName : sconcat("gk_anomalous_diffusion_boundary_surf", dirVar,"_", side, "_", bc, "_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+            funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_inv, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out);~%"),
+            printf(fh, funcSign)
+          ),
 
-        funcName : sconcat("gk_anomalous_diffusion_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
-        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_inv, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out);~%"),
-        printf(fh, funcSign),
+          for bc in bound_diag_bc_type do (
+            funcName : sconcat("gk_anomalous_diffusion_boundary_diag", dirVar,"_", side, "_", bc, "_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+            funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_inv, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out);~%"),
+            printf(fh, funcSign)
+          )
+        ),
 
         printf(fh, "~%")
       )

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-header.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-header.mac
@@ -58,19 +58,19 @@ for bInd : 1 thru length(bName) do (
         dirVar : dirVars[cdim][vdim][dir], 
 
         funcName : sconcat("gk_anomalous_diffusion_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
-        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wc, const double *dxc, const double *nul, const double *nuc, const double *nur, const double *jacobgeo_inv, const double *Jfl, const double *Jfc, const double *Jfr, double* GKYL_RESTRICT out);~%"),
+        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wc, const double *dxc, const double *nul, const double *nuc, const double *nur, const double *jacobgeo_invl, const double *jacobgeo_invc, const double *jacobgeo_invr, const double *Jfl, const double *Jfc, const double *Jfr, double* GKYL_RESTRICT out);~%"),
         printf(fh, funcSign),
 
         for side in bound_side do (
           for bc in bound_surf_bc_type do (
             funcName : sconcat("gk_anomalous_diffusion_boundary_surf", dirVar,"_", side, "_", bc, "_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
-            funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_inv, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out);~%"),
+            funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_invEdge, const double *jacobgeo_invSkin, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out);~%"),
             printf(fh, funcSign)
           ),
 
           for bc in bound_diag_bc_type do (
             funcName : sconcat("gk_anomalous_diffusion_boundary_diag", dirVar,"_", side, "_", bc, "_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
-            funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_inv, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out);~%"),
+            funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_invSkin, const double *jacobgeo_invGhost, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out);~%"),
             printf(fh, funcSign)
           )
         ),

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-header.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-header.mac
@@ -1,0 +1,76 @@
+kill(all)$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+vDims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser     , minCdim_Tensor     ]$
+maxCdim      : [maxCdim_Ser     , maxCdim_Tensor     ]$
+dirVars      : [[[x,vpar],[x,vpar,mu]],[[null],[x,y,vpar,mu]],[[null],[x,y,z,vpar,mu]]]$
+
+varsPerDim : [[x],[x,y],[x,y,z]]$
+
+fh : openw("~/max-out/gkyl_gk_anomalous_diffusion_kernels.h")$
+printf(fh, "#pragma once~%")$
+printf(fh, "#include <math.h>~%")$
+printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_BEG~%")$
+printf(fh, "~%")$
+
+for bInd : 1 thru length(bName) do (
+  for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+      /* Write volume kernel declaration. */
+      vars : varsPerDim[cdim],
+
+      for vdim in vDims[cdim] do (
+
+        funcName : sconcat("gk_anomalous_diffusion_vol_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *w, const double *dx, const double *nu, const double *jacobgeo_inv, const double *Jfin, double* GKYL_RESTRICT out);~%"),
+        printf(fh, funcSign),
+        printf(fh, "~%"),
+
+        /* Write surface and boundary surface kernel declaration. */
+        dir : 1,
+        dirVar : dirVars[cdim][vdim][dir], 
+
+        funcName : sconcat("gk_anomalous_diffusion_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wc, const double *dxc, const double *nul, const double *nuc, const double *nur, const double *jacobgeo_inv, const double *Jfl, const double *Jfc, const double *Jfr, double* GKYL_RESTRICT out);~%"),
+        printf(fh, funcSign),
+
+        funcName : sconcat("gk_anomalous_diffusion_boundary_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuEdge, const double *nuSkin, const double *jacobgeo_inv, int edge, const double *JfEdge, const double *JfSkin, double* GKYL_RESTRICT out);~%"),
+        printf(fh, funcSign),
+
+        funcName : sconcat("gk_anomalous_diffusion_boundary_diag", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        funcSign : sconcat("GKYL_CU_DH double ",funcName,"(const double *wSkin, const double *dxSkin, const double *nuSkin, const double *nuGhost, const double *jacobgeo_inv, int edge, const double *JfSkin, const double *JfGhost, double* GKYL_RESTRICT out);~%"),
+        printf(fh, funcSign),
+
+        printf(fh, "~%")
+      )
+    )
+  )
+)$
+
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_END~%")$
+close(fh)$

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-surf.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-surf.mac
@@ -1,0 +1,47 @@
+kill(all)$
+load("gk_anomalous_diff/gk_anom_diff-surf.mac")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+vDims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser     , minCdim_Tensor     ]$
+maxCdim      : [maxCdim_Ser     , maxCdim_Tensor     ]$
+dirVars      : [[[x,vpar],[x,vpar,mu]],[[null],[x,y,vpar,mu]],[[null],[x,y,z,vpar,mu]]]$ 
+
+for bInd : 1 thru length(bName) do (
+  for polyOrder : minPolyOrder[bInd] thru maxPolyOrder[bInd] do (
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+      for vdim in vDims[cdim] do (
+        dir : 1,
+        dirVar : dirVars[cdim][vdim][dir], 
+
+        fname : sconcat("~/max-out/gk_anomalous_diffusion_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        funcName : sconcat("gk_anomalous_diffusion_surf", dirVar,"_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_gk_anomalous_diffusion_kernels.h>~%~%"),
+        print("Generating:", fname),
+        gk_anomalous_diff_gen_surf_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder, dir),
+        close(fh)
+      )
+    )
+  )
+)$

--- a/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-vol.mac
+++ b/maxima/g0/gk_anomalous_diff/ms-gk_anom_diff-vol.mac
@@ -1,0 +1,48 @@
+kill(all)$
+load("gk_anomalous_diff/gk_anom_diff-vol.mac")$
+
+/* Generate kernels for the anomalous diffusion volume term. */
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 1$
+minCdim_Ser : 2$
+maxCdim_Ser : 2$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 0$
+
+/* ...... END OF USER INPUTS........ */
+
+vDims : [[1,2], [2], [2]]$
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+for bInd : 1 thru length(bName) do (
+  for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+    for vdim in vDims[cdim] do (
+      minPolyOrderB : minPolyOrder[bInd],
+      maxPolyOrderB : maxPolyOrder[bInd],
+
+      for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+        disp(printf(false,sconcat("Creating volume diffusion",bName[bInd]," ~ax~avp~a"),cdim,vdim,polyOrder)),
+        fname : sconcat("~/max-out/gk_anomalous_diffusion_vol_", cdim, "x", cdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_gk_anomalous_diffusion_kernels.h>~%~%"),
+        funcName : sconcat("gk_anomalous_diffusion_vol_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder),
+        gk_anomalous_diff_gen_boundary_vol_ker(fh, funcName, cdim, vdim, bName[bInd], polyOrder),
+        close(fh)
+      )
+    )
+  )
+);


### PR DESCRIPTION
Previously we were using a single diffusion operator for anomalous diffusion in 2x and numerical hyperdiffusion. This makes the Maxima unnecessarily complicated, hard to maintain and extend. So we split off the anomalous diffusion maxima into its own folder, and we change the discretization to use single-integration by parts + recovery of f + average of D (we may revisit this later).