### PR TITLE
Maxima to generate dg_differentiate kernels

### DIFF
--- a/maxima/g0/dg_differentiate/dg_diff-local.mac
+++ b/maxima/g0/dg_differentiate/dg_diff-local.mac
@@ -29,9 +29,11 @@ gen_dg_diff_local(fh, funcName, cdim, basisType, polyOrder) := block(
       printf(fh, "  // out: output derivative of fin. ~%"),
       printf(fh, "~%"),
 
-      der_c : 0.5*dx*calcInnerProdList(vars, 1, basis, diff(f_e,diff_dir,diff_order)),
+      printf(fh, "  const double rdx2fac = pow(2.0/dx, ~a);~%",diff_order),
+
+      der_c : rdx2fac*calcInnerProdList(vars, 1, basis, diff(f_e,diff_dir,diff_order)),
       
-      writeCExprsWithZeros(out, der_c),
+      writeCExprsWithZeros1(out, der_c),
       printf(fh, "~%"),
 
       printf(fh, "}~%"),

--- a/maxima/g0/dg_differentiate/dg_diff-local.mac
+++ b/maxima/g0/dg_differentiate/dg_diff-local.mac
@@ -1,0 +1,41 @@
+/* Generate kernels for calculating the local derivative of a DG field. */
+load("modal-basis");
+load("out-scripts");
+load(stringproc)$
+fpprec : 24$
+
+gen_dg_diff_local(fh, funcName, cdim, basisType, polyOrder) := block(
+  [maxDiffOrder,vars,basis,numB,dir,order,der_c,diff_dir],
+
+  /* Maximum derivative order to calculate. */
+  maxDiffOrder : 2,
+
+  /* Load basis of dimensionality requested. */
+  [vars,basis] : loadBasis(basisType, cdim, polyOrder),
+  numB : length(basis),
+
+  f_e : doExpand1(fin, basis),
+
+  for dir : 1 thru cdim do (
+
+    diff_dir : vars[dir],
+
+    for diff_order : 1 thru maxDiffOrder do (
+      /* Function declaration with input/output variables. */
+      printf(fh, "GKYL_CU_DH void ~%"),
+      printf(fh, "~a_dir~a_order~a(double dx, const double *fin, double *out) ~%{ ~%", funcName, dir-1, diff_order),
+      printf(fh, "  // dx: cell size in each direction. ~%"),
+      printf(fh, "  // fin: Input scalar DG field. ~%"),
+      printf(fh, "  // out: output derivative of fin. ~%"),
+      printf(fh, "~%"),
+
+      der_c : 0.5*dx*calcInnerProdList(vars, 1, basis, diff(f_e,diff_dir,diff_order)),
+      
+      writeCExprsWithZeros(out, der_c),
+      printf(fh, "~%"),
+
+      printf(fh, "}~%"),
+      printf(fh, "~%")
+    )
+  )
+)$

--- a/maxima/g0/dg_differentiate/ms-dg_diff-header.mac
+++ b/maxima/g0/dg_differentiate/ms-dg_diff-header.mac
@@ -51,7 +51,7 @@ printPrototypes(fh) := block(
   )
 )$
 
-fname : sconcat("~/max-out/gkyl_dg_differentiate_local.h")$
+fname : sconcat("~/max-out/gkyl_dg_differentiate_kernels.h")$
 fh : openw(fname)$
 printf(fh, "#pragma once~%")$
 printf(fh, "~%")$

