### PR TITLE
DG eval at coord proj maxima & new gkhybrid_vel basis

### DIFF
--- a/ginac/Makefile
+++ b/ginac/Makefile
@@ -7,15 +7,19 @@
 CFLAGS = -O3 -g -Wall
 CXXFLAGS = -O3 -g -std=c++11
 
-GINAC_INC = ${HOME}/gkylsoft/ginac/include
-CLN_INC = ${HOME}/gkylsoft/cln/include
+GKYLSOFT ?= ${HOME}/gkylsoft
 
-GINAC_LIB_DIR = ${HOME}/gkylsoft/ginac/lib
-CLN_LIB_DIR = ${HOME}/gkylsoft/cln/lib
+GINAC_INC = $(GKYLSOFT)/ginac/include
+CLN_INC = $(GKYLSOFT)/cln/include
+GMP_INC = /opt/homebrew/include
+
+GINAC_LIB_DIR = $(GKYLSOFT)/ginac/lib
+CLN_LIB_DIR = $(GKYLSOFT)/cln/lib
+GMP_LIB_DIR = /opt/homebrew/lib
 
 KERN_INCLUDES = -Ikernels -Ikernels/basis -Ikernels/bin_op
-INCLUDES = -Iunit -Ilib -I${GINAC_INC} -I${CLN_INC} 
-LIBDIRS = -L${GINAC_LIB_DIR} -L${CLN_LIB_DIR}
+INCLUDES = -Iunit -Ilib -I${GINAC_INC} -I${CLN_INC} -I${GMP_INC}
+LIBDIRS = -L${GINAC_LIB_DIR} -L${CLN_LIB_DIR} -L${GMP_LIB_DIR}
 PREFIX = ${HOME}/gkylsoft
 LDFLAGS = "-Wl,-rpath,${CLN_LIB_DIR}"
 

--- a/ginac/codegen/codegen_basis.cxx
+++ b/ginac/codegen/codegen_basis.cxx
@@ -18,6 +18,8 @@ get_basis_name(Gkyl::ModalBasisType type)
     bn = "hyb";
   else if (type == Gkyl::MODAL_GKHYB)
     bn = "gkhyb";
+  else if (type == Gkyl::MODAL_GKHYB_VEL)
+    bn = "gkhyb_vel";
 
   return bn;
 }
