### PR TITLE
Add a protection in GK ambipolar Boltzmann electron potential kernels

### DIFF
--- a/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
+++ b/maxima/g0/ambi_bolt_potential/ambi_bolt_potential_funcs.mac
@@ -218,12 +218,20 @@ genPhiCalcKernel(fh, funcNm, dim, basisNm, polyOrder) := block(
     phiS_n[i]   : subst(cSub, phiS_e)
   ),
 
+  printf(fh,"  double phi_qp[~a];~%", ordNum),
+  printf(fh,"  double m0IonS_curr;~%"),
   phi_n : makelist(0,i,1,ordNum),
   for i : 1 thru ordNum do (
-    phi_n[i] : phiS_n[i] - (T_e/q_e)*log(m0Ion_n[i]/m0IonS_n[i])
+    printf(fh,"  m0IonS_curr = ~a;~%",float(expand(m0IonS_n[i]))),
+
+    phi_n[i] : phiS_n[i] - (T_e/q_e)*log(fmax(m0Ion_n[i],m0IonS_curr)/m0IonS_curr),
+
+    printf(fh,"  if ((isfinite(~a)) && (~a>0.)) {~%",m0IonS_curr,m0IonS_curr),
+    printf(fh,"    phi_qp[~a] = ~a;~%",i-1,float(expand(phi_n[i]))),
+    printf(fh,"  } else {~%"),
+    printf(fh,"    phi_qp[~a] = 0.0;~%",i-1),
+    printf(fh,"  }~%")
   ),
-  printf(fh,"  double phi_qp[~a];~%", ordNum),
-  writeCExprs1(phi_qp, phi_n),
   printf(fh,"~%"),
 
   phi_c : makelist(0,i,1,numB),


### PR DESCRIPTION
This goes with [PR 986 of gkeyll](https://github.com/ammarhakim/gkeyll/pull/986)

The GK Boltzmann field solver computes the potential using
```math
\phi = \phi_s + (T_e/e) \ln \left( n_i / n_{i,s} \right)
```
where $\phi_s$ and $n_{i,s}$ are the sheath potential and ion density. A problem arises when transiently $n_i$ or $n_{i,s}$ is zero.

So here we implement the above equation as
```
if n_i,s > 0 {
phi = phi_s + (T_e/e) log ( fmax(n_i, n_i,s) / n_i,s )
}
else {
phi = 0
}
```

In tests this has shown to avoid a sudden appearance of NaNs.