--- a/maxima/g0/dg_differentiate/ms-dg_diff-header.mac
+++ b/maxima/g0/dg_differentiate/ms-dg_diff-header.mac
@@ -1,0 +1,66 @@
+load(stringproc)$
+/* Generate kernels for a local (to a cell) calculation of the derivative of a
+   DG field. */
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+/* Tensor product basis. */
+/* Note that Serendipity, p = 1, is equivalent to Tensor */
+/* Thus no need to calculate p = 1 Tensor basis */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 2$
+
+/* ...... END OF USER INPUTS........ */
+
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+printPrototypes(fh) := block(
+  [bInd,cdim,polyOrder,dir,diff_order],
+
+  /* Maximum derivative order to calculate. */
+  maxDiffOrder : 2,
+
+  for bInd : 1 thru length(bName) do (
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+      minPolyOrderB : minPolyOrder[bInd],
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (cdim>2 and maxPolyOrderB>1) then maxPolyOrderB : 1,
+  
+      for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+        funcName : sconcat("dg_differentiate_local_",bName[bInd], "_", cdim, "x_p", polyOrder),
+        for dir : 1 thru cdim do (
+          for diff_order : 1 thru maxDiffOrder do (
+            printf(fh, "GKYL_CU_DH void ~a_dir~a_order~a(double dx, const double *fin, double *out);~%", funcName, dir-1, diff_order)
+          )
+        ),
+        printf(fh, "~%")
+      )
+    )
+  )
+)$
+
+fname : sconcat("~/max-out/gkyl_dg_differentiate_local.h")$
+fh : openw(fname)$
+printf(fh, "#pragma once~%")$
+printf(fh, "~%")$
+printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "#include <math.h>~%")$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_BEG~%")$
+printf(fh, "~%")$
+printPrototypes(fh)$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_END~%")$
+close(fh)$

--- a/maxima/g0/dg_differentiate/ms-dg_diff-local.mac
+++ b/maxima/g0/dg_differentiate/ms-dg_diff-local.mac
@@ -1,0 +1,46 @@
+load("dg_differentiate/dg_diff-local")$
+load(stringproc)$
+/* Generate kernels for a local (to a cell) calculation of the derivative of a
+   DG field. */
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+/* Tensor product basis. */
+/* Note that Serendipity, p = 1, is equivalent to Tensor */
+/* Thus no need to calculate p = 1 Tensor basis */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 2$
+
+/* ...... END OF USER INPUTS........ */
+
+bName        : ["ser","tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+for bInd : 1 thru length(bName) do (
+  for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+    minPolyOrderB : minPolyOrder[bInd],
+    maxPolyOrderB : maxPolyOrder[bInd],
+    if (cdim>2 and maxPolyOrderB>1) then maxPolyOrderB : 1,
+
+    for polyOrder : minPolyOrderB thru maxPolyOrderB do (
+      fname : sconcat("~/max-out/dg_differentiate_local_",  bName[bInd], "_", cdim, "x_p", polyOrder, ".c"),
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_dg_differentiate.h>~%"),
+      printf(fh, "~%"),
+      funcName : sconcat("dg_differentiate_local_",bName[bInd], "_", cdim, "x_p", polyOrder),
+      gen_dg_diff_local(fh, funcName, cdim, bName[bInd], polyOrder),
+      close(fh)
+    )
+  )
+);

--- a/maxima/g0/dg_differentiate/ms-dg_diff-local.mac
+++ b/maxima/g0/dg_differentiate/ms-dg_diff-local.mac
@@ -36,7 +36,7 @@ for bInd : 1 thru length(bName) do (
     for polyOrder : minPolyOrderB thru maxPolyOrderB do (
       fname : sconcat("~/max-out/dg_differentiate_local_",  bName[bInd], "_", cdim, "x_p", polyOrder, ".c"),
       fh : openw(fname),
-      printf(fh, "#include <gkyl_dg_differentiate.h>~%"),
+      printf(fh, "#include <gkyl_dg_differentiate_kernels.h>~%"),
       printf(fh, "~%"),
       funcName : sconcat("dg_differentiate_local_",bName[bInd], "_", cdim, "x_p", polyOrder),
       gen_dg_diff_local(fh, funcName, cdim, bName[bInd], polyOrder),


### PR DESCRIPTION
Generates kernels for an operator that computes the derivate of a DG field local to a cell and projects it back to the same basis. This goes with [PR #1068 of gkeyll](https://github.com/ammarhakim/gkeyll/pull/1068).