@@ -43,7 +45,7 @@ gen_eval(Gkyl::ModalBasisType type, std::ostream& fh, std::ostream& fc, const Gk
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
     // function declaration
     fh << "GKYL_CU_DH void eval_" << ndim << "d_" << bn << "_" << "p" << polyOrder
        << "(const double *z, double *b);" << std::endl;  
@@ -100,7 +102,7 @@ gen_eval_expand(Gkyl::ModalBasisType type, std::ostream& fh, std::ostream& fc, c
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declaration
     fh << "GKYL_CU_DH double eval_expand_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -158,7 +160,7 @@ gen_eval_grad_expand(Gkyl::ModalBasisType type, std::ostream& fh, std::ostream& 
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declaration
     fh << "GKYL_CU_DH double eval_grad_expand_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -225,7 +227,7 @@ gen_flip_odd_sign(Gkyl::ModalBasisType type,
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declarations
     fh << "GKYL_CU_DH void flip_odd_sign_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -288,7 +290,7 @@ gen_flip_even_sign(Gkyl::ModalBasisType type,
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declarations
     fh << "GKYL_CU_DH void flip_even_sign_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -340,7 +342,7 @@ gen_node_coords(Gkyl::ModalBasisType type, std::ostream& fh, std::ostream& fc, c
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declaration
     fh << "GKYL_CU_DH void node_coords_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -365,7 +367,7 @@ gen_nodal_to_modal(Gkyl::ModalBasisType type, std::ostream& fh, std::ostream& fc
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declaration
     fh << "GKYL_CU_DH void nodal_to_modal_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -389,7 +391,7 @@ gen_quad_to_modal(Gkyl::ModalBasisType type, std::ostream& fh, std::ostream& fc,
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declaration
     fh << "GKYL_CU_DH void quad_to_modal_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -413,7 +415,7 @@ gen_modal_to_quad(Gkyl::ModalBasisType type, std::ostream& fh, std::ostream& fc,
   int ndim = basis.get_ndim(), polyOrder = basis.get_polyOrder();
   int vdim = basis.get_vdim();
 
-  if (vdim == 0) {
+  if (vdim == 0 || (ndim == vdim)) {
 
     // function declaration
     fh << "GKYL_CU_DH void modal_to_quad_" << ndim << "d_" << bn << "_" << "p" << polyOrder
@@ -607,6 +609,64 @@ gen_gkhyb_basis()
 }
 
 void
+gen_gkhyb_vel_basis()
+{
+  // compute time-stamp
+  char buff[70];
+  time_t t = time(NULL);
+  struct tm curr_tm = *localtime(&t);
+  strftime(buff, sizeof buff, "%c", &curr_tm);
+  
+  int dims[] = { 1, 2, };
+  int max_order[] = { 1, 1, };
+
+  symbol z0("z0"), z1("z1");
+  std::vector<symbol> vars { z0, z1, };
+
+  std::ofstream header("kernels/basis/gkyl_basis_gkhyb_vel_kernels.h", std::ofstream::out);
+  header << "// " << buff << std::endl;
+  header << "#pragma once" << std::endl;
+  header << "#include <gkyl_util.h>" << std::endl;
+  header << "EXTERN_C_BEG" << std::endl;
+  
+  std::ofstream eval_file("kernels/basis/basis_eval_gkhyb_vel.c", std::ofstream::out);
+  std::ofstream flip_file("kernels/basis/basis_flip_sign_gkhyb_vel.c", std::ofstream::out);
+
+  eval_file << "// " << buff << std::endl;
+  eval_file << "#include <gkyl_basis_gkhyb_vel_kernels.h>" << std::endl;
+
+  flip_file << "// " << buff << std::endl;
+  flip_file << "#include <gkyl_basis_gkhyb_vel_kernels.h>" << std::endl;
+
+  for (int vd=1; vd<3; ++vd) {
+    int dim = vd;
+    int p = 1;
+    std::cout << vd << "vp" << p << " ";      
+    Gkyl::ModalBasis mbasis(Gkyl::MODAL_GKHYB_VEL, vd, vd, vars, p);
+      
+    // generate eval method
+    gen_eval(Gkyl::MODAL_GKHYB_VEL, header, eval_file, mbasis);
+    // generate eval_expand method
+    gen_eval_expand(Gkyl::MODAL_GKHYB_VEL, header, eval_file, mbasis);
+    gen_eval_grad_expand(Gkyl::MODAL_GKHYB_VEL, header, eval_file, mbasis);
+    // generate flip_sign methods
+    gen_flip_odd_sign(Gkyl::MODAL_GKHYB_VEL, header, flip_file, mbasis);
+    gen_flip_even_sign(Gkyl::MODAL_GKHYB_VEL, header, flip_file, mbasis);
+    // generate node_coords
+    gen_node_coords(Gkyl::MODAL_GKHYB_VEL, header, flip_file, mbasis);
+    // generate nodal to modal
+    gen_nodal_to_modal(Gkyl::MODAL_GKHYB_VEL, header, flip_file, mbasis);
+    // generate Gauss-Legendre quadrature nodal to modal
+    gen_quad_to_modal(Gkyl::MODAL_GKHYB_VEL, header, flip_file, mbasis);
+    // generate modal to Gauss-Legendre quadrature nodal 
+    gen_modal_to_quad(Gkyl::MODAL_GKHYB_VEL, header, flip_file, mbasis);
+    std::cout << std::endl;
+  }
+  
+  header << "EXTERN_C_END" << std::endl;
+}
+
+void
 gen_ten_basis()
 {
   // compute time-stamp
@@ -686,6 +746,11 @@ main(int argc, char **argv)
   gen_gkhyb_basis();
   tm = gkyl_time_diff_now_sec(tstart);
   std::cout << "Generating of modal gk hybrid basis took " << tm << " seconds" << std::endl;
+  
+  tstart = gkyl_wall_clock();
+  gen_gkhyb_vel_basis();
+  tm = gkyl_time_diff_now_sec(tstart);
+  std::cout << "Generating of modal gk hybrid vel basis took " << tm << " seconds" << std::endl;
   
   return 1;
 }

--- a/ginac/lib/gkhyb_vel_mono.cpp
+++ b/ginac/lib/gkhyb_vel_mono.cpp
@@ -1,0 +1,20 @@
+#include <ginac/ginac.h>
+#include <gkhyb_vel_mono.h>
+
+GiNaC::lst
+gkhyb_vel_1v_p1(const std::vector<GiNaC::symbol> &vars)
+{
+  GiNaC::symbol vx = vars[0];
+  
+  GiNaC::lst l { 1,vx,vx*vx };
+  return l; 
+}
+
+GiNaC::lst
+gkhyb_vel_2v_p1(const std::vector<GiNaC::symbol> &vars)
+{
+  GiNaC::symbol vx = vars[0], vy = vars[1];
+  
+  GiNaC::lst l { 1,vx,vy,vx*vy,vx*vx,vx*vx*vy };
+  return l;  
+}

--- a/ginac/lib/gkhyb_vel_mono.h
+++ b/ginac/lib/gkhyb_vel_mono.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <ginac/ginac.h>
+
+// 1v
+GiNaC::lst gkhyb_vel_1v_p1(const std::vector<GiNaC::symbol> &vars);
+// 2v
+GiNaC::lst gkhyb_vel_2v_p1(const std::vector<GiNaC::symbol> &vars);

--- a/ginac/lib/modal_basis.cpp
+++ b/ginac/lib/modal_basis.cpp
@@ -5,6 +5,7 @@
 #include "tensor_mono.h"
 #include "hyb_mono.h"
 #include "gkhyb_mono.h"
+#include "gkhyb_vel_mono.h"
 #include <modal_basis.h>
 
 // Serendipity basis function monomial list for each dimension: mo_list[ndim].ev[polyOrder]
@@ -51,6 +52,13 @@ static struct { GiNaC::lst (*ev[4])(const std::vector<GiNaC::symbol>&);
   {NULL,          NULL, gkhyb_3x2v_p1, NULL},
 };
 
+// Serendipity GK hybrid velocity basis function monomial list for each dimension: mo_list[ndim].ev[polyOrder]
+static struct { GiNaC::lst (*ev[4])(const std::vector<GiNaC::symbol>&);
+} gkhyb_vel_mo_list[] = {
+  {NULL, NULL, NULL, NULL}, // No 0D basis functions
+  {NULL, gkhyb_vel_1v_p1, gkhyb_vel_2v_p1, NULL},
+};
+
 Gkyl::ModalBasis::ModalBasis(ModalBasisType type, int ndim, int vdim, const std::vector<GiNaC::symbol>& invars, int polyOrder)
 : ndim(ndim), vdim(vdim), polyOrder(polyOrder)
 {
@@ -79,6 +87,12 @@ Gkyl::ModalBasis::ModalBasis(ModalBasisType type, int ndim, int vdim, const std:
     int cdim = ndim-vdim;
     assert(gkhyb_mo_list[cdim].ev[vdim] != NULL);
     bc = gsOrthoNorm(gkhyb_mo_list[cdim].ev[vdim](vars));
+  }  
+  else if (type == Gkyl::MODAL_GKHYB_VEL) {
+    assert(vdim > 0 && vdim < 3);
+    assert(polyOrder == 1);
+    assert(gkhyb_vel_mo_list[1].ev[vdim] != NULL);
+    bc = gsOrthoNorm(gkhyb_vel_mo_list[1].ev[vdim](vars));
   }  
 }
 

--- a/ginac/lib/modal_basis.h
+++ b/ginac/lib/modal_basis.h
@@ -5,7 +5,7 @@
 
 namespace Gkyl {
   /* Basis type */
-  enum ModalBasisType { MODAL_SER, MODAL_TEN, MODAL_HYB, MODAL_GKHYB };
+  enum ModalBasisType { MODAL_SER, MODAL_TEN, MODAL_HYB, MODAL_GKHYB, MODAL_GKHYB_VEL };
   
   class ModalBasis {
   public:

--- a/install-deps/build-cln.sh
+++ b/install-deps/build-cln.sh
@@ -3,9 +3,9 @@
 source ./build-opts.sh
 
 # Edit to suite your system
-PREFIX=$GKYLSOFT/cln-1.3.6
+PREFIX=$GKYLSOFT/cln-1.3.7
 # Location where dependency sources will be downloaded
-DEP_SOURCES=$HOME/gkylsoft/dep_src/
+DEP_SOURCES=$GKYLSOFT/dep_src/
 
 mkdir -p $DEP_SOURCES
 cd $DEP_SOURCES
@@ -13,10 +13,10 @@ cd $DEP_SOURCES
 # delete old checkout and builds
 rm -rf cln-*
 
-curl -L https://www.ginac.de/CLN/cln-1.3.6.tar.bz2 > cln-1.3.6.tar.bz2
-bunzip2 cln-1.3.6.tar.bz2
-tar xvf cln-1.3.6.tar
-cd cln-1.3.6
+curl -L https://www.ginac.de/CLN/cln-1.3.7.tar.bz2 > cln-1.3.7.tar.bz2
+bunzip2 cln-1.3.7.tar.bz2
+tar xvf cln-1.3.7.tar
+cd cln-1.3.7
 ./configure --prefix=$PREFIX
 make -j
 make install

--- a/install-deps/build-ginac.sh
+++ b/install-deps/build-ginac.sh
@@ -3,9 +3,9 @@
 source ./build-opts.sh
 
 # Edit to suite your system
-PREFIX=$GKYLSOFT/ginac-1.8.0
+PREFIX=$GKYLSOFT/ginac-1.8.10
 # Location where dependency sources will be downloaded
-DEP_SOURCES=$HOME/gkylsoft/dep_src/
+DEP_SOURCES=$GKYLSOFT/dep_src/
 
 mkdir -p $DEP_SOURCES
 cd $DEP_SOURCES
@@ -13,11 +13,11 @@ cd $DEP_SOURCES
 # delete old checkout and builds
 rm -rf ginac-*
 
-curl -L https://www.ginac.de/ginac-1.8.0.tar.bz2 > ginac-1.8.0.tar.bz2
-bunzip2 ginac-1.8.0.tar.bz2
-tar xvf ginac-1.8.0.tar
-cd ginac-1.8.0
-PKG_CONFIG_PATH=$GKYLSOFT/cln-1.3.6/lib/pkgconfig ./configure --prefix=$PREFIX --disable-shared
+curl -L https://www.ginac.de/ginac-1.8.10.tar.bz2 > ginac-1.8.10.tar.bz2
+bunzip2 ginac-1.8.10.tar.bz2
+tar xvf ginac-1.8.10.tar
+cd ginac-1.8.10
+PKG_CONFIG_PATH=$GKYLSOFT/cln-1.3.7/lib/pkgconfig ./configure --prefix=$PREFIX --disable-shared
 make -j
 make install
 

--- a/maxima/g0/basis-precalc/basis-pre-calc-hybrid.mac
+++ b/maxima/g0/basis-precalc/basis-pre-calc-hybrid.mac
@@ -42,6 +42,15 @@ writeGkHybBasisToFile(cdim, vdim, fname) := block([varsC, varsP, basisC, basisP]
   save(fname, varsC, varsP, basisC, basisP)
 )$
 
+writeGkHybVelBasisToFile(vdim, fname) := block([varsC, varsP, basisC, basisP],
+  varsV  : makevarsV(vdim),
+  basisV : [ gsOrthoNorm(varsV,
+                         append(makeSerendipBasis(varsV, 1), vx^2*makeSerendipBasis(delete(vx, varsV), 1) )
+                        )
+           ],
+  save(fname, varsV, basisV)
+)$
+
 /* Compute list of monomials */
 calcHybMonoList(cdim, vdim) := block(
   [varsC, varsP, basisC, basisP],
@@ -63,6 +72,13 @@ calcGkHybMonoList(cdim, vdim) := block(
                   vx^2*makeSerendipBasis(delete(vx, varsP), 1) ))
 )$
 
+calcGkHybVelMonoList(vdim) := block(
+  [varsV, basisV],
+  varsV : makevarsV(vdim),
+  return (append( makeSerendipBasis(varsV, 1),
+                  vx^2*makeSerendipBasis(delete(vx, varsV), 1) ))
+)$
+
 /* Generate hybrid basis files. Every combination to account for
    surface evaluations, GK and sims that are kinetic in 1v only. */
 for c : 1 thru 3 do (
@@ -81,6 +97,11 @@ for c : 1 thru 3 do (
   )
 )$
 
+/* Generate GK hybrid velocity basis files. */
+for v : 1 thru 2 do (
+  writeGkHybVelBasisToFile(v, sconcat("~/max-out/basisGkHybridVel",v,"v.lisp"))
+)$
+
 /* MF 2022/07/03: I believe these are used by GINAC, but additional manual
    steps are still needed. I'd prefer that we get rid of the GINAC stuff for
    now and do everything in Maxima. */
@@ -95,5 +116,8 @@ for c : 1 thru 3 do (
     v : gkVdims[c][vs],
     printf(fh, "~a", calcGkHybMonoList(c, v))
   )
+)$
+for v : 1 thru 2 do (
+  printf(fh, "~a", calcGkHybVelMonoList(v))
 )$
 close(fh)$

--- a/maxima/g0/basis-precalc/basisGkHybridVel1v.lisp
+++ b/maxima/g0/basis-precalc/basisGkHybridVel1v.lisp
@@ -1,0 +1,28 @@
+;;; -*- Mode: LISP; package:maxima; syntax:common-lisp; -*- 
+(in-package :maxima)
+(DSKSETQ |$varsV| '((MLIST SIMP) $VX)) 
+(ADD2LNC '|$varsV| $VALUES) 
+(DSKSETQ |$basisV|
+         '((MLIST SIMP
+            (47.
+             #A((95.) BASE-CHAR
+                . "/Users/mfrancis/Documents/gkeyll/code/gkylcas/maxima/g0/basis-precalc/basis-pre-calc-hybrid.mac")
+             SRC |$writeGkHybVelBasisToFile| 45.))
+           ((MLIST SIMP
+             (33.
+              #A((71.) BASE-CHAR
+                 . "/Users/mfrancis/Documents/gkeyll/code/gkylcas/maxima/g0/modal-basis.mac")
+              SRC |$gsOrthoNorm| 31.))
+            ((MEXPT SIMP) 2. ((RAT SIMP) -1. 2.))
+            ((MTIMES SIMP) ((MEXPT SIMP) 2. ((RAT SIMP) -1. 2.))
+             ((MEXPT SIMP) 3. ((RAT SIMP) 1. 2.)) $VX)
+            ((MTIMES SIMP) 3. ((MEXPT SIMP) 2. ((RAT SIMP) -3. 2.))
+             ((MEXPT SIMP) 5. ((RAT SIMP) 1. 2.))
+             ((MPLUS SIMP) ((RAT SIMP) -1. 3.)
+              ((MEXPT SIMP
+                (48.
+                 #A((95.) BASE-CHAR
+                    . "/Users/mfrancis/Documents/gkeyll/code/gkylcas/maxima/g0/basis-precalc/basis-pre-calc-hybrid.mac")
+                 SRC |$writeGkHybVelBasisToFile| 45.))
+               $VX 2.)))))) 
+(ADD2LNC '|$basisV| $VALUES) 

--- a/maxima/g0/basis-precalc/basisGkHybridVel2v.lisp
+++ b/maxima/g0/basis-precalc/basisGkHybridVel2v.lisp
@@ -1,0 +1,42 @@
+;;; -*- Mode: LISP; package:maxima; syntax:common-lisp; -*- 
+(in-package :maxima)
+(DSKSETQ |$varsV| '((MLIST SIMP) $VX $VY)) 
+(ADD2LNC '|$varsV| $VALUES) 
+(DSKSETQ |$basisV|
+         '((MLIST SIMP
+            (47.
+             #A((95.) BASE-CHAR
+                . "/Users/mfrancis/Documents/gkeyll/code/gkylcas/maxima/g0/basis-precalc/basis-pre-calc-hybrid.mac")
+             SRC |$writeGkHybVelBasisToFile| 45.))
+           ((MLIST SIMP
+             (33.
+              #A((71.) BASE-CHAR
+                 . "/Users/mfrancis/Documents/gkeyll/code/gkylcas/maxima/g0/modal-basis.mac")
+              SRC |$gsOrthoNorm| 31.))
+            ((RAT SIMP) 1. 2.)
+            ((MTIMES SIMP) ((RAT SIMP) 1. 2.)
+             ((MEXPT SIMP) 3. ((RAT SIMP) 1. 2.)) $VX)
+            ((MTIMES SIMP) ((RAT SIMP) 1. 2.)
+             ((MEXPT SIMP) 3. ((RAT SIMP) 1. 2.)) $VY)
+            ((MTIMES SIMP) ((RAT SIMP) 3. 2.) $VX $VY)
+            ((MTIMES SIMP) ((RAT SIMP) 3. 4.)
+             ((MEXPT SIMP) 5. ((RAT SIMP) 1. 2.))
+             ((MPLUS SIMP) ((RAT SIMP) -1. 3.)
+              ((MEXPT SIMP
+                (48.
+                 #A((95.) BASE-CHAR
+                    . "/Users/mfrancis/Documents/gkeyll/code/gkylcas/maxima/g0/basis-precalc/basis-pre-calc-hybrid.mac")
+                 SRC |$writeGkHybVelBasisToFile| 45.))
+               $VX 2.)))
+            ((MTIMES SIMP) ((RAT SIMP) 3. 4.)
+             ((MEXPT SIMP) 15. ((RAT SIMP) 1. 2.))
+             ((MPLUS SIMP) ((MTIMES SIMP) ((RAT SIMP) -1. 3.) $VY)
+              ((MTIMES SIMP)
+               ((MEXPT SIMP
+                 (48.
+                  #A((95.) BASE-CHAR
+                     . "/Users/mfrancis/Documents/gkeyll/code/gkylcas/maxima/g0/basis-precalc/basis-pre-calc-hybrid.mac")
+                  SRC |$writeGkHybVelBasisToFile| 45.))
+                $VX 2.)
+               $VY)))))) 
+(ADD2LNC '|$basisV| $VALUES) 

--- a/maxima/g0/dg_eval_at_coords_proj/dg_ev_proj.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/dg_ev_proj.mac
@@ -1,0 +1,80 @@
+/**
+ * Create kernels which evaluate a DG expansion at a coordinate and projects
+ * onto lower dimensional basis. Currently
+ * it is meant for:
+ *   - x     -> scalar
+ *   - x,y   -> y
+ *   - x,y   -> x
+ *   - x,y   -> scalar
+ *   - x,y,z -> y,z
+ *   - x,y,z -> x,z
+ *   - x,y,z -> x,y
+ *   - x,y,z -> z
+ *   - x,y,z -> y
+ *   - x,y,z -> x
+ *   - x,y,z -> scalar
+*/
+load("modal-basis");
+load("out-scripts");
+fpprec : 24$
+
+get_ev_combos(varsIn) := block([pss,ps,combos],
+  pss    : listify(powerset(setify(varsIn))),
+  ps     : makelist(listify(pss[i]),i,1,length(pss)),
+  combos : sublist(ps, lambda([x], length(x)>0)),
+  return(combos)
+)$
+
+gen_dg_evproj_kernel(fh, funcNm, cdim_do, basisFun, polyOrder_do) := block(
+  [polyOrder_tar,varsC_do,bC_do,fdo_e,ev_var_combos,ivc,ev_varsC,ev_dirs1,
+   ev_dirs0,ev_str,varsC_tar,bC_tar,varsub_lst,ftar_c],
+
+  /* Assume polyOrder remain the same. */
+  polyOrder_tar : polyOrder_do,
+
+  /* Get desired basis. */
+  [varsC_do,bC_do] : loadBasis(basisFun, cdim_do, polyOrder_do),
+
+  fdo_e : doExpand1(fdo,bC_do),
+
+  /* Get combinations of variables to evaluate be evaluated. */
+  ev_var_combos : get_ev_combos(varsC_do),
+  
+  for ivc : 1 thru length(ev_var_combos) do (
+
+    /* Variables to evaluate. */
+    ev_varsC : ev_var_combos[ivc],
+
+    /* Directions to evaluate. */
+    ev_dirs1 : makelist(sublist_indices(varsC_do, lambda([x], x=ev_varsC[i]))[1], i, 1, length(ev_varsC)),
+    ev_dirs0 : makelist(ev_dirs1[i]-1, i, 1, length(ev_dirs1)),
+    ev_str : simplode(flatten(ev_dirs0)),
+
+    printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a(const double *coords, const double *fdo, double *ftar) ~%{ ~%", funcNm, ev_str),
+    printf(fh, "  // coords: logical coordinates to evaluate the field at.~%"),
+    printf(fh, "  // fdo: donor field to get DG coefficients from.~%"),
+    printf(fh, "  // ftar: target field whose DG coefficients to populate.~%"),
+    printf(fh, "~%"),
+  
+    /* Load donor basis. */
+    varsC_tar : sublist(varsC_do, lambda([x], freeof(x, ev_varsC))),
+    if length(varsC_tar) > 0 then
+      bC_tar : basisFromVars(basisFun, varsC_tar, polyOrder_tar)
+    else
+      bC_tar : [basisFromVars(basisFun, [x], 1)[1]],
+
+    varsub_lst : makelist(ev_varsC[i]=coords[i-1], i, 1, length(ev_varsC)),
+
+    ftar_c : calcInnerProdList(varsC_tar,1,bC_tar,subst(varsub_lst,fdo_e)),
+
+    coords_lst : makelist(coords[i-1],i,1,length(ev_dirs0)),
+
+    tempVars : [],
+    tempVars : writeCExprsWithZeros1noPowers(ftar, ftar_c, [coords_lst], tempVars),
+    
+    printf(fh, "}~%"),
+    printf(fh, "~%")
+    
+  )
+
+)$

--- a/maxima/g0/dg_eval_at_coords_proj/dg_ev_proj.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/dg_ev_proj.mac
@@ -1,52 +1,52 @@
 /**
  * Create kernels which evaluate a DG expansion at a coordinate and projects
- * onto lower dimensional basis. Currently
- * it is meant for:
- *   - x     -> scalar
- *   - x,y   -> y
- *   - x,y   -> x
- *   - x,y   -> scalar
- *   - x,y,z -> y,z
- *   - x,y,z -> x,z
- *   - x,y,z -> x,y
- *   - x,y,z -> z
- *   - x,y,z -> y
- *   - x,y,z -> x
- *   - x,y,z -> scalar
+ * onto lower dimensional basis.
 */
 load("modal-basis");
 load("out-scripts");
 fpprec : 24$
 
 get_ev_combos(varsIn) := block([pss,ps,combos],
+
+  /* Ordered variable lists. */
+  vars_order : [x,y,z,vx,vy,vz,vpar,mu],
+  sort_func(a,b) := sublist_indices(vars_order, lambda([x], x=a))[1] < sublist_indices(vars_order, lambda([x], x=b))[1],
+
   pss    : listify(powerset(setify(varsIn))),
   ps     : makelist(listify(pss[i]),i,1,length(pss)),
   combos : sublist(ps, lambda([x], length(x)>0)),
+  /* Sort list. */
+  for i : 1 thru length(combos) do (
+    combos[i] : sort(combos[i], 'sort_func)
+  ),
   return(combos)
 )$
 
-gen_dg_evproj_kernel(fh, funcNm, cdim_do, basisFun, polyOrder_do) := block(
-  [polyOrder_tar,varsC_do,bC_do,fdo_e,ev_var_combos,ivc,ev_varsC,ev_dirs1,
-   ev_dirs0,ev_str,varsC_tar,bC_tar,varsub_lst,ftar_c],
+gen_dg_evproj_kernel(fh, funcNm, cdim_do, vdim_do, basisFun, polyOrder_do) := block(
+  [polyOrder_tar,vars_do,basis_do,varsC_do,bC_do,gkVsub,fdo_e,ev_var_combos,ivc,ev_vars,ev_dirs1,
+   ev_dirs0,ev_str,vars_tar,basis_tar,varsub_lst,ftar_c],
 
   /* Assume polyOrder remain the same. */
   polyOrder_tar : polyOrder_do,
 
   /* Get desired basis. */
-  [varsC_do,bC_do] : loadBasis(basisFun, cdim_do, polyOrder_do),
+  if (basisFun = "gkhyb") then
+    [varsC_do,bC_do,vars_do,basis_do,gkVsub] : loadGkBasis(basisFun, cdim_do, vdim_do, polyOrder_do)
+  else
+    [vars_do,basis_do] : loadBasis(basisFun, cdim_do+vdim_do, polyOrder_do),
 
-  fdo_e : doExpand1(fdo,bC_do),
+  fdo_e : doExpand1(fdo,basis_do),
 
   /* Get combinations of variables to evaluate be evaluated. */
-  ev_var_combos : get_ev_combos(varsC_do),
+  ev_var_combos : get_ev_combos(vars_do),
   
   for ivc : 1 thru length(ev_var_combos) do (
 
     /* Variables to evaluate. */
-    ev_varsC : ev_var_combos[ivc],
+    ev_vars : ev_var_combos[ivc],
 
     /* Directions to evaluate. */
-    ev_dirs1 : makelist(sublist_indices(varsC_do, lambda([x], x=ev_varsC[i]))[1], i, 1, length(ev_varsC)),
+    ev_dirs1 : makelist(sublist_indices(vars_do, lambda([x], x=ev_vars[i]))[1], i, 1, length(ev_vars)),
     ev_dirs0 : makelist(ev_dirs1[i]-1, i, 1, length(ev_dirs1)),
     ev_str : simplode(flatten(ev_dirs0)),
 
@@ -57,15 +57,18 @@ gen_dg_evproj_kernel(fh, funcNm, cdim_do, basisFun, polyOrder_do) := block(
     printf(fh, "~%"),
   
     /* Load donor basis. */
-    varsC_tar : sublist(varsC_do, lambda([x], freeof(x, ev_varsC))),
-    if length(varsC_tar) > 0 then
-      bC_tar : basisFromVars(basisFun, varsC_tar, polyOrder_tar)
-    else
-      bC_tar : [basisFromVars(basisFun, [x], 1)[1]],
+    vars_tar : sublist(vars_do, lambda([x], freeof(x, ev_vars))),
+    if length(vars_tar) > 0 then (
+      if (basisFun = "gkhyb") then
+        [vars_tar,basis_tar] : loadGkHybBasisFromVars(vars_tar)
+      else 
+        basis_tar : basisFromVars(basisFun, vars_tar, polyOrder_tar)
+    ) else
+      basis_tar : [basisFromVars(basisFun, [x], 1)[1]],
 
-    varsub_lst : makelist(ev_varsC[i]=coords[i-1], i, 1, length(ev_varsC)),
+    varsub_lst : makelist(ev_vars[i]=coords[i-1], i, 1, length(ev_vars)),
 
-    ftar_c : calcInnerProdList(varsC_tar,1,bC_tar,subst(varsub_lst,fdo_e)),
+    ftar_c : calcInnerProdList(vars_tar,1,basis_tar,subst(varsub_lst,fdo_e)),
 
     coords_lst : makelist(coords[i-1],i,1,length(ev_dirs0)),
 

--- a/maxima/g0/dg_eval_at_coords_proj/dg_ev_proj.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/dg_ev_proj.mac
@@ -81,3 +81,93 @@ gen_dg_evproj_kernel(fh, funcNm, cdim_do, vdim_do, basisFun, polyOrder_do) := bl
   )
 
 )$
+
+gen_dg_evproj_num_basis_tar_kernel(fh, funcNm, cdim_do, vdim_do, basisFun, polyOrder_do) := block(
+  [polyOrder_tar,vars_do,basis_do,varsC_do,bC_do,gkVsub,fdo_e,ev_var_combos,ivc,ev_vars,ev_dirs1,
+   ev_dirs0,ev_str,vars_tar,basis_tar,varsub_lst,ftar_c],
+
+  /* Generate kernels return the properties of the target basis. */
+
+  /* Get desired basis. */
+  if (basisFun = "gkhyb") then
+    [varsC_do,bC_do,vars_do,basis_do,gkVsub] : loadGkBasis(basisFun, cdim_do, vdim_do, polyOrder_do)
+  else
+    [vars_do,basis_do] : loadBasis(basisFun, cdim_do+vdim_do, polyOrder_do),
+
+  /* Get combinations of variables to evaluate be evaluated. */
+  ev_var_combos : get_ev_combos(vars_do),
+  
+  for ivc : 1 thru length(ev_var_combos) do (
+
+    /* Variables to evaluate. */
+    ev_vars : ev_var_combos[ivc],
+    num_ev_dirs : length(ev_vars),
+
+    /* Directions to evaluate. */
+    ev_dirs1 : makelist(sublist_indices(vars_do, lambda([x], x=ev_vars[i]))[1], i, 1, num_ev_dirs),
+    ev_dirs0 : makelist(ev_dirs1[i]-1, i, 1, length(ev_dirs1)),
+    ev_str : simplode(flatten(ev_dirs0)),
+
+    printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a_target_basis(int *cdim, int *ndim, enum gkyl_basis_type *btype, int *poly_order, int *num_basis) ~%{~%", funcNm, ev_str),
+    printf(fh, "~%"),
+  
+    /* Load donor basis. */
+    vars_tar : sublist(vars_do, lambda([x], freeof(x, ev_vars))),
+    ndim_tar : length(vars_tar),
+    if ndim_tar > 0 then (
+      /* Assume polyOrder remain the same. */
+      polyOrder_tar : polyOrder_do,
+
+      if (basisFun = "gkhyb") then (
+        [vars_tar,basis_tar] : loadGkHybBasisFromVars(vars_tar),
+
+        cdim_tar : length(sublist(vars_tar, lambda([x], not freeof(x, varsC_do)))),
+        vdim_tar : ndim_tar - cdim_tar,
+
+        if (freeof(vpar, vars_tar)) then (
+          btype_str : "GKYL_BASIS_MODAL_SERENDIPITY"
+        ) else (
+          if (cdim_tar = 0) then (
+            if (vdim_tar = 1) then (
+              btype_str : "GKYL_BASIS_MODAL_SERENDIPITY",
+              polyOrder_tar : 2
+            ) else (
+              btype_str : "GKYL_BASIS_MODAL_GKHYBRID_VEL"
+            )
+          ) else (
+            if (freeof(mu, vars_tar)) then (
+              btype_str : "GKYL_BASIS_MODAL_HYBRID"
+            ) else (
+              btype_str : "GKYL_BASIS_MODAL_GKHYBRID"
+            )
+          )
+        )
+
+      ) else (
+        basis_tar : basisFromVars(basisFun, vars_tar, polyOrder_tar),
+      
+        if basisFun = "ser" then
+          btype_str : "GKYL_BASIS_MODAL_SERENDIPITY"
+        else if basisFun = "tensor" then
+          btype_str : "GKYL_BASIS_MODAL_TENSOR"
+      )
+    ) else (
+      basis_tar : [basisFromVars(basisFun, [x], 1)[1]],
+      cdim_tar : 1,
+      ndim_tar : 1,
+      btype_str : "GKYL_BASIS_MODAL_SERENDIPITY",
+      polyOrder_tar : 0
+    ),
+
+    printf(fh, "  *cdim = ~a;~%", cdim_tar),
+    printf(fh, "  *ndim = ~a;~%", ndim_tar),
+    printf(fh, "  *btype = ~a;~%", btype_str),
+    printf(fh, "  *poly_order = ~a;~%", polyOrder_tar),
+    printf(fh, "  *num_basis = ~a;~%", length(basis_tar)),
+    
+    printf(fh, "}~%"),
+    printf(fh, "~%")
+    
+  )
+
+)$

--- a/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj-header.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj-header.mac
@@ -9,55 +9,84 @@ load("dg_eval_at_coords_proj/dg_ev_proj.mac")$
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
-minCdim_Ser : 1$
-maxCdim_Ser : 3$
+min_dim_Ser : 1$
+max_dim_Ser : 6$
 
 /* Tensor order basis. No need to generate p=1. */
 minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
-minCdim_Tensor : 1$
-maxCdim_Tensor : 2$
+min_dim_Tensor : 1$
+max_dim_Tensor : 4$
+
+/* GkHybrid basis. */
+minCdim_GkHybrid : 1$
+maxCdim_GkHybrid : 3$
 
 /* ...... END OF USER INPUTS........ */
 
+gkVdims : [ [1,2], [2], [2] ]$
+
 /* To generate other bases, just add corresponding column to arrays below. */
-bName        : ["ser", "tensor"]$
-minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
-maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
-minCdim      : [minCdim_Ser, minCdim_Tensor]$
-maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+bName        : ["ser", "tensor", "gkhyb"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor, 1                    ]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor, 1                    ]$
+minCdim      : [min_dim_Ser     , min_dim_Tensor     , minCdim_GkHybrid     ]$
+maxCdim      : [max_dim_Ser     , max_dim_Tensor     , maxCdim_GkHybrid     ]$
+minVdim      : [0               , 0                  , 2                    ]$
+maxVdim      : [0               , 0                  , 2                    ]$
+
 
 printPrototypes(fh) := block(
-  [bInd,cdim,maxPolyOrderB,polyOrder,funcName,varsC_do,bC_do,ev_var_combos,ivc,ev_varsC,ev_dirs1,ev_dirs0,ev_str],
+  [bInd,cdim,vdimList,vI,vdim,pdim,maxPolyOrderB,polyOrder,funcName,varsC_do,bC_do,
+   vars_do,basis_do,ev_var_combos,ivc,ev_vars,ev_dirs1,ev_dirs0,ev_str],
 
   for bInd : 1 thru length(bName) do (
-    /* Generate kernels that translate conf-space fields. */
     for cdim : minCdim[bInd] thru maxCdim[bInd] do (
   
-      maxPolyOrderB : maxPolyOrder[bInd],
-      if (cdim=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+      if (bName[bInd] = "gkhyb") then (
+        vdimList : gkVdims[cdim]
+      ) else (
+        vdimList : [0]
+      ),
   
-      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-        funcName : sconcat("gkyl_dg_eval_at_coord_proj_", cdim, "x_", bName[bInd], "_p", polyOrder),
+      for vI : 1 thru length(vdimList) do (
+  
+        vdim : vdimList[vI],
+        pdim : cdim+vdim,
 
-        /* Get desired basis. */
-        [varsC_do,bC_do] : loadBasis(bName[bInd], cdim, polyOrder),
+        maxPolyOrderB : maxPolyOrder[bInd],
+        if (pdim>4) then maxPolyOrderB : 1,
+  
+        for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+          if (bName[bInd] = "gkhyb") then (
+            funcName : sconcat("gkyl_dg_eval_at_coord_proj_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder)
+          ) else (
+            funcName : sconcat("gkyl_dg_eval_at_coord_proj_", pdim, "x_", bName[bInd], "_p", polyOrder)
+          ),
+          print(funcName),
 
-        /* Get combinations of variables to evaluate be evaluated. */
-        ev_var_combos : get_ev_combos(varsC_do),
-        
-        for ivc : 1 thru length(ev_var_combos) do (
-          /* Variables to evaluate. */
-          ev_varsC : ev_var_combos[ivc],
+          /* Get desired basis. */
+          if (bName[bInd] = "gkhyb") then
+            [varsC_do,bC_do,vars_do,basis_do,gkVsub] : loadGkBasis(bName[bInd], cdim, vdim, polyOrder)
+          else
+            [vars_do,basis_do] : loadBasis(bName[bInd], pdim, polyOrder),
 
-          /* Directions to evaluate. */
-          ev_dirs1 : makelist(sublist_indices(varsC_do, lambda([x], x=ev_varsC[i]))[1], i, 1, length(ev_varsC)),
-          ev_dirs0 : makelist(ev_dirs1[i]-1, i, 1, length(ev_dirs1)),
-          ev_str : simplode(flatten(ev_dirs0)),
+          /* Get combinations of variables to evaluate be evaluated. */
+          ev_var_combos : get_ev_combos(vars_do),
+          
+          for ivc : 1 thru length(ev_var_combos) do (
+            /* Variables to evaluate. */
+            ev_vars : ev_var_combos[ivc],
 
-          printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a(const double *coords, const double *fdo, double *ftar);~%", funcName, ev_str)
-        ),
-        printf(fh, "~%")
+            /* Directions to evaluate. */
+            ev_dirs1 : makelist(sublist_indices(vars_do, lambda([x], x=ev_vars[i]))[1], i, 1, length(ev_vars)),
+            ev_dirs0 : makelist(ev_dirs1[i]-1, i, 1, length(ev_dirs1)),
+            ev_str : simplode(flatten(ev_dirs0)),
+
+            printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a(const double *coords, const double *fdo, double *ftar);~%", funcName, ev_str)
+          ),
+          printf(fh, "~%")
+        )
       )
     )
   )

--- a/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj-header.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj-header.mac
@@ -1,0 +1,77 @@
+/*
+  Generate the kernels header file for the updater which evaluates a
+  DG field at a coord and projects it onto the target basis.
+*/
+load("dg_eval_at_coords_proj/dg_ev_proj.mac")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 2$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+printPrototypes(fh) := block(
+  [bInd,cdim,maxPolyOrderB,polyOrder,funcName,varsC_do,bC_do,ev_var_combos,ivc,ev_varsC,ev_dirs1,ev_dirs0,ev_str],
+
+  for bInd : 1 thru length(bName) do (
+    /* Generate kernels that translate conf-space fields. */
+    for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+  
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (cdim=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+  
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        funcName : sconcat("gkyl_dg_eval_at_coord_proj_", cdim, "x_", bName[bInd], "_p", polyOrder),
+
+        /* Get desired basis. */
+        [varsC_do,bC_do] : loadBasis(bName[bInd], cdim, polyOrder),
+
+        /* Get combinations of variables to evaluate be evaluated. */
+        ev_var_combos : get_ev_combos(varsC_do),
+        
+        for ivc : 1 thru length(ev_var_combos) do (
+          /* Variables to evaluate. */
+          ev_varsC : ev_var_combos[ivc],
+
+          /* Directions to evaluate. */
+          ev_dirs1 : makelist(sublist_indices(varsC_do, lambda([x], x=ev_varsC[i]))[1], i, 1, length(ev_varsC)),
+          ev_dirs0 : makelist(ev_dirs1[i]-1, i, 1, length(ev_dirs1)),
+          ev_str : simplode(flatten(ev_dirs0)),
+
+          printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a(const double *coords, const double *fdo, double *ftar);~%", funcName, ev_str)
+        ),
+        printf(fh, "~%")
+      )
+    )
+  )
+)$
+
+fh : openw("~/max-out/gkyl_dg_eval_at_coord_proj_kernels.h")$
+printf(fh, "#pragma once~%")$
+printf(fh, "~%")$
+printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "#include <math.h>~%")$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_BEG~%")$
+printf(fh, "~%")$
+printPrototypes(fh)$
+printf(fh, "~%")$
+printf(fh, "EXTERN_C_END~%")$
+close(fh)$

--- a/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj-header.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj-header.mac
@@ -83,7 +83,8 @@ printPrototypes(fh) := block(
             ev_dirs0 : makelist(ev_dirs1[i]-1, i, 1, length(ev_dirs1)),
             ev_str : simplode(flatten(ev_dirs0)),
 
-            printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a(const double *coords, const double *fdo, double *ftar);~%", funcName, ev_str)
+            printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a(const double *coords, const double *fdo, double *ftar);~%", funcName, ev_str),
+            printf(fh, "GKYL_CU_DH void ~a_eval_dirs_~a_target_basis(int *cdim, int *ndim, enum gkyl_basis_type *btype, int *poly_order, int *num_basis);~%", funcName, ev_str)
           ),
           printf(fh, "~%")
         )
@@ -96,6 +97,7 @@ fh : openw("~/max-out/gkyl_dg_eval_at_coord_proj_kernels.h")$
 printf(fh, "#pragma once~%")$
 printf(fh, "~%")$
 printf(fh, "#include <gkyl_util.h>~%")$
+printf(fh, "#include <gkyl_basis.h>~%")$
 printf(fh, "#include <math.h>~%")$
 printf(fh, "~%")$
 printf(fh, "EXTERN_C_BEG~%")$

--- a/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj.mac
@@ -1,18 +1,6 @@
 /**
  * Create kernels which evaluate a DG expansion at a coordinate and projects
- * onto lower dimensional basis. Currently
- * it is meant for:
- *   - x     -> scalar
- *   - x,y   -> y
- *   - x,y   -> x
- *   - x,y   -> scalar
- *   - x,y,z -> y,z
- *   - x,y,z -> x,z
- *   - x,y,z -> x,y
- *   - x,y,z -> z
- *   - x,y,z -> y
- *   - x,y,z -> x
- *   - x,y,z -> scalar
+ * onto lower dimensional basis. 
  */
 load("dg_eval_at_coords_proj/dg_ev_proj.mac")$
 
@@ -21,42 +9,66 @@ load("dg_eval_at_coords_proj/dg_ev_proj.mac")$
 /* Serendipity basis. */
 minPolyOrder_Ser : 1$
 maxPolyOrder_Ser : 2$
-minCdim_Ser : 1$
-maxCdim_Ser : 3$
+min_dim_Ser : 1$
+max_dim_Ser : 6$
 
 /* Tensor order basis. No need to generate p=1. */
 minPolyOrder_Tensor : 2$
 maxPolyOrder_Tensor : 2$
-minCdim_Tensor : 1$
-maxCdim_Tensor : 2$
+min_dim_Tensor : 1$
+max_dim_Tensor : 3$
+
+/* GkHybrid basis. */
+minCdim_GkHybrid : 1$
+maxCdim_GkHybrid : 3$
 
 /* ...... END OF USER INPUTS........ */
 
+gkVdims : [ [1,2], [2], [2] ]$
+
 /* To generate other bases, just add corresponding column to arrays below. */
-bName        : ["ser", "tensor"]$
-minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
-maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
-minCdim      : [minCdim_Ser, minCdim_Tensor]$
-maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+bName        : ["ser", "tensor", "gkhyb"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor, 1                    ]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor, 1                    ]$
+minCdim      : [min_dim_Ser     , min_dim_Tensor     , minCdim_GkHybrid     ]$
+maxCdim      : [max_dim_Ser     , max_dim_Tensor     , maxCdim_GkHybrid     ]$
+minVdim      : [0               , 0                  , 2                    ]$
+maxVdim      : [0               , 0                  , 2                    ]$
 
 for bInd : 1 thru length(bName) do (
-  /* Generate kernels that translate conf-space fields. */
   for cdim : minCdim[bInd] thru maxCdim[bInd] do (
 
-    maxPolyOrderB : maxPolyOrder[bInd],
-    if (cdim=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+    if (bName[bInd] = "gkhyb") then (
+      vdimList : gkVdims[cdim]
+    ) else (
+      vdimList : [0]
+    ),
 
-    for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
-      fname : sconcat("~/max-out/dg_eval_at_coord_proj_", cdim, "x_", bName[bInd], "_p", polyOrder, ".c"),
-      disp(printf(false,"Creating file: ~a",fname)),
-  
-      fh : openw(fname),
-      printf(fh, "#include <gkyl_dg_eval_at_coord_proj_kernels.h> ~%"),
-      printf(fh, "~%"),
+    for vI : 1 thru length(vdimList) do (
 
-      funcName : sconcat("gkyl_dg_eval_at_coord_proj_", cdim, "x_", bName[bInd], "_p", polyOrder),
-      gen_dg_evproj_kernel(fh, funcName, cdim, bName[bInd], polyOrder),
-      close(fh)
+      vdim : vdimList[vI],
+      pdim : cdim+vdim,
+
+      maxPolyOrderB : maxPolyOrder[bInd],
+      if (pdim>4) then maxPolyOrderB : 1,
+
+      for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+        if (bName[bInd] = "gkhyb") then (
+          fname : sconcat("~/max-out/dg_eval_at_coord_proj_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder, ".c"),
+          funcName : sconcat("gkyl_dg_eval_at_coord_proj_", cdim, "x", vdim, "v_", bName[bInd], "_p", polyOrder)
+        ) else (
+          fname : sconcat("~/max-out/dg_eval_at_coord_proj_", pdim, "x_", bName[bInd], "_p", polyOrder, ".c"),
+          funcName : sconcat("gkyl_dg_eval_at_coord_proj_", pdim, "x_", bName[bInd], "_p", polyOrder)
+        ),
+        disp(printf(false,"Creating file: ~a",fname)),
+    
+        fh : openw(fname),
+        printf(fh, "#include <gkyl_dg_eval_at_coord_proj_kernels.h> ~%"),
+        printf(fh, "~%"),
+
+        gen_dg_evproj_kernel(fh, funcName, cdim, vdim, bName[bInd], polyOrder),
+        close(fh)
+      )
     )
   )
 )$

--- a/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj.mac
@@ -1,0 +1,62 @@
+/**
+ * Create kernels which evaluate a DG expansion at a coordinate and projects
+ * onto lower dimensional basis. Currently
+ * it is meant for:
+ *   - x     -> scalar
+ *   - x,y   -> y
+ *   - x,y   -> x
+ *   - x,y   -> scalar
+ *   - x,y,z -> y,z
+ *   - x,y,z -> x,z
+ *   - x,y,z -> x,y
+ *   - x,y,z -> z
+ *   - x,y,z -> y
+ *   - x,y,z -> x
+ *   - x,y,z -> scalar
+ */
+load("dg_eval_at_coords_proj/dg_ev_proj.mac")$
+
+/* ...... USER INPUTS........ */
+
+/* Serendipity basis. */
+minPolyOrder_Ser : 1$
+maxPolyOrder_Ser : 2$
+minCdim_Ser : 1$
+maxCdim_Ser : 3$
+
+/* Tensor order basis. No need to generate p=1. */
+minPolyOrder_Tensor : 2$
+maxPolyOrder_Tensor : 2$
+minCdim_Tensor : 1$
+maxCdim_Tensor : 2$
+
+/* ...... END OF USER INPUTS........ */
+
+/* To generate other bases, just add corresponding column to arrays below. */
+bName        : ["ser", "tensor"]$
+minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
+maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
+minCdim      : [minCdim_Ser, minCdim_Tensor]$
+maxCdim      : [maxCdim_Ser, maxCdim_Tensor]$
+
+for bInd : 1 thru length(bName) do (
+  /* Generate kernels that translate conf-space fields. */
+  for cdim : minCdim[bInd] thru maxCdim[bInd] do (
+
+    maxPolyOrderB : maxPolyOrder[bInd],
+    if (cdim=3) then maxPolyOrderB : 1, /* Only generate p=1 kernels for 3x2v */
+
+    for polyOrder : minPolyOrder[bInd] thru maxPolyOrderB do (
+      fname : sconcat("~/max-out/dg_eval_at_coord_proj_", cdim, "x_", bName[bInd], "_p", polyOrder, ".c"),
+      disp(printf(false,"Creating file: ~a",fname)),
+  
+      fh : openw(fname),
+      printf(fh, "#include <gkyl_dg_eval_at_coord_proj_kernels.h> ~%"),
+      printf(fh, "~%"),
+
+      funcName : sconcat("gkyl_dg_eval_at_coord_proj_", cdim, "x_", bName[bInd], "_p", polyOrder),
+      gen_dg_evproj_kernel(fh, funcName, cdim, bName[bInd], polyOrder),
+      close(fh)
+    )
+  )
+)$

--- a/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj.mac
+++ b/maxima/g0/dg_eval_at_coords_proj/ms-dg_ev_proj.mac
@@ -67,6 +67,9 @@ for bInd : 1 thru length(bName) do (
         printf(fh, "~%"),
 
         gen_dg_evproj_kernel(fh, funcName, cdim, vdim, bName[bInd], polyOrder),
+
+        gen_dg_evproj_num_basis_tar_kernel(fh, funcName, cdim, vdim, bName[bInd], polyOrder),
+
         close(fh)
       )
     )

--- a/maxima/g0/modal-basis.mac
+++ b/maxima/g0/modal-basis.mac
@@ -345,7 +345,7 @@ loadPhaseBasis(basisType, cdim, vdim, pOrder) := block(
 )$
 
 loadGkBasis(basisType, cdim, vdim, pOrder) := block(
-  [btype,modNm,vSub,varsC,basisC,varsP,basisP,bC,bP,p],
+  [btype,modNm,vSub,varsC,basisC,varsP,basisP,varsV,basisV,bC,bP,p],
   /* Load phase-space basis for gyrokinetics. Some complication below is due to the fact
      that some routines may call this version for surfaces and/or hybrid bases. */
   btype : basisType,
@@ -365,10 +365,14 @@ loadGkBasis(basisType, cdim, vdim, pOrder) := block(
       else
         modNm : sconcat("basis-precalc/basis", btype, cdim, "x", vdim, "v")
     ) else (
-      if btype = "tensor" then 
-        modNm : sconcat("basis-precalc/basisTensor", vdim, "x")
-      else
-        modNm : sconcat("basis-precalc/basisSer", vdim, "x")
+      if ((btype = "GkHybrid") or (pOrder = 1 and btype = "Ser")) then (
+        modNm : sconcat("basis-precalc/basisGkHybridVel", vdim, "v")
+      ) else (
+        if btype = "Tensor" then
+          modNm : sconcat("basis-precalc/basisTensor", vdim, "x")
+        else
+          modNm : sconcat("basis-precalc/basisSer", vdim, "x")
+      )
     )
   ) else (
     if btype = "tensor" then
@@ -378,6 +382,18 @@ loadGkBasis(basisType, cdim, vdim, pOrder) := block(
   ),
   load(modNm),
 
+  /* Set up varsC and basisC for cdim=0 so substitutions later below work. */
+  if cdim=0 and vdim > 0 then (
+    if ((btype = "GkHybrid") or (pOrder = 1 and btype = "Ser")) then (
+      varsC : copylist(varsV),
+      basisC : copylist(basisV),
+      kill(varsV,basisV)
+    ) else (
+      varsC  : subst([x=vx,y=vy],varsC),
+      basisC : subst([x=vx,y=vy],basisC)
+    )
+  ),
+
   /* Save configuration and phase space basis and switch to GK variables. */
   vSub : [vx=vpar, vy=mu],
 
@@ -386,13 +402,13 @@ loadGkBasis(basisType, cdim, vdim, pOrder) := block(
       bC : copylist(basisC[pOrder]),  varsC : copylist(varsC),
       bP : subst(vSub, copylist(basisP[pOrder])),  varsP : subst(vSub, copylist(varsP))
     ) else (
-      if vdim=1 and btype = "GkHybrid" then (
-        print("** Incorrect use of loadGkBasis: cdim/vdim not enough to specify which GkHybrid basis to load when vdim=1. **"),
-        tmp : [1],  print(tmp[2]) /* just to trigger an error. */
-      ),
-      if btype = "GkHybrid" then p : 2 else p : pOrder,  /* Forcing p=1 to hybrid. */
-      bP    : subst([x=vpar,y=mu],copylist(basisC[p])),
-      varsP : subst([x=vpar,y=mu],copylist(varsC)),
+      if ((btype = "GkHybrid") or (pOrder = 1 and btype = "Ser")) then
+        p : 1
+      else
+        p : pOrder,
+
+      bP    : subst(vSub,copylist(basisC[p])),
+      varsP : subst(vSub,copylist(varsC)),
       bC : [],  varsC : []
     )
   ) else (
@@ -413,7 +429,7 @@ loadGkBasis(basisType, cdim, vdim, pOrder) := block(
 )$
 
 loadGkHybBasisFromVars(varsIn) := block(
-  [dimIn,cdim,vdim,hasvpar,vars,basis,varsC,basisC,varsP,basisP,basisConstant],
+  [dimIn,cdim,vdim,hasvpar,vars,basis,varsC,basisC,varsP,basisP,varsV,basisV,basisConstant],
   /* Load a basis given the variables, intended to be used with the GkHybrid
      basis. The need to do this arises when needing surface bases, which
      more complicated with GkHybrid. */
@@ -424,22 +440,17 @@ loadGkHybBasisFromVars(varsIn) := block(
 
   hasvpar : isInList(vpar,varsIn) or isInList(vx,varsIn),
 
-  /* In case varsP and varsC were already loaded, save them
+  /* In case varsP, varsV and varsC were already loaded, save them
      and restore them at the end of this function. */
   if listp(varsC) then (oldVarsC : copylist(varsC)),
+  if listp(varsV) then (oldVarsV : copylist(varsV)),
   if listp(varsP) then (oldVarsP : copylist(varsP)),
 
   if hasvpar then (
     if cdim=0 then (
-      if vdim=1 then (
-        load(sconcat("basis-precalc/basisSer1x")),
-        basis : subst(x=vpar,basisC[2]),  vars : subst(x=vpar,varsC)
-      ) elseif vdim=2 then (
-        load(sconcat("basis-precalc/basisHybrid1x1v")),
-        /* Careful, the order of these substitutions matter. */
-        basis : subst([vx^2*x-x/3=vpar^2*mu-mu/3,vx^2=vpar^2,vx=mu,x=vpar],basisP[1]),
-        vars  : subst([x=vpar,vx=mu],varsP)
-      )
+      load(sconcat("basis-precalc/basisGkHybridVel",vdim,"v")),
+      basis : subst([vx=vpar,vy=mu],basisV[1]),
+      vars  : subst([vx=vpar,vy=mu],varsV)
     ) else (
       if vdim=1 then (
         load(sconcat("basis-precalc/basisHybrid",cdim,"x",vdim,"v"))
@@ -463,8 +474,9 @@ loadGkHybBasisFromVars(varsIn) := block(
   replaceList : makelist(vars[i]=varsIn[i],i,1,dimIn),
   basis : psubst(replaceList,basis),
 
-  /* Restore varsC and varsP. */
+  /* Restore varsC, varsV and varsP. */
   if listp(oldVarsC) then (varsC : copylist(oldVarsC)),
+  if listp(oldVarsV) then (varsV : copylist(oldVarsV)),
   if listp(oldVarsP) then (varsP : copylist(oldVarsP)),
 
   return([varsIn,basis])

--- a/maxima/g0/nodal_operations/basis_vol_modal_to_quad.mac
+++ b/maxima/g0/nodal_operations/basis_vol_modal_to_quad.mac
@@ -78,3 +78,41 @@ genModalToQuadKernelHyb(fh, cdim, vdim, basisName) := block(
   printf(fh, "} ~%"),
   printf(fh, "~%")
 )$
+
+genModalToQuadKernelHybVel(fh, vdim, basisName) := block(
+  [cdim,pdim,varsc,basisc,varsp,basisp,varsv,nodes,numNodes,
+   f_e,basisNodal,fHatNodal_e,fHatModProj_e],
+
+  cdim : 0,
+  pdim : cdim+vdim,
+
+  if basisName = "gkhyb_vel" then (
+    [varsc,basisc,varsp,basisp,vsub] : loadGkBasis(basisName, cdim, vdim, 1),
+    varsv : listify(setdifference(setify(varsp),setify(varsc))),
+    nodes : gaussOrdGkHyb(1+1, varsc, varsv)
+  ),
+
+  f_e : doExpand1(fmodal, basisp),
+
+  numNodes : length(nodes),
+
+  printf(fh, "GKYL_CU_DH ~%"), 
+  printf(fh, "void ~%"),
+  printf(fh, "modal_to_quad_~ad_~a_p1(const double* fmodal, double* GKYL_RESTRICT fquad, long linc2) { ~%", vdim, basisName),
+
+  /* Evaluate f at quadrature nodes. */
+  fOrdR_n : evAtNodes(f_e,nodes,varsp),
+
+  printf(fh, "  switch (linc2) { ~%"), 
+  for i : 1 thru numNodes do (
+    printf(fh, "    case ~a: ~%", i-1),
+    printf(fh, "      fquad[~a] = ~a; ~%", i-1, float(expand(fOrdR_n[i]))), 
+    printf(fh, "    break; ~%"),  
+    printf(fh, "~%")
+  ),
+  printf(fh, "  } ~%"), 
+  flush_output(fh),
+
+  printf(fh, "} ~%"),
+  printf(fh, "~%")
+)$

--- a/maxima/g0/nodal_operations/basis_vol_quad_to_modal.mac
+++ b/maxima/g0/nodal_operations/basis_vol_quad_to_modal.mac
@@ -93,3 +93,43 @@ genQuadToModalKernelHyb(fh, cdim, vdim, basisName) := block(
   printf(fh, "} ~%"),
   printf(fh, "~%")
 )$
+
+genQuadToModalKernelHybVel(fh, vdim, basisName) := block(
+  [cdim,pdim,varsc,basisc,varsp,basisp,varsv,nodes,numNodes,
+   basisNodal,fHatNodal_e,fHatModProj_e],
+
+  cdim : 0,
+  pdim : cdim+vdim,
+
+  if basisName = "gkhyb_vel" then (
+    [varsc,basisc,varsp,basisp,vsub] : loadGkBasis(basisName, cdim, vdim, 1),
+    varsv : listify(setdifference(setify(varsp),setify(varsc))),
+    nodes : gaussOrdGkHyb(1+1, varsc, varsv)
+  ),
+
+  numNodes : length(nodes),
+
+  printf(fh, "GKYL_CU_DH ~%"), 
+  printf(fh, "void ~%"),
+  printf(fh, "quad_to_modal_~ad_~a_p1(const double* fquad, double* GKYL_RESTRICT fmodal, long linc2) { ~%", vdim, basisName),
+
+  /* Make nodal expansions in tensor nodal basis where nodes are Gauss-Legendre quadrature points */
+  basisNodal  : getVarsNodalBasisWithNodesHyb(basisName, cdim, vdim, varsp, nodes),
+  fHatNodal_e : doExpand1(fquad,basisNodal),
+  /* Project nodal basis back onto modal basis */
+  fHatModProj_e : fullratsimp(calcInnerProdList(varsp, 1, basisp, fHatNodal_e)),
+
+  /* Write out projection of tensor nodal basis onto modal basis. */
+  printf(fh, "  switch (linc2) { ~%"), 
+  for i : 1 thru length(fHatModProj_e) do (
+    printf(fh, "    case ~a: ~%", i-1),
+    printf(fh, "      fmodal[~a] = ~a; ~%", i-1, float(expand(fHatModProj_e[i]))), 
+    printf(fh, "    break; ~%"),  
+    printf(fh, "~%")
+  ),
+  printf(fh, "  } ~%"), 
+  flush_output(fh),
+
+  printf(fh, "} ~%"),
+  printf(fh, "~%")
+)$

--- a/maxima/g0/nodal_operations/ms-basis_vol_modal_to_quad.mac
+++ b/maxima/g0/nodal_operations/ms-basis_vol_modal_to_quad.mac
@@ -29,18 +29,24 @@ minCdim_gkhyb : 1$
 maxCdim_gkhyb : 3$
 vDims_gkhyb : [[1,2], [2], [2]]$  /* Vdim for each of Cdim. */
 
+/* GK hybrid vel basis. */
+vDims_gkhyb_vel : [1,2]$
+
 /* ...... END OF USER INPUTS........ */
 
-bName : ["ser","tensor"]$
+bName        : ["ser","tensor"]$
 minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
-minDim : [minDim_Ser, minDim_Tensor]$
-maxDim : [maxDim_Ser, maxDim_Tensor]$
+minDim       : [minDim_Ser, minDim_Tensor]$
+maxDim       : [maxDim_Ser, maxDim_Tensor]$
 
-bNameHyb : ["hyb","gkhyb"]$
-minCdimHyb : [minCdim_hyb, minCdim_gkhyb]$
-maxCdimHyb : [maxCdim_hyb, maxCdim_gkhyb]$
-vDims : [vDims_hyb, vDims_gkhyb]$
+bNameHyb     : ["hyb","gkhyb"]$
+minCdimHyb   : [minCdim_hyb, minCdim_gkhyb]$
+maxCdimHyb   : [maxCdim_hyb, maxCdim_gkhyb]$
+vDims        : [vDims_hyb, vDims_gkhyb]$
+
+bNameHybVel  : ["gkhyb_vel"]$
+vDimsHybVel  : [vDims_gkhyb_vel]$
 
 /* Generate kernels that take the f at Gauss-Legendre quadrature nodes,
    and do a nodal-to-modal transformation to yield the modal DG coefficients of f. */
@@ -74,6 +80,21 @@ for bInd : 1 thru length(bNameHyb) do (
       disp(printf(false,sconcat("Creating quad_to_modal ",bNameHyb[bInd]," ~ax~av_p1"),c,v)),     
       genModalToQuadKernelHyb(fh, c, v, bNameHyb[bInd])
     )
+  ),
+  close(fh)
+)$
+
+/* Generate the hybrid vel basis kernels. */
+for bInd : 1 thru length(bNameHybVel) do (
+  fname : sconcat("~/max-out/basis_modal_to_quad_", bNameHybVel[bInd], ".c"),
+  fh : openw(fname), 
+  printf(fh, "#include <gkyl_basis_~a_kernels.h> ~%", bNameHybVel[bInd]),
+
+  vmin : xreduce(min,vDimsHybVel[bInd]),
+  vmax : xreduce(max,vDimsHybVel[bInd]),
+  for v : vmin thru vmax do (
+    disp(printf(false,sconcat("Creating quad_to_modal ",bNameHybVel[bInd]," ~ad_p1"),v)),
+    genModalToQuadKernelHybVel(fh, v, bNameHybVel[bInd])
   ),
   close(fh)
 )$

--- a/maxima/g0/nodal_operations/ms-basis_vol_quad_to_modal.mac
+++ b/maxima/g0/nodal_operations/ms-basis_vol_quad_to_modal.mac
@@ -29,18 +29,24 @@ minCdim_gkhyb : 1$
 maxCdim_gkhyb : 3$
 vDims_gkhyb : [[1,2], [2], [2]]$  /* Vdim for each of Cdim. */
 
+/* GK hybrid vel basis. */
+vDims_gkhyb_vel : [1,2]$
+
 /* ...... END OF USER INPUTS........ */
 
-bName : ["ser","tensor"]$
+bName        : ["ser","tensor"]$
 minPolyOrder : [minPolyOrder_Ser, minPolyOrder_Tensor]$
 maxPolyOrder : [maxPolyOrder_Ser, maxPolyOrder_Tensor]$
-minDim : [minDim_Ser, minDim_Tensor]$
-maxDim : [maxDim_Ser, maxDim_Tensor]$
+minDim       : [minDim_Ser, minDim_Tensor]$
+maxDim       : [maxDim_Ser, maxDim_Tensor]$
 
-bNameHyb : ["hyb","gkhyb"]$
+bNameHyb   : ["hyb","gkhyb"]$
 minCdimHyb : [minCdim_hyb, minCdim_gkhyb]$
 maxCdimHyb : [maxCdim_hyb, maxCdim_gkhyb]$
-vDims : [vDims_hyb, vDims_gkhyb]$
+vDims      : [vDims_hyb, vDims_gkhyb]$
+
+bNameHybVel : ["gkhyb_vel"]$
+vDimsHybVel : [vDims_gkhyb_vel]$
 
 /* Generate kernels that take the f at Gauss-Legendre quadrature nodes,
    and do a nodal-to-modal transformation to yield the modal DG coefficients of f. */
@@ -74,6 +80,21 @@ for bInd : 1 thru length(bNameHyb) do (
       disp(printf(false,sconcat("Creating quad_to_modal ",bNameHyb[bInd]," ~ax~av_p1"),c,v)),     
       genQuadToModalKernelHyb(fh, c, v, bNameHyb[bInd])
     )
+  ),
+  close(fh)
+)$
+
+/* Generate the hybrid basis vel kernels. */
+for bInd : 1 thru length(bNameHybVel) do (
+  fname : sconcat("~/max-out/basis_quad_to_modal_", bNameHybVel[bInd], ".c"),
+  fh : openw(fname), 
+  printf(fh, "#include <gkyl_basis_~a_kernels.h> ~%", bNameHybVel[bInd]),
+
+  vmin : xreduce(min,vDimsHybVel[bInd]),
+  vmax : xreduce(max,vDimsHybVel[bInd]),
+  for v : vmin thru vmax do (
+    disp(printf(false,sconcat("Creating quad_to_modal ",bNameHybVel[bInd]," ~ad_p1"),v)),
+    genQuadToModalKernelHybVel(fh, v, bNameHybVel[bInd])
   ),
   close(fh)
 )$

--- a/maxima/g0/nodal_operations/ms-eval_nod.mac
+++ b/maxima/g0/nodal_operations/ms-eval_nod.mac
@@ -31,6 +31,9 @@ minCdim_gkhyb : 1$
 maxCdim_gkhyb : 3$
 vDims_gkhyb : [[1,2], [2], [2]]$  /* Vdim for each of Cdim. */
 
+/* GK hybrid vel basis. */
+vDims_gkhyb_vel : [1,2]$
+
 /* ...... END OF USER INPUTS........ */
 
 bName        : ["ser","tensor"]$
@@ -43,6 +46,9 @@ bNameHyb   : ["hyb","gkhyb"]$
 minCdimHyb : [minCdim_hyb, minCdim_gkhyb]$
 maxCdimHyb : [maxCdim_hyb, maxCdim_gkhyb]$
 vDims      : [vDims_hyb, vDims_gkhyb]$
+
+bNameHybVel : ["gkhyb_vel"]$
+vDimsHybVel : [vDims_gkhyb_vel]$
 
 writeNodeCoordsKernel(dim, basisName, pOrder) := block([nodes,numNodes,n,dir],
   printf(fh, "GKYL_CU_DH~%"),
@@ -89,6 +95,28 @@ writeNodeCoordsKernelHyb(cdim, vdim, basisName) := block([nodes,numNodes,n,dir],
   printf(fh, "}~%~%")
 )$
 
+writeNodeCoordsKernelHybVel(vdim, basisName) := block([nodes,numNodes,n,dir],
+  printf(fh, "GKYL_CU_DH~%"),
+  printf(fh, "void~%"),
+  printf(fh, "node_coords_~ad_~a_p1(double *node_coords)~%", vdim, basisName),
+  printf(fh, "{~%"),
+
+  /* Get equi-distant node locations */
+  if basisName = "gkhyb_vel" then (
+    nodes : getNodesGkHyb(0, vdim)
+  ),
+  numNodes : length(nodes),
+
+  pdim : vdim,
+
+  for n : 1 thru numNodes do (
+    for dir : 1 thru pdim do (
+      printf(fh, "  node_coords[~a] = ~a;~%", (n-1)*pdim + dir-1, nodes[n][dir])
+    )
+  ),
+  printf(fh, "}~%~%")
+)$
+
 /* Generate a file for regular bases. */
 for bInd : 1 thru length(bName) do (
   fname : sconcat("~/max-out/basis_node_coords_",bName[bInd], ".c"),
@@ -118,6 +146,20 @@ for bInd : 1 thru length(bNameHyb) do (
     for v : vmin thru vmax do (
       writeNodeCoordsKernelHyb(c, v, bNameHyb[bInd])
     )
+  ),
+  close(fh)
+);
+
+/* Generate a file for gkhybrid vel basis. */
+for bInd : 1 thru length(bNameHybVel) do (
+  fname : sconcat("~/max-out/basis_node_coords_",bNameHybVel[bInd], ".c"),
+  fh : openw(fname),
+  printf(fh, "#include <gkyl_basis_~a_kernels.h>~%", bNameHybVel[bInd]),
+
+  vmin : xreduce(min,vDimsHybVel[bInd]),
+  vmax : xreduce(max,vDimsHybVel[bInd]),
+  for v : vmin thru vmax do (
+    writeNodeCoordsKernelHybVel(v, bNameHybVel[bInd])
   ),
   close(fh)
 );

--- a/maxima/g0/nodal_operations/ms-nod_to_mod.mac
+++ b/maxima/g0/nodal_operations/ms-nod_to_mod.mac
@@ -31,6 +31,9 @@ minCdim_gkhyb : 1$
 maxCdim_gkhyb : 3$
 vDims_gkhyb : [[1,2], [2], [2]]$  /* Vdim for each of Cdim. */
 
+/* GK hybrid vel basis. */
+vDims_gkhyb_vel : [1,2]$
+
 /* ...... END OF USER INPUTS........ */
 
 bName        : ["ser","tensor"]$
@@ -43,6 +46,9 @@ bNameHyb   : ["hyb","gkhyb"]$
 minCdimHyb : [minCdim_hyb, minCdim_gkhyb]$
 maxCdimHyb : [maxCdim_hyb, maxCdim_gkhyb]$
 vDims      : [vDims_hyb, vDims_gkhyb]$
+
+bNameHybVel : ["gkhyb_vel"]$
+vDimsHybVel : [vDims_gkhyb_vel]$
 
 writeNod2ModKernel(dim, basisName, pOrder) := block([nodes,numNodes,nodToMod,fmod_e],
   printf(fh, "GKYL_CU_DH~%"),
@@ -95,6 +101,26 @@ writeNod2ModKernelHyb(cdim, vdim, basisName) := block([nodes,numNodes,nodToMod,f
   printf(fh, "}~%~%")
 )$
 
+writeNod2ModKernelHybVel(vdim, basisName) := block([cdim,nodes,numNodes,nodToMod,fmod_e],
+  cdim : 0,
+  printf(fh, "GKYL_CU_DH~%"),
+  printf(fh, "void~%"),
+  printf(fh, "nodal_to_modal_~ad_~a_p1(const double *fnodal, double *fmodal)~%", vdim, basisName),
+  printf(fh, "{~%"),
+  /* Get equi-distant node locations */
+  if basisName = "gkhyb_vel" then (
+    nodes : getNodesGkHyb(cdim, vdim)
+  ),
+  numNodes : length(nodes),
+
+  /* Get modal expansion from nodal points. */
+  nodToMod : calcNodToModWithNodesHyb(basisName, cdim, vdim, nodes),
+  fmod_e : gcfac(fullratsimp(nodToMod . makelist(fnodal[i-1],i,1,numNodes))),
+  fmod_e : makelist(fmod_e[i][1],i,1,numNodes),
+  writeCExprs1(fmodal, fmod_e),
+  printf(fh, "}~%~%")
+)$
+
 /* Generate kernels for modal-to-nodal transform for regular bases. */
 for bInd : 1 thru length(bName) do (
   fname : sconcat("~/max-out/basis_nodal_to_modal_",bName[bInd], ".c"),
@@ -124,6 +150,20 @@ for bInd : 1 thru length(bNameHyb) do (
     for v : vmin thru vmax do (
       writeNod2ModKernelHyb(c, v, bNameHyb[bInd])
     )
+  ),
+  close(fh)
+);
+
+/* Generate kernels for modal-to-nodal transform for hybrid vel bases. */
+for bInd : 1 thru length(bNameHybVel) do (
+  fname : sconcat("~/max-out/basis_nodal_to_modal_",bNameHybVel[bInd], ".c"),
+  fh : openw(fname),
+  printf(fh, "#include <gkyl_basis_~a_kernels.h>~%", bNameHybVel[bInd]),
+
+  vmin : xreduce(min,vDimsHybVel[bInd]),
+  vmax : xreduce(max,vDimsHybVel[bInd]),
+  for v : vmin thru vmax do (
+    writeNod2ModKernelHybVel(v, bNameHybVel[bInd])
   ),
   close(fh)
 );

--- a/maxima/g0/nodal_operations/nodal_functions.mac
+++ b/maxima/g0/nodal_operations/nodal_functions.mac
@@ -64,6 +64,8 @@ calcBasisNodToModWithNodesHyb(basisType, cdim, vdim, nodes) := block(
     [varsC,bC,vars,basis] : loadPhaseBasis("ser", cdim, vdim, 1)
   ) elseif basisType = "gkhyb" then (
     [varsC,bC,vars,basis,vSub] : loadGkBasis("ser", cdim, vdim, 1)
+  ) elseif basisType = "gkhyb_vel" then (
+    [varsC,bC,vars,basis,vSub] : loadGkBasis("ser", 0, vdim, 1)
   ),
   basisNodToMod : calcBasisNodToModWithNodesAndBasis(nodes, basis, vars),
   return(basisNodToMod)
@@ -225,7 +227,7 @@ getVarsNodalBasisWithNodesHyb(basisType, cdim, vdim, varsIn, nodes) := block(
         load(sconcat("basis-precalc/basisTensorHybrid", cdim, "x", vdim, "v")),
         basis : basisP[1],  vars : varsP
       )
-    ) elseif basisType="gkhyb" then (
+    ) elseif (basisType="gkhyb" or basisType="gkhyb_vel") then (
       /* gkhyb is tricker because it's p=2 only in vpar. */      
       [vars, basis] : loadGkHybBasisFromVars(varsIn)
     )

--- a/maxima/g0/out-scripts.mac
+++ b/maxima/g0/out-scripts.mac
@@ -323,6 +323,35 @@ writeCExprs1noPowers(lhs, rhs, qPow, alreadyDecl) := block(
   return(alreadyDecl)
 )$
 
+writeCExprsWithZeros1noPowers(lhs, rhs, qPow, alreadyDecl) := block(
+  [i,subList,expr,ep,outStr],
+  /* Search for powers of the quantities in qPow. If one of them is found
+     then define a temporary variable for it before writing out the increment.
+       qPow: list of quantities whose powers to search for.
+       numElemMax: maximum number of elements in each quantity of qPow.
+       writeDecl: indicate whether to write out the declaration of temporary variables.
+     We return the list of declared temporary variables, to be used in avoiding
+     redefining the same variables.
+  */
+
+  [subList,alreadyDecl] : findReplacePowers(rhs, qPow, 1, alreadyDecl), 
+
+  expr : float(rhs),
+  for i : 1 thru length(rhs) do (
+    ep : string(expr[i]),
+    if (length(subList) > 0) then (
+      outStr : ssubst(subList[1][2],subList[1][1],ep),
+      for s : 2 thru length(subList) do (
+        outStr : ssubst(subList[s][2],subList[s][1],outStr)
+      )
+    ) else (
+      outStr : ep
+    ),
+    printf(fh, "  ~a = ~a; ~%", lhs[i-1], outStr)
+  ),
+  return(alreadyDecl)
+)$
+
 writeCExprsCollect1noPowers(lhs, rhs, clst, qPow, alreadyDecl) := block(
   [i,subList,expr,ep,outStr],
 


### PR DESCRIPTION
This goes with [PR 1071 of gkeyll](https://github.com/ammarhakim/gkeyll/pull/1071).

We add a new basis, gkhybrid_vel, to make it easier to evaluate velocity-space fields when working with gkhybrid basis. For this we had to update the ginac build and ginac scripts (frankly, it'd be nice to move this stuff back to Maxima).

We also add the Maxima for the dg_eval_at_coord_proj updater, which evaluates a DG field at a coordinate and projects it onto a basis. NOTE: if all coords are evaluated, the basis it projects onto is 1/sqrt(